### PR TITLE
Heuristics now being auto saved on tab change.

### DIFF
--- a/src/components/organisms/EditHeuristicsTest.vue
+++ b/src/components/organisms/EditHeuristicsTest.vue
@@ -16,10 +16,26 @@
     </v-tabs>
 
     <div>
-      <Heuristic v-if="index == 0" :heuristics="object.heuristics" @change="emitChange()" />
-      <OptionsTable v-if="index == 1" :options="object.options" @change="emitChange()" />
-      <ImportCsvTable v-if="index == 2" :options="object.importCsv" @change="emitChange()" />
-      <WeightTable v-if="index == 3" :options="object.weight" @change="emitChange()" />
+      <Heuristic
+        v-if="index == 0"
+        :heuristics="object.heuristics"
+        @change="emitChange()"
+      />
+      <OptionsTable
+        v-if="index == 1"
+        :options="object.options"
+        @change="emitChange()"
+      />
+      <ImportCsvTable
+        v-if="index == 2"
+        :options="object.importCsv"
+        @change="emitChange()"
+      />
+      <WeightTable
+        v-if="index == 3"
+        :options="object.weight"
+        @change="emitChange()"
+      />
     </div>
   </div>
 </template>
@@ -45,7 +61,7 @@ export default {
 
     object: {
       type: Object,
-      default: () => { },
+      default: () => {},
     },
   },
   data: () => ({
@@ -59,11 +75,11 @@ export default {
   methods: {
     tabClicked(index) {
       this.index = index
+      this.$emit('tabClicked', index)
     },
     emitChange() {
       this.$emit('change')
     },
-
   },
 }
 </script>

--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -2,11 +2,11 @@ import { initializeApp } from 'firebase/app'
 import { getAnalytics } from 'firebase/analytics'
 import {
   getAuth,
-  // connectAuthEmulator,
+  //  connectAuthEmulator
 } from 'firebase/auth'
 import {
   getFirestore,
-  // connectFirestoreEmulator,
+  // connectFirestoreEmulator
 } from 'firebase/firestore'
 import {
   getFunctions,

--- a/src/views/admin/EditTestView.vue
+++ b/src/views/admin/EditTestView.vue
@@ -93,6 +93,7 @@
           type="content"
           :object="object"
           :index="index"
+          @tabClicked="handleTabClick"
           @change="change = true"
         />
 
@@ -306,6 +307,9 @@ export default {
       this.valids[index] = valid
     },
     validateAll() {
+      this.submit()
+    },
+    handleTabClick(index) {
       this.submit()
     },
     preventNav(event) {


### PR DESCRIPTION
Closes #376 

Earlier, while creating heuristics, if someone changed the tab without hitting save button, the data was vanishing. 
Now, whenever someone changes a tab, the heuristic first auto saves and then proceeds. 

Here is the video demonstration of the same :


https://github.com/ruxailab/RUXAILAB/assets/107767172/f067058a-1918-4a99-a10f-7ebfc000ec31



