### PR TITLE
Dependabot Implemented for Automated Dependency Updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enable Dependabot:
- Go to your repository settings on GitHub.
- Navigate to the “Security & analysis” section.
- Enable Dependabot alerts and security updates.

Addresses Issue #377 