### PR TITLE
Issue #435: deleting wrong option in heuristic test

### DIFF
--- a/src/components/molecules/OptionsTable.vue
+++ b/src/components/molecules/OptionsTable.vue
@@ -128,6 +128,7 @@ export default {
     },
     updateOptions() {
       if (this.editIndex == -1) {
+        this.option.timestamp = Date.now() // using the current timestamp as a unique identifier
         this.options.push(this.option)
       } else {
         Object.assign(this.options[this.editIndex], this.option)
@@ -141,10 +142,13 @@ export default {
       this.hasValue = true
     },
     deleteItem(item) {
-      this.options.splice(this.options.indexOf(item), 1)
+      const index = this.options.findIndex((option) => option.timestamp === item.timestamp)
+      if (index !== -1) {
+        this.options.splice(index, 1)
+      }
     },
     editItem(item) {
-      this.editIndex = this.options.indexOf(item)
+      this.editIndex = this.options.findIndex((option) => option.timestamp === item.timestamp)
       this.option.text = this.options[this.editIndex].text
       this.option.value = this.options[this.editIndex].value
 


### PR DESCRIPTION
### Description

This PR fixes #435 

### What's Causing the Bug

The bug seems to happen exclusively for options with no value set, as discussed [here](https://github.com/ruxailab/RUXAILAB/issues/435#issuecomment-2059213309). To figure out why, first let's take a closer look at the `deleteItem` method:

```
deleteItem(item) {
  this.options.splice(this.options.indexOf(item), 1)
}
```

Now, my understanding is that if there are multiple items with values as null, indexOf might always return the index of the first item with null value, not necessarily the one we want to delete.

### Measures
One way to fix this issue is to assign a unique identifier to each item when it is created, and use this identifier to find the correct item to delete. This ensures that even items with identical visible properties can be correctly distinguished. For this, I have attached a timestamp property to the items. 

### Working Demo

https://github.com/ruxailab/RUXAILAB/assets/34897621/2574367b-413c-4170-8710-fc0a6968128b

