### PR TITLE
fix: typo and broken discord link

### DIFF
--- a/src/components/molecules/IntroAnalytics.vue
+++ b/src/components/molecules/IntroAnalytics.vue
@@ -50,7 +50,7 @@ export default {
       this.$router.push('/analytics/documentation').catch(() => {})
     },
     goToDisc() {
-      window.open('https://discord.gg/XHhnXBjgRh')
+      window.open('https://discord.gg/MFWNpwTq9q')
     },
     callFunc(func) {
       this[func]()

--- a/src/components/molecules/IntroAnswer.vue
+++ b/src/components/molecules/IntroAnswer.vue
@@ -52,7 +52,7 @@ export default {
       this.$router.push('/answers/documentation').catch(() => {})
     },
     goToDisc() {
-      window.open('https://discord.gg/XHhnXBjgRh')
+      window.open('https://discord.gg/MFWNpwTq9q')
     },
     callFunc(func) {
       this[func]()

--- a/src/components/molecules/IntroCoops.vue
+++ b/src/components/molecules/IntroCoops.vue
@@ -47,7 +47,7 @@ export default {
       this.$router.push('/cooperators/documentation').catch(() => {})
     },
     goToDisc() {
-      window.open('https://discord.gg/XHhnXBjgRh')
+      window.open('https://discord.gg/MFWNpwTq9q')
     },
     closeIntro() {
       this.$emit('closeIntro')

--- a/src/components/molecules/IntroEdit.vue
+++ b/src/components/molecules/IntroEdit.vue
@@ -48,7 +48,7 @@ export default {
       this.$router.push('/edit/documentation').catch(() => {})
     },
     goToDisc() {
-      window.open('https://discord.gg/XHhnXBjgRh')
+      window.open('https://discord.gg/MFWNpwTq9q')
     },
     closeIntro() {
       this.$emit('closeIntro')

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -203,7 +203,7 @@
       "learnMore": "Learn More",
       "docTitle": "Read documentation",
       "docSubtitle": "Click to access the documentation on how to use the page ",
-      "discTitle": "Join the comunity!",
+      "discTitle": "Join the community!",
       "discSubtitle": "You will find support on our discord server."
     },
     "finalReport": {


### PR DESCRIPTION
This PR addresses the problem documented in issue #453 by updating the Discord link and correcting the typo "comunity" to **community.**