### PR TITLE
fix: Save changes button added to save updated changes of a test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ package-lock.json
 firebase.json
 firestore.indexes.json
 firestore.rules
+firestore-debug.log
 /docs 
 
 # local env files

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -460,7 +460,8 @@
     "stay": "Stay",
     "leave": "Leave",
     "help": "Help",
-    "delete": "Delete"
+    "delete": "Delete",
+    "save_edit": "Save Changes"
   },
   "switches": {
     "noAnswer": "No answer",

--- a/src/views/admin/SettingsView.vue
+++ b/src/views/admin/SettingsView.vue
@@ -122,6 +122,16 @@
             <v-btn style="margin-right: 40px" outlined color="green" @click="duplicateTest()">
               Duplicate test
             </v-btn>
+
+            <v-btn
+              :disabled="!change"
+              color="primary"
+              :loading="loading"
+              @click="submit()"
+            >
+              <v-icon left>mdi-content-save</v-icon>
+              {{ $t('buttons.save_edit') }}
+            </v-btn>
           </v-row>
 
           <v-divider class="my-3 mx-2" />
@@ -303,12 +313,13 @@ export default {
     validate(valid, index) {
       this.valids[index] = valid
     },
+    
     async submit() {
       const element = this.object.testTitle
       if (element.length > 0 && element.length < 200) {
         await this.$store.dispatch('updateTest', new Test(this.object))
         this.$store.commit('SET_LOCAL_CHANGES', false)
-        console.log('changes Saved')
+        console.log('Changes Saved')
         this.$toast.success('Changes Saved')
       } else if (element.length >= 200) {
         this.$toast.warning('Title must not exceed 200 characters.')


### PR DESCRIPTION
resolves #560 

added a button to save updated changes

[Screencast from 2025-02-02 14-36-08.webm](https://github.com/user-attachments/assets/f176608a-8812-400d-94aa-22accfc04bb2)
