### PR TITLE
Fixed the error related to expected CSS shorthand usage and added a generic font-family in src/components/molecules/Toolbar.vue

### DIFF
--- a/src/components/molecules/Toolbar.vue
+++ b/src/components/molecules/Toolbar.vue
@@ -71,7 +71,7 @@
         <v-btn
           dark
           text
-          style="text-transform: none !important; font: Roboto; font-size: 17px"
+          style="text-transform: none !important; font-family: Roboto, sans-serif; font-size: 17px"
           @click.stop="signOut()"
         >
           {{ $t('buttons.signout') }}
@@ -183,7 +183,7 @@
           </v-btn>
         </template>
         <v-list dense class="ma-0 py-1" style="border-radius: 0px !important">
-          <v-list-item dense style="font-size: 14px; font: Roboto" class="px-2">
+          <v-list-item dense style="font-size: 14px; font-family: Roboto, sans-serif" class="px-2">
             <v-list-item-content>
               <v-list-item-title style="font-weight: bold">
                 {{ $t('buttons.username') }}
@@ -196,7 +196,7 @@
 
           <v-list-item
             dense
-            style="font-size: 14px; font: Roboto"
+            style="font-size: 14px; font-family: Roboto, sans-serif"
             class="px-2"
             @click="signOut(), (menu = false)"
           >
@@ -393,7 +393,7 @@ export default {
 <style scoped>
 .console-button {
   font-size: 13px;
-  font: Roboto;
+  font-family: Roboto, sans-serif;
   text-transform: none !important;
   padding: 7px !important;
 }


### PR DESCRIPTION
fixed #563 

1. Replaced "font" with "font-family"
2. Added a fallback font-family "sans-serif