### PR TITLE
Added missing updatePassword import to ProfileView.vue

### DIFF
--- a/src/views/admin/ProfileView.vue
+++ b/src/views/admin/ProfileView.vue
@@ -131,6 +131,7 @@
 import {
   getAuth,
   reauthenticateWithCredential,
+  updatePassword,
   EmailAuthProvider,
 } from 'firebase/auth'
 import {


### PR DESCRIPTION
Fixes #580 

**Issue**
Previously updatePassword method was not imported in the codebase which was causing an error and the password was not getting updated.

**Resolution**
I imported the built in updatePassword method of firebase into the codebase so that the password gets updated succesfully.

![Screenshot 2025-02-09 171755](https://github.com/user-attachments/assets/d2bcbbc3-b6a5-481c-ba3a-327a877c5c88)

Users will now be able to update their passwords.
[Changes made under file src/views/admin/Profileview.vue]