### PR TITLE
Fix Design Inconsistencies & Missing Eye Icon in Update Password Field

### DIFF
--- a/src/views/admin/DashboardView.vue
+++ b/src/views/admin/DashboardView.vue
@@ -61,6 +61,7 @@
             background-color="transparent"
             color="black"
             class="hidden-sm-and-down mt-4"
+            active-class="active-tab"
           >
             <v-tab>{{ $t('Dashboard.tests') }}</v-tab>
             <!-- <v-tab>Answers</v-tab>-->
@@ -88,6 +89,7 @@
             background-color="transparent"
             color="black"
             class="hidden-sm-and-down"
+            active-class="active-tab"
           >
             <v-tab>{{ $t('Dashboard.myTests') }}</v-tab>
             <v-tab>{{ $t('Dashboard.sharedWithMe') }}</v-tab>
@@ -105,6 +107,7 @@
             background-color="transparent"
             color="black"
             class="hidden-sm-and-down"
+            active-class="active-tab"
           >
             <v-tab>{{ $t('Dashboard.personal') }}</v-tab>
             <v-tab>{{ $t('Dashboard.explore') }}</v-tab>
@@ -435,5 +438,12 @@ export default {
 .titleText {
   font-size: 40px;
   font-weight: 300;
+}
+
+.active-tab {
+  background-color: rgba(249, 168, 38, 0.2) !important; 
+  border-radius: 4px; 
+  color: #000000 !important; 
+  font-weight: bold;
 }
 </style>

--- a/src/views/admin/ProfileView.vue
+++ b/src/views/admin/ProfileView.vue
@@ -80,10 +80,12 @@
                     v-model="newPassword"
                     :rules="passwordRules"
                     label="New Password"
-                    type="password"
+                    :type="showPassword ? 'text' : 'password'"
                     outlined
                     dense
                     required
+                    :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+                    @click:append="showPassword = !showPassword"
                   ></v-text-field>
                 </v-col>
                 <v-col cols="12" md="6">
@@ -91,10 +93,12 @@
                     v-model="confirmPassword"
                     :rules="confirmPasswordRules"
                     label="Confirm New Password"
-                    type="password"
+                    :type="showConfirmPassword ? 'text' : 'password'"
                     outlined
                     dense
                     required
+                    :append-icon="showConfirmPassword ? 'mdi-eye' : 'mdi-eye-off'"
+                    @click:append="showConfirmPassword = !showConfirmPassword"
                   ></v-text-field>
                 </v-col>
               </v-row>
@@ -162,7 +166,6 @@
 import {
   getAuth,
   reauthenticateWithCredential,
-  updatePassword,
   EmailAuthProvider,
   updatePassword,
 } from 'firebase/auth'
@@ -197,6 +200,8 @@ export default {
       displayMissingInfo: 'INFO MISSING',
       loading: true,
       valid: false,
+      showPassword: false,
+      showConfirmPassword: false,
       newPassword: '',
       confirmPassword: '',
       passwordRules: [

--- a/src/views/public/SignUpView.vue
+++ b/src/views/public/SignUpView.vue
@@ -101,8 +101,10 @@ export default {
       (v) => /.+@.+\..+/.test(v) || i18n.t('errors.invalidEmail'),
     ],
     passwordRules: [
-      (v) => !!v || i18n.t('errors.passwordRequired'),
-      (v) => v.length >= 6 || i18n.t('errors.passwordValidate'),
+      v => !!v || 'Password is required',
+      v => v.length >= 8 || 'Password must be at least 8 characters',
+      v => /[A-Z]/.test(v) || 'Must contain an uppercase letter',
+      v => /[!@#$%^&*(),.?":{}|<>]/.test(v) || 'Must contain a symbol'
     ],
     confirmpassword: '',
     showPassword: false,


### PR DESCRIPTION
This PR addresses inconsistencies in the password field across the Signup and Update Password pages.

Fixes:
Adds the missing eye icon to the update password field, allowing users to toggle password visibility.
Aligns password rules between Signup and Update Password, ensuring consistency.

Closes #586 

**Before changes-**
![Screenshot 2025-02-10 204715](https://github.com/user-attachments/assets/5a562c3f-d1c4-4de9-95ac-8e1904e54bf9)
![Screenshot 2025-02-10 204920](https://github.com/user-attachments/assets/cfe5b038-7dd3-4b20-b6b1-fb090a652d09)


**After changes-**
![Screenshot 2025-02-10 204814](https://github.com/user-attachments/assets/a0c8cfe9-d873-4618-aeff-e57b455f1f2c)
![Screenshot 2025-02-10 205839](https://github.com/user-attachments/assets/ccb90900-8c9b-4ce0-b417-decbf9db7dd3)

**Additional changes-**
Added orange highlights to make UI more intuitive and user friendly.
![Screenshot 2025-02-12 214656](https://github.com/user-attachments/assets/ca59965b-516e-4afe-bee3-834ae37a69ef)
![Screenshot 2025-02-12 225215](https://github.com/user-attachments/assets/476515aa-8e4b-487f-a4a0-172dd344be3f)
