### PR TITLE
fix: "Cannot read properties of undefined (reading '__esModule')" Error

### DIFF
--- a/src/components/atoms/GlobalErrorHandler.vue
+++ b/src/components/atoms/GlobalErrorHandler.vue
@@ -1,38 +1,46 @@
 <template>
-  <div>
-    <Toast position="top-right" auto-close="{3000}" :render="error()" />
-  </div>
+  <div />
 </template>
 
 <script>
-import Toast from 'vue-toastification'
+import { mapState, mapMutations } from 'vuex'
 import 'vue-toastification/dist/index.css'
 
 export default {
-  components: { Toast },
+  data() {
+    return {
+      previousErrorMessage: '',
+      previousErrorCode: '',
+    }
+  },
   computed: {
-    isError() {
-      return (
-        this.$store.state.error.message || this.$store.state.error.errorCode
-      )
+    ...mapState({
+      error: (state) => state.error,
+    }),
+  },
+  watch: {
+    error: {
+      immediate: true,
+      deep: true,
+      handler(newError) {
+        if (
+          newError &&
+          (newError.message || newError.errorCode) &&
+          (newError.message !== this.previousErrorMessage ||
+            newError.errorCode !== this.previousErrorCode)
+        ) {
+          const toast = useToast()
+          toast.error(`${newError.errorCode}: ${newError.message}`)
+
+          this.previousErrorMessage = newError.message
+          this.previousErrorCode = newError.errorCode
+          this.clearError()
+        }
+      },
     },
   },
   methods: {
-    error() {
-      const mainError = this.$store.state.error
-      if (mainError && (mainError.message || mainError.errorCode)) {
-        if (
-          this.previousErrorMessage !== mainError.message ||
-          this.previousErrorCode !== mainError.errorCode
-        ) {
-          this.$toast.error(`${mainError.errorCode}: ${mainError.message}`)
-          this.previousErrorMessage = ''
-          this.previousErrorCode = ''
-        }
-        this.$store.state.error.errorCode = ''
-        this.$store.state.error.message = ''
-      }
-    },
+    ...mapMutations(['clearError']),
   },
 }
 </script>

--- a/src/components/atoms/GlobalErrorHandler.vue
+++ b/src/components/atoms/GlobalErrorHandler.vue
@@ -4,7 +4,6 @@
 
 <script>
 import { mapState, mapMutations } from 'vuex'
-import 'vue-toastification/dist/index.css'
 
 export default {
   data() {
@@ -29,9 +28,7 @@ export default {
           (newError.message !== this.previousErrorMessage ||
             newError.errorCode !== this.previousErrorCode)
         ) {
-          const toast = useToast()
-          toast.error(`${newError.errorCode}: ${newError.message}`)
-
+          this.$toast.error(`${newError.errorCode}: ${newError.message}`)
           this.previousErrorMessage = newError.message
           this.previousErrorCode = newError.errorCode
           this.clearError()


### PR DESCRIPTION
# Fix "Cannot read properties of undefined (reading '__esModule')" Error

## Issue  (Solves #591 )
The application encountered the following runtime error:  

### **Cause**  
1. **Direct Access to Vuex State**  
   - The original implementation accessed `this.$store.state.error` directly in the `error()` method.  
   - When the state was uninitialized or reset, `errorCode` and `message` were `undefined`, causing the error.

2. **Improper Toast Invocation**  
   - The Vue Toastification instance (`this.$toast.error`) was used without proper initialization.  

### **Fix**  
- **Used `mapState` to Bind State Correctly**  
  ```js
  computed: {
    ...mapState({
      error: (state) => state.error,
    }),
  }

