### PR TITLE
fix: Fixed rendering of tests in DashboardView and fixed navigation to that specific test ManagerView

### DIFF
--- a/src/views/admin/DashboardView.vue
+++ b/src/views/admin/DashboardView.vue
@@ -277,8 +277,8 @@ export default {
 
     filteredTests() {
       return this.tests?.filter(test => {
-        return test.testTitle.toLowerCase().includes(this.search.toLowerCase())
-      }) ?? this.tests
+        return test.testTitle.toLowerCase().includes(this.search.toLowerCase());
+      }) ?? this.tests;
     },
 
     templates() {
@@ -399,7 +399,7 @@ export default {
         if (this.subIndex === 0) {
           this.$router.push({
             name: 'ManagerView',
-            params: { id: test.testDocId },
+            params: { id: test.id },
           })
         }
         // if it is the shared with me tests
@@ -407,12 +407,12 @@ export default {
           if (test.accessLevel >= 2) {
             this.$router.push({
               name: 'TestView',
-              params: { id: test.testDocId },
+              params: { id: test.id },
             })
           } else {
             this.$router.push({
               name: 'ManagerView',
-              params: { id: test.testDocId },
+              params: { id: test.id },
             })
           }
         } else if (this.subIndex === 2) {


### PR DESCRIPTION
Previously, after test creation, the DashboardView remained empty and no tests have been rendered on it.
Also added an onclick navigation to the route of that specific test ManagerView.

Before:
[Screencast from 2025-02-20 20-23-29.webm](https://github.com/user-attachments/assets/9ca317eb-5ee9-402b-b70f-9ab0e0105e54)

After all fixes:
[Screencast from 2025-02-20 20-17-18.webm](https://github.com/user-attachments/assets/a8339818-65c7-4bc1-96df-6cf78e2a8436)
