### PR TITLE
Update .gitignore to ignore databse-debug.log and ui-debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 firebase-debug.log
+database-debug.log 
+ui-debug.log
 
 # Editor directories and files
 .idea

--- a/ui-debug.log
+++ b/ui-debug.log
@@ -1,2 +1,0 @@
-Web / API server started at 127.0.0.1:4000
-Web / API server started at ::1:4000


### PR DESCRIPTION
while using firebase emulators there is one more debug file that gets created when we create a test which is not included in the .gitignore, this pr adds database-debug.log to .gitignore.
This PR also adds debug-ui.log to .gitignore and also removes ui-debug.log from the codebase.