### PR TITLE
# Fixes #635: Replaced Multiple [TODO] Placeholders with Meaningful Text

### DIFF
--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -200,7 +200,7 @@
   },
   "HeuristicsOptionsTable": {
     "titles": {
-      "options": "[TODO]"
+      "options": "Opciones"
     },
     "messages": {},
     "placeHolders": {},
@@ -220,128 +220,127 @@
   },
   "HeuristicsSettings": {
     "titles": {
-      "settings": "[TODO]"
+      "settings": "Configuración"
     },
     "messages": {
-      "acceptCsv": "[TODO]",
-      "noCsvFileSelected": "[TODO]"
+      "acceptCsv": "Aceptar archivo CSV",
+      "noCsvFileSelected": "No se ha seleccionado ningún archivo CSV"
     },
     "placeHolders": {
-      "importCsv": "[TODO]"
+      "importCsv": "Importar CSV"
     },
     "actions": {
-      "downloadCsvTemplate": "[TODO]",
-      "update": "[TODO]"
+      "downloadCsvTemplate": "Descargar plantilla CSV",
+      "update": "Actualizar"
     }
   },
   "HeuristicsTestView": {
     "messages": {
-      "submitTest": "[TODO]",
-      "submitOnce": "[TODO]",
-      "noHeuristics": "[TODO]"
+      "submitTest": "Enviar prueba",
+      "submitOnce": "Solo puede enviar una vez",
+      "noHeuristics": "No hay heurísticas disponibles"
     },
     "actions": {
-      "cancel": "[TODO]",
-      "submit": "[TODO]",
-      "save": "[TODO]",
-      "continueAs": "[TODO]",
-      "notMail": "[TODO]",
-      "changeAccount": "[TODO]",
-      "startTest": "[TODO]"
+      "cancel": "Cancelar",
+      "submit": "Enviar",
+      "save": "Guardar",
+      "continueAs": "Continuar como",
+      "notMail": "¿No es tu correo?",
+      "changeAccount": "Cambiar cuenta",
+      "startTest": "Comenzar prueba"
     }
   },
   "HeuristicsEditTest": {
     "titles": {
-      "heuristics": "[TODO]",
-      "options": "[TODO]",
-      "weights": "[TODO]",
-      "settings": "[TODO]"
+      "heuristics": "Heurísticas",
+      "options": "Opciones",
+      "weights": "Pesos",
+      "settings": "Configuración"
     }
   },
   "HeuristicsTestAnswer": {
     "titles": {
-      "answers": "[TODO]",
-      "statistics": "[TODO]",
-      "evaluators": "[TODO]",
-      "heuristics": "[TODO]",
-      "analytics": "[TODO]"
+      "answers": "Respuestas",
+      "statistics": "Estadísticas",
+      "evaluators": "Evaluadores",
+      "heuristics": "Heurísticas",
+      "analytics": "Análisis"
     },
     "statistics": {
-      "usabilityPercentage": "[TODO]",
-      "max": "[TODO]",
-      "min": "[TODO]",
-      "std": "[TODO]"
+      "usabilityPercentage": "Porcentaje de usabilidad",
+      "max": "Máximo",
+      "min": "Mínimo",
+      "std": "Desviación estándar"
     },
     "evaluators": {
       "headers": {
-        "table": "[TODO]",
-        "graphic": "[TODO]"
+        "table": "Tabla",
+        "graphic": "Gráfico"
       },
       "messages": {
-        "graphForMoreThan3": "[TODO]"
+        "graphForMoreThan3": "El gráfico está disponible para más de 3 evaluadores"
       }
     },
     "heuristics": {
       "headers": {
-        "heuristicsData": "[TODO]",
-        "answersByEvaluator": "[TODO]",
-        "answersByHeuristics": "[TODO]",
-        "graphic": "[TODO]",
-        "weights": "[TODO]"
+        "heuristicsData": "Datos heurísticos",
+        "answersByEvaluator": "Respuestas por evaluador",
+        "answersByHeuristics": "Respuestas por heurísticas",
+        "graphic": "Gráfico",
+        "weights": "Pesos"
       },
       "messages": {
-        "needMoreThan1Answer": "[TODO]",
-        "runWeightFunction": "[TODO]"
+        "needMoreThan1Answer": "Necesita más de una respuesta",
+        "runWeightFunction": "Ejecutar función de peso"
       }
-    },
-    "analytics": {}
+    }
   },
   "HeuristicsReport": {
     "titles": {
-      "reports": "[TODO]",
-      "last_updated": "[TODO]"
+      "reports": "Informes",
+      "last_updated": "Última actualización"
     },
     "headers": {
-      "evaluator": "[TODO]",
-      "last_update": "[TODO]",
-      "progress": "[TODO]",
-      "status": "[TODO]",
-      "more": "[TODO]"
+      "evaluator": "Evaluador",
+      "last_update": "Última actualización",
+      "progress": "Progreso",
+      "status": "Estado",
+      "more": "Más"
     },
     "messages": {
-      "confirm_delete_report": "[TODO]",
-      "reports_loading": "[TODO]",
-      "remove_report": "[TODO]",
-      "sure_to_delete": "[TODO] {user}",
-      "report_deleted": "[TODO]"
+      "confirm_delete_report": "Confirmar eliminación del informe",
+      "reports_loading": "Cargando informes",
+      "remove_report": "Eliminar informe",
+      "sure_to_delete": "¿Está seguro de eliminar el informe de {user}?",
+      "report_deleted": "Informe eliminado"
     },
     "status": {
-      "submitted": "[TODO]",
-      "in_progress": "[TODO]"
+      "submitted": "Enviado",
+      "in_progress": "En progreso"
     }
   },
   "HeuristicsCooperators": {
     "title": {
-      "cooperators": "[TODO]"
+      "cooperators": "Cooperadores"
     },
     "headers": {
-      "email": "[TODO]",
-      "role": "[TODO]",
-      "invited": "[TODO]",
-      "accepted": "[TODO]",
-      "more": "[TODO]",
-      "title": "[TODO]",
-      "content": "[TODO]"
+      "email": "Correo electrónico",
+      "role": "Rol",
+      "invited": "Invitado",
+      "accepted": "Aceptado",
+      "more": "Más",
+      "title": "Título",
+      "content": "Contenido"
     },
     "actions": {
-      "send_invitation": "[TODO]",
-      "send_message": "[TODO]",
-      "reinvite": "[TODO]",
-      "remove_cooperator": "[TODO]",
-      "cancel_invitation": "[TODO]",
-      "cancel": "[TODO]",
-      "send": "[TODO]",
-      "select_cooperator": "[TODO]"
+      "send_invitation": "Enviar invitación",
+      "send_message": "Enviar mensaje",
+      "reinvite": "Reinvitar",
+      "remove_cooperator": "Eliminar cooperador",
+      "cancel_invitation": "Cancelar invitación",
+      "cancel": "Cancelar",
+      "send": "Enviar",
+      "select_cooperator": "Seleccionar cooperador"
     },
     "roles": {
       "administrator": "[TODO]",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -35,12 +35,12 @@
     "unread":"अनपढ़",
     "inbox":"इनबॉक्स",
     "timeAgo": {
-      "years": "[TODO] {count}",
-      "months": "[TODO] {count}",
-      "days": "[TODO] {count}",
-      "hours": "[TODO] {count}",
-      "minutes": "[TODO] {count}",
-      "now": "[TODO]"
+      "years": "{count} साल पहले",
+      "months": "{count} महीने पहले",
+      "days": "{count} दिन पहले",
+      "hours": "{count} घंटे पहले",
+      "minutes": "{count} मिनट पहले",
+      "now": "अभी"
     },
     "viewAll": "सभी देखें",
     "sentBy": "के द्वारा भेजा गया है",
@@ -297,7 +297,7 @@
     },
     "HeuristicsOptionsTable": {
       "titles": {
-        "options": "[TODO]"
+        "options": "विकल्प"
       },
       "messages": {},
       "placeHolders": {},
@@ -305,54 +305,54 @@
     },
     "HeuristicsWeightsTable": {
       "titles": {
-        "weights": "[TODO]",
-        "heuristics": "[TODO]"
+        "weights": "वज़न",
+        "heuristics": "ह्यूरिस्टिक्स"
       },
       "messages": {
-        "atLeast2HeuristicsForWeighting": "[TODO]"
+        "atLeast2HeuristicsForWeighting": "वज़न निर्धारित करने के लिए कम से कम 2 ह्यूरिस्टिक्स की आवश्यकता है"
       },
       "actions": {
-        "saveWeights": "[TODO]"
+        "saveWeights": "वज़न मान सहेजें"
       }
     },
     "HeuristicsSettings": {
       "titles": {
-        "settings": "[TODO]"
+        "settings": "सेटिंग्स"
       },
       "messages": {
-        "acceptCsv": "[TODO]",
-        "noCsvFileSelected": "[TODO]"
+        "acceptCsv": "CSV फ़ाइल स्वीकार करें",
+        "noCsvFileSelected": "कोई CSV फ़ाइल नहीं चुनी गई"
       },
       "placeHolders": {
-        "importCsv": "[TODO]"
+        "importCsv": "CSV आयात करें"
       },
       "actions": {
-        "downloadCsvTemplate": "[TODO]",
-        "update": "[TODO]"
+        "downloadCsvTemplate": "CSV टेम्पलेट डाउनलोड करें",
+        "update": "अपडेट करें"
       }
     },
     "HeuristicsTestView": {
       "messages": {
-        "submitTest": "[TODO]",
-        "submitOnce": "[TODO]",
-        "noHeuristics": "[TODO]"
+        "submitTest": "परीक्षण जमा करें",
+        "submitOnce": "आप केवल एक बार जमा कर सकते हैं",
+        "noHeuristics": "कोई ह्यूरिस्टिक्स उपलब्ध नहीं हैं"
       },
       "actions": {
-        "cancel": "[TODO]",
-        "submit": "[TODO]",
-        "save": "[TODO]",
-        "continueAs": "[TODO]",
-        "notMail": "[TODO]",
-        "changeAccount": "[TODO]",
-        "startTest": "[TODO]"
+        "cancel": "रद्द करें",
+        "submit": "जमा करें",
+        "save": "सहेजें",
+        "continueAs": "जारी रखें",
+        "notMail": "आपका ईमेल नहीं है?",
+        "changeAccount": "खाता बदलें",
+        "startTest": "परीक्षण शुरू करें"
       }
     },
     "HeuristicsEditTest": {
       "titles": {
-        "heuristics": "[TODO]",
-        "options": "[TODO]",
-        "weights": "[TODO]",
-        "settings": "[TODO]"
+        "heuristics": "ह्यूरिस्टिक्स",
+        "options": "विकल्प",
+        "weights": "वज़न",
+        "settings": "सेटिंग्स"
       }
     },
     "HeuristicsTestAnswer": {
@@ -362,12 +362,12 @@
     },
     "forms": {
       "labels": {
-        "testName": "[TODO]",
-        "name": "[TODO]",
-        "variableName": "[TODO]",
-        "question": "[TODO]",
-        "text": "[TODO]",
-        "value": "[TODO]"
+        "testName": "परीक्षण का नाम",
+        "name": "नाम",
+        "variableName": "चर का नाम",
+        "question": "प्रश्न",
+        "text": "पाठ",
+        "value": "मान"
       }
     },
     "settings": {
@@ -466,5 +466,12 @@
     "analyseresultsanswer": "परिणामों का विश्लेषण करने के लिए, अपने परीक्षण के प्रबंधक पृष्ठ पर जाएं। वहां से, बाएँ साइडबार में 'उत्तर' चुनें। यहां, आप आँकड़े, मूल्यांकनकर्ता और हीयूरिस्टिक्स देख सकते हैं।",
     "sendmessage": "मैं अपने सहयोगियों को संदेश कैसे भेजूं?",
     "sendmessageanswer": "संदेश भेजने के लिए, अपने परीक्षण के प्रबंधक पृष्ठ पर जाएं। बाएँ साइडबार से 'सहयोगी' चुनें। उस सहयोगी के नाम के बगल में तीन बिंदु वाले आइकन पर क्लिक करें जिसे आप संदेश भेजना चाहते हैं। फिर, 'संदेश भेजें' विकल्प चुनें और शीर्षक और सामग्री सहित अपना संदेश लिखें।"
+  },
+  "HeuristicsCooperators": {
+    "roles": {
+      "administrator": "प्रशासक",
+      "evaluator": "मूल्यांकनकर्ता",
+      "guest": "अतिथि"
+    }
   }
 }

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -35,12 +35,12 @@
     "unread":"não lido",
     "inbox":"Caixa de entrada",
     "timeAgo": {
-      "years": "[TODO] {count}",
-      "months": "[TODO] {count}",
-      "days": "[TODO] {count}",
-      "hours": "[TODO] {count}",
-      "minutes": "[TODO] {count}",
-      "now": "[TODO]"
+      "years": "{count} ano{count !== 1 ? 's' : ''} atrás",
+      "months": "{count} mês{count !== 1 ? 'es' : ''} atrás",
+      "days": "{count} dia{count !== 1 ? 's' : ''} atrás",
+      "hours": "{count} hora{count !== 1 ? 's' : ''} atrás",
+      "minutes": "{count} minuto{count !== 1 ? 's' : ''} atrás",
+      "now": "Agora"
     },
     "viewAll": "Ver tudo",
     "sentBy": "Enviado por",
@@ -199,7 +199,7 @@
   },
   "HeuristicsOptionsTable": {
     "titles": {
-      "options": "[TODO]"
+      "options": "Opções"
     },
     "messages": {},
     "placeHolders": {},
@@ -207,54 +207,54 @@
   },
   "HeuristicsWeightsTable": {
     "titles": {
-      "weights": "[TODO]",
-      "heuristics": "[TODO]"
+      "weights": "Pesos",
+      "heuristics": "Heurísticas"
     },
     "messages": {
-      "atLeast2HeuristicsForWeighting": "[TODO]"
+      "atLeast2HeuristicsForWeighting": "É necessário pelo menos 2 heurísticas para poder colocar os pesos"
     },
     "actions": {
-      "saveWeights": "[TODO]"
+      "saveWeights": "Salvar valores de peso"
     }
   },
   "HeuristicsSettings": {
     "titles": {
-      "settings": "[TODO]"
+      "settings": "Configurações"
     },
     "messages": {
-      "acceptCsv": "[TODO]",
-      "noCsvFileSelected": "[TODO]"
+      "acceptCsv": "Aceitar arquivo CSV",
+      "noCsvFileSelected": "Nenhum arquivo CSV selecionado"
     },
     "placeHolders": {
-      "importCsv": "[TODO]"
+      "importCsv": "Importar CSV"
     },
     "actions": {
-      "downloadCsvTemplate": "[TODO]",
-      "update": "[TODO]"
+      "downloadCsvTemplate": "Baixar modelo CSV",
+      "update": "Atualizar"
     }
   },
   "HeuristicsTestView": {
     "messages": {
-      "submitTest": "[TODO]",
-      "submitOnce": "[TODO]",
-      "noHeuristics": "[TODO]"
+      "submitTest": "Enviar teste",
+      "submitOnce": "Você só pode enviar uma vez",
+      "noHeuristics": "Não há heurísticas disponíveis"
     },
     "actions": {
-      "cancel": "[TODO]",
-      "submit": "[TODO]",
-      "save": "[TODO]",
-      "continueAs": "[TODO]",
-      "notMail": "[TODO]",
-      "changeAccount": "[TODO]",
-      "startTest": "[TODO]"
+      "cancel": "Cancelar",
+      "submit": "Enviar",
+      "save": "Salvar",
+      "continueAs": "Continuar como",
+      "notMail": "Não é seu e-mail?",
+      "changeAccount": "Mudar conta",
+      "startTest": "Iniciar teste"
     }
   },
   "HeuristicsEditTest": {
     "titles": {
-      "heuristics": "[TODO]",
-      "options": "[TODO]",
-      "weights": "[TODO]",
-      "settings": "[TODO]"
+      "heuristics": "Heurísticas",
+      "options": "Opções",
+      "weights": "Pesos",
+      "settings": "Configurações"
     }
   },
   "HeuristicsTestAnswer": {


### PR DESCRIPTION
# Fixes #635 : Replaced Multiple [TODO] Placeholders with Meaningful Text

## Changes Made
- Replaced multiple `[TODO]` placeholders with appropriate text.
- Ensured consistency in terminology and UI elements across different sections.
- Updated user-facing texts in alerts, buttons, switches, inputs, and settings.

## Screenshots

### Before:
![Screenshot 1](https://github.com/user-attachments/assets/d286a5c5-09c7-400d-885e-ce1ffac7c9ed)
![Screenshot 2](https://github.com/user-attachments/assets/907f9d91-6a8a-4f72-bd49-12f7d0406cf3)

### After:
![Screenshot 3](https://github.com/user-attachments/assets/7c7ac8c4-de29-4b86-9f9c-e0d9e458297b)
![Screenshot from 2025-03-06 23-02-29](https://github.com/user-attachments/assets/a265f037-f1bb-4aaa-a8a5-eb8a9379473a)



## Testing Steps
1. Open the updated sections in the project.
2. Verify that all `[TODO]` placeholders have been replaced with meaningful text.
3. Check for consistency in terminology and UI elements.

## Additional Context
These updates improve the user experience by replacing placeholders with clear and accurate text.
