### PR TITLE
Added ToolTips in LiveTest to remove confusion

### DIFF
--- a/src/components/molecules/FeedbackView.vue
+++ b/src/components/molecules/FeedbackView.vue
@@ -9,42 +9,72 @@
     <v-col cols="12">
       <v-row justify="center">
         <v-card class="pa-2 buttonCard" depressed>
-          <v-btn
-            v-if="localCameraStream"
-            class="mx-3"
-            :dark="isMicrophoneMuted"
-            :class="{ red: isMicrophoneMuted, white: !isMicrophoneMuted }"
-            fab
-            depressed
-            @click="toggleMicrophone"
-          >
-            <v-icon v-if="!isMicrophoneMuted">
-              mdi-microphone
-            </v-icon>
-            <v-icon v-else>
-              mdi-microphone-off
-            </v-icon>
-          </v-btn>
-          <v-btn
-            class="mx-3"
-            :dark="isSharingScreen"
-            :class="{ red: isSharingScreen, white: !isSharingScreen }"
-            depressed
-            fab
-            @click="toggleCameraScreen"
-          >
-            <v-icon v-if="!isSharingScreen">
-              mdi-monitor-screenshot
-            </v-icon>
-            <v-icon v-else>
-              mdi-monitor-off
-            </v-icon></v-btn
-          >
-          <v-btn class="mx-3 white" depressed fab @click="redirect()">
-            <v-icon>
-              mdi-link
-            </v-icon></v-btn
-          >
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn
+                v-if="localCameraStream"
+                class="mx-3"
+                :dark="isMicrophoneMuted"
+                :class="{ red: isMicrophoneMuted, white: !isMicrophoneMuted }"
+                fab
+                depressed
+                @click="toggleMicrophone"
+                v-bind="attrs"
+                v-on="on"
+              >
+                <v-icon v-if="!isMicrophoneMuted">
+                  mdi-microphone
+                </v-icon>
+                <v-icon v-else>
+                  mdi-microphone-off
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>{{
+              isMicrophoneMuted ? 'Unmute microphone' : 'Mute microphone'
+            }}</span>
+          </v-tooltip>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn
+                class="mx-3"
+                :dark="isSharingScreen"
+                :class="{ red: isSharingScreen, white: !isSharingScreen }"
+                depressed
+                fab
+                @click="toggleCameraScreen"
+                v-bind="attrs"
+                v-on="on"
+              >
+                <v-icon v-if="!isSharingScreen">
+                  mdi-monitor-screenshot
+                </v-icon>
+                <v-icon v-else>
+                  mdi-monitor-off
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>{{
+              isSharingScreen ? 'Stop screen sharing' : 'Share screen'
+            }}</span>
+          </v-tooltip>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on, attrs }">
+              <v-btn
+                class="mx-3 white"
+                depressed
+                fab
+                @click="redirect()"
+                v-bind="attrs"
+                v-on="on"
+              >
+                <v-icon>
+                  mdi-link
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>Open link</span>
+          </v-tooltip>
         </v-card>
       </v-row>
     </v-col>
@@ -100,6 +130,11 @@ export default {
   },
   methods: {
     redirect() {
+      if(this.test.testStructure.landingPage.trim() == '') {
+        this.$toast.error('No landing page provided')
+        return
+      }
+      console.log(this.test.testStructure.landingPage)
       window.open(this.test.testStructure.landingPage)
     },
     setupStreams() {


### PR DESCRIPTION
previous state the tooltip was missing 
![previous state](https://github.com/user-attachments/assets/b6294414-1980-4108-a922-ea18b5fa18f3)
also link open as blank if moderator doesnt provide the link 

Added ToolTips in Live test and also added a validation In case the link in empty
![Tooltip for live test](https://github.com/user-attachments/assets/c7902d1c-f18d-4a87-aa94-ae1af3520cf3)
