### PR TITLE
Fix Responsiveness of Moderator Edit Test ( #642)

### DIFF
--- a/src/components/atoms/FormPostTest.vue
+++ b/src/components/atoms/FormPostTest.vue
@@ -56,7 +56,7 @@
                 </div>
               </v-form>
               <v-row>
-                <v-col cols="6">
+                <v-col :cols="6" class="checkbox-container">
                   <v-checkbox
                     v-model="items[i].selectionField"
                     :label="$t('UserTestTable.checkboxes.selectionAnswer')"
@@ -64,7 +64,7 @@
                     @click="selectField(i)"
                   />
                 </v-col>
-                <v-col cols="5">
+                <v-col :cols="5" class="checkbox-container">
                   <v-checkbox
                     v-model="items[i].textField"
                     :label="$t('UserTestTable.checkboxes.textAnswer')"
@@ -221,4 +221,18 @@ export default {
 }
 </script>
 
-<style></style>
+<style scoped>
+@media (max-width: 600px) {
+  .checkbox-container {
+    width: 100%;
+    max-width: 100%;
+    flex: 0 0 100%;
+  }
+  .v-row {
+    flex-direction: column;
+  }
+  .v-btn.mt-5 {
+    margin-top: 0 !important;
+  }
+}
+</style>

--- a/src/components/atoms/UserVariables.vue
+++ b/src/components/atoms/UserVariables.vue
@@ -56,7 +56,7 @@
                 </div>
               </v-form>
               <v-row>
-                <v-col cols="6">
+                <v-col :cols="6" class="checkbox-container">
                   <v-checkbox
                     v-model="items[i].selectionField"
                     :label="$t('UserTestTable.checkboxes.selectionField')"
@@ -64,7 +64,7 @@
                     @click="selectField(i)"
                   />
                 </v-col>
-                <v-col cols="5">
+                <v-col :cols="5" class="checkbox-container">
                   <v-checkbox
                     v-model="items[i].textField"
                     :label="$t('UserTestTable.checkboxes.textField')"
@@ -227,5 +227,18 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
+@media (max-width: 600px) {
+  .checkbox-container {
+    width: 100%;
+    max-width: 100%;
+    flex: 0 0 100%;
+  }
+  .v-row {
+    flex-direction: column;
+  }
+  .v-btn.mt-5 {
+    margin-top: 0 !important;
+  }
+}
 </style>

--- a/src/components/organisms/EditModeratedUserTest.vue
+++ b/src/components/organisms/EditModeratedUserTest.vue
@@ -1,150 +1,258 @@
 <template>
-  <v-tabs
-    v-if="type == 'tabs'"
-    background-color="transparent"
-    color="#FCA326"
-    class="pb-0 mb-0"
-  >
-    <v-tab @click="tabClicked(0)">
-      PRE-TEST
-    </v-tab>
-    <v-tab @click="tabClicked(1)">
-      TASKS
-    </v-tab>
-    <v-tab @click="tabClicked(2)">
-      POST-TEST
-    </v-tab>
-  </v-tabs>
+  <div>
+    <v-tabs
+      v-if="type == 'tabs'"
+      background-color="transparent"
+      color="#FCA326"
+      class="pb-0 mb-0"
+    >
+      <v-tab @click="tabClicked(0)">
+        PRE-TEST
+      </v-tab>
+      <v-tab @click="tabClicked(1)">
+        TASKS
+      </v-tab>
+      <v-tab @click="tabClicked(2)">
+        POST-TEST
+      </v-tab>
+    </v-tabs>
 
-  <v-col v-else-if="type == 'content'" cols="12">
-    <v-row>
-      <!-- PRE-TEST -->
-      <v-col v-if="index == 0" cols="8">
-        <v-card style="background: #f5f7ff" flat class="cards">
-          <v-col cols="12" class="pb-0 px-5 pt-4">
-            <span class="cardsTitle ml-3"> Consent Form</span>
-            <br />
-            <span class="cardsSubtitle ml-3"
-              >This is a Consent Checkbox with a text for confirm the
-              consentiment</span
-            >
-          </v-col>
-          <UserConsent />
-        </v-card>
-      </v-col>
-      <v-col v-if="index == 0" cols="4" class="pl-0" style="height: 19vh;">
-        <v-card flat style="background: #f5f7ff" class="cards">
-          <v-col cols="12" class="pb-0 pt-4 px-8">
-            <span class="cardsTitle mt-4">Welcome message</span>
-            <br />
-            <span class="cardsSubtitle"
-              >This message will be the first thing participants see before the
-              session is started.</span
-            >
-          </v-col>
-          <v-textarea
-            v-model="welcomeMessage"
-            outlined
-            color="orange"
-            class="mx-6 mt-3"
-            placeholder="Thank you for participating..."
-            @change="saveWelcomeState()"
-          />
-          <v-col cols="12" class="pb-0 px-8">
-            <span class="cardsTitle">Landing Page</span>
-            <br />
-            <span class="cardsSubtitle"
-              >This URL will automatically load when participants starts
-              session.</span
-            >
-            <v-text-field
-              v-model="landingPage"
-              class="mt-3"
-              style="border-radius: 20px;"
-              placeholder="https://www.ruxailab.com"
+    <v-col v-else-if="type == 'content'" cols="12">
+      <!-- Desktop Layout -->
+      <v-row v-if="$vuetify.breakpoint.lgAndUp">
+        <!-- PRE-TEST -->
+        <v-col v-if="index == 0" cols="8">
+          <v-card style="background: #f5f7ff" flat class="cards">
+            <v-col cols="12" class="pb-0 px-5 pt-4">
+              <span class="cardsTitle ml-3"> Consent Form</span>
+              <br />
+              <span class="cardsSubtitle ml-3"
+                >This is a Consent Checkbox with a text for confirm the
+                consentiment</span
+              >
+            </v-col>
+            <UserConsent />
+          </v-card>
+        </v-col>
+        <v-col v-if="index == 0" cols="4" class="pl-0" style="height: 19vh;">
+          <v-card flat style="background: #f5f7ff" class="cards">
+            <v-col cols="12" class="pb-0 pt-4 px-8">
+              <span class="cardsTitle mt-4">Welcome message</span>
+              <br />
+              <span class="cardsSubtitle"
+                >This message will be the first thing participants see before the
+                session is started.</span
+              >
+            </v-col>
+            <v-textarea
+              v-model="welcomeMessage"
               outlined
               color="orange"
-              @change="saveLandingPage()"
+              class="mx-6 mt-3"
+              placeholder="Thank you for participating..."
+              @change="saveWelcomeState()"
             />
-          </v-col>
-          <v-col cols="12" class="pb-1 px-8 pb-0">
-            <span class="cardsTitle">Participant camera</span>
-            <v-radio-group
-              v-model="participantCamera"
-              class="pt-0"
-              @change="saveParticipantCamera()"
-            >
-              <v-radio label="Optional" color="orange" value="optional" />
-              <v-radio label="Required" color="orange" value="required" />
-              <v-radio label="Disabled" color="orange" value="disabled" />
-            </v-radio-group>
-          </v-col>
-        </v-card>
-      </v-col>
-      <v-col v-if="index == 0" cols="8" class="pt-0 pb-0">
-        <v-card
-          style="background: #f5f7ff; min-height: 420px;"
-          flat
-          class="cards"
-        >
-          <v-col cols="12">
-            <span class="cardsTitle ml-3">Pre-Form</span>
-            <br />
-            <span class="cardsSubtitle ml-3"
-              >This is a pre-questions you make to get participants data</span
-            >
-            <UserVariables @input="updateData" />
-          </v-col>
-        </v-card>
-      </v-col>
+            <v-col cols="12" class="pb-0 px-8">
+              <span class="cardsTitle">Landing Page</span>
+              <br />
+              <span class="cardsSubtitle"
+                >This URL will automatically load when participants starts
+                session.</span
+              >
+              <v-text-field
+                v-model="landingPage"
+                class="mt-3"
+                style="border-radius: 20px;"
+                placeholder="https://www.ruxailab.com"
+                outlined
+                color="orange"
+                @change="saveLandingPage()"
+              />
+            </v-col>
+            <v-col cols="12" class="pb-1 px-8 pb-0">
+              <span class="cardsTitle">Participant camera</span>
+              <v-radio-group
+                v-model="participantCamera"
+                class="pt-0"
+                @change="saveParticipantCamera()"
+              >
+                <v-radio label="Optional" color="orange" value="optional" />
+                <v-radio label="Required" color="orange" value="required" />
+                <v-radio label="Disabled" color="orange" value="disabled" />
+              </v-radio-group>
+            </v-col>
+          </v-card>
+        </v-col>
+        <v-col v-if="index == 0" cols="8" class="pt-0 pb-0">
+          <v-card
+            style="background: #f5f7ff; min-height: 420px;"
+            flat
+            class="cards"
+          >
+            <v-col cols="12">
+              <span class="cardsTitle ml-3">Pre-Form</span>
+              <br />
+              <span class="cardsSubtitle ml-3"
+                >This is a pre-questions you make to get participants data</span
+              >
+              <UserVariables @input="updateData" />
+            </v-col>
+          </v-card>
+        </v-col>
 
-      <!-- Tasks -->
+        <!-- Tasks -->
 
-      <v-col v-if="index == 1" cols="12">
-        <ModeratedTasks />
-      </v-col>
+        <v-col v-if="index == 1" cols="12">
+          <ModeratedTasks />
+        </v-col>
 
-      <!-- Post Test -->
+        <!-- Post Test -->
 
-      <v-col v-if="index == 2" cols="12">
-        <v-card
-          style="background: #f5f7ff; min-height: 410px;"
-          flat
-          class="cards"
-        >
-          <v-col cols="12" class="pb-0 px-5 pt-4">
-            <span class="cardsTitle ml-3">Post Form</span>
-            <br />
-            <span class="cardsSubtitle ml-3"
-              >This is a post-questions you make to get participants data</span
-            >
-            <FormPostTest @input="updateData" />
-          </v-col>
-        </v-card>
-      </v-col>
-      <v-col v-if="index == 2" cols="12" class="pt-0">
-        <v-card style="background: #f5f7ff" flat class="cards">
-          <v-col cols="12" class="pb-0 px-5 pt-4 pb-0">
-            <span class="cardsTitle ml-3">Final message</span>
-            <br />
-            <span class="cardsSubtitle ml-3"
-              >This is a Final message you leave to the participant on finish
-              test.</span
-            >
-          </v-col>
-          <v-textarea
-            v-model="finalMessage"
-            rows="3"
-            outlined
-            color="orange"
-            class="mx-6 mt-3"
-            placeholder="Thank you for participating..."
-            @change="saveFinalMessage()"
-          />
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-col>
+        <v-col v-if="index == 2" cols="12">
+          <v-card
+            style="background: #f5f7ff; min-height: 410px;"
+            flat
+            class="cards"
+          >
+            <v-col cols="12" class="pb-0 px-5 pt-4">
+              <span class="cardsTitle ml-3">Post Form</span>
+              <br />
+              <span class="cardsSubtitle ml-3"
+                >This is a post-questions you make to get participants data</span
+              >
+              <FormPostTest @input="updateData" />
+            </v-col>
+          </v-card>
+        </v-col>
+        <v-col v-if="index == 2" cols="12" class="pt-0">
+          <v-card style="background: #f5f7ff" flat class="cards">
+            <v-col cols="12" class="pb-0 px-5 pt-4 pb-0">
+              <span class="cardsTitle ml-3">Final message</span>
+              <br />
+              <span class="cardsSubtitle ml-3"
+                >This is a Final message you leave to the participant on finish
+                test.</span
+              >
+            </v-col>
+            <v-textarea
+              v-model="finalMessage"
+              rows="3"
+              outlined
+              color="orange"
+              class="mx-6 mt-3"
+              placeholder="Thank you for participating..."
+              @change="saveFinalMessage()"
+            />
+          </v-card>
+        </v-col>
+      </v-row>
+
+      <!-- Mobile/Tablet Layout -->
+      <v-row v-else>
+        <!-- PRE-TEST Mobile -->
+        <v-col v-if="index == 0" cols="12">
+          <v-card style="background: #f5f7ff" flat class="cards">
+            <v-col cols="12" class="pb-0 px-4 pt-4">
+              <span class="cardsTitle">Consent Form</span>
+              <br />
+              <span class="cardsSubtitle">This is a Consent Checkbox with a text for confirm the consentiment</span>
+            </v-col>
+            <UserConsent />
+          </v-card>
+
+          <v-card flat style="background: #f5f7ff" class="cards mt-4">
+            <v-col cols="12" class="pb-0 pt-4 px-4">
+              <span class="cardsTitle">Welcome message</span>
+              <br />
+              <span class="cardsSubtitle">This message will be the first thing participants see before the session is started.</span>
+              <v-textarea
+                v-model="welcomeMessage"
+                outlined
+                color="orange"
+                class="mt-3"
+                placeholder="Thank you for participating..."
+                @change="saveWelcomeState()"
+              />
+            </v-col>
+
+            <v-col cols="12" class="pb-0 px-4">
+              <span class="cardsTitle">Landing Page</span>
+              <br />
+              <span class="cardsSubtitle">This URL will automatically load when participants starts session.</span>
+              <v-text-field
+                v-model="landingPage"
+                class="mt-3"
+                style="border-radius: 20px;"
+                placeholder="https://www.ruxailab.com"
+                outlined
+                color="orange"
+                @change="saveLandingPage()"
+              />
+            </v-col>
+
+            <v-col cols="12" class="pb-1 px-4">
+              <span class="cardsTitle">Participant camera</span>
+              <v-radio-group
+                v-model="participantCamera"
+                class="pt-0"
+                @change="saveParticipantCamera()"
+              >
+                <v-radio label="Optional" color="orange" value="optional" />
+                <v-radio label="Required" color="orange" value="required" />
+                <v-radio label="Disabled" color="orange" value="disabled" />
+              </v-radio-group>
+            </v-col>
+          </v-card>
+
+          <v-card style="background: #f5f7ff" flat class="cards mt-4">
+            <v-col cols="12">
+              <span class="cardsTitle">Pre-Form</span>
+              <br />
+              <span class="cardsSubtitle">This is a pre-questions you make to get participants data</span>
+              <UserVariables @input="updateData" />
+            </v-col>
+          </v-card>
+        </v-col>
+
+        <!-- Tasks Mobile -->
+        <v-col v-if="index == 1" cols="12">
+          <ModeratedTasks />
+        </v-col>
+
+        <!-- Post Test Mobile -->
+        <v-col v-if="index == 2" cols="12">
+          <v-card style="background: #f5f7ff" flat class="cards">
+            <v-col cols="12" class="pb-0 px-4 pt-4">
+              <span class="cardsTitle">Post Form</span>
+              <br />
+              <span class="cardsSubtitle">This is a post-questions you make to get participants data</span>
+              <FormPostTest
+                @input="updateData"
+                :class="{'mobile-post-form': !$vuetify.breakpoint.lgAndUp}"
+              />
+            </v-col>
+          </v-card>
+
+          <v-card style="background: #f5f7ff" flat class="cards mt-4">
+            <v-col cols="12" class="pb-0 px-4 pt-4">
+              <span class="cardsTitle">Final message</span>
+              <br />
+              <span class="cardsSubtitle">This is a Final message you leave to the participant on finish test.</span>
+              <v-textarea
+                v-model="finalMessage"
+                rows="3"
+                outlined
+                color="orange"
+                class="mt-3"
+                placeholder="Thank you for participating..."
+                @change="saveFinalMessage()"
+              />
+            </v-col>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-col>
+  </div>
 </template>
 
 <script>
@@ -319,5 +427,54 @@ export default {
 .v-text-field--outlined >>> fieldset {
   border-radius: 25px;
   border: 1px solid #ffceb2;
+}
+
+@media (max-width: 1264px) {
+  .cards {
+    margin-bottom: 16px;
+  }
+  .cardsTitle {
+    font-size: 16px;
+  }
+  .cardsSubtitle {
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 600px) {
+  .cards {
+    margin-bottom: 12px;
+  }
+  .cardsTitle {
+    font-size: 15px;
+  }
+  .cardsSubtitle {
+    font-size: 13px;
+  }
+}
+.mobile-post-form :deep(.v-select__selections) {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-post-form :deep(.v-select) {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.mobile-post-form :deep(.v-menu__content) {
+  max-width: 90vw !important;
+}
+
+@media (max-width: 600px) {
+  .mobile-post-form :deep(.v-select__slot) {
+    font-size: 14px;
+  }
+  
+  .mobile-post-form :deep(.v-select__selection) {
+    max-width: calc(100% - 40px);
+  }
 }
 </style>


### PR DESCRIPTION
This PR addresses issue #642 , where the Moderator Edit test was not responsive on all devices. The existing form layout was conflicting between desktop and mobile/tablet views.

## Changes Made
- Created a new template specifically for mobile and tablet devices to ensure proper alignment.
- Separated the desktop form structure to prevent conflicts.
- Applied media queries and flexible CSS properties (`flexbox`, `grid`) for better responsiveness.
- Ensured consistency across various screen sizes.

## Steps to Test
1. Open the Moderator Edit test on different devices (mobile, tablet, desktop).
2. Verify that the layout adapts correctly without breaking.
3. Check if the form elements align properly on all screen sizes.

## Videos

**Before:**  

[Screencast from 07-03-25 11:21:19 PM IST.webm](https://github.com/user-attachments/assets/7eefa5b7-1085-4bed-8444-a9cb97efd805)

**After:**  

[Screencast from 07-03-25 11:26:26 PM IST.webm](https://github.com/user-attachments/assets/338aac74-4d38-4d90-92e0-5d806fbc0fa0) 
