### PR TITLE
chore: update readme to use correct comment syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Follow these steps to set up the development environment and run the application
 
 In the folder of your project, create a file with the name .env and put the following data:
 
-  ```javascript
+  ```bash
   VUE_APP_FIREBASE_API_KEY=""
   VUE_APP_FIREBASE_AUTH_DOMAIN=""
   VUE_APP_FIREBASE_DB_URL=""
@@ -81,7 +81,7 @@ In the folder of your project, create a file with the name .env and put the foll
   VUE_APP_FIREBASE_APP_ID=""
 
 
-  // Doesn't need changes
+  # Doesn't need changes
   VUE_APP_I18N_LOCALE="en"
   VUE_APP_I18N_FALLBACK_LOCALE="en"
   ```


### PR DESCRIPTION
While setting up the project locally, I noticed that the comment format for the .env file in the README is incorrect. This can lead to confusion for new contributors or anyone trying to set up the project, as the comments might not be interpreted correctly by the environment.

### Steps to Reproduce
1. Go to the README file.
2. Navigate to the section describing the .env file configuration.
3. Observe the comment format used in the example.

### Expected Behavior
The comments in the .env file example should follow the correct format (e.g., # for comments in .env files). Also the language should we either bash or ini for better syntax highlighting.

### Actual Behavior
The comments in the .env file example are using an incorrect format (e.g., // or another invalid format). And uses javascript for syntax highlighting.