### PR TITLE
Fixed Question content overflow in Heuristics table sub header

### DIFF
--- a/src/components/molecules/HeuristicsTable.vue
+++ b/src/components/molecules/HeuristicsTable.vue
@@ -430,10 +430,11 @@
             md="4"
           >
             <v-card height="560px" elevation="0" class="pa-0 ma-0">
-              <v-subheader class="px-2 pt-0 ma-0 " style="font-size: 12px; height: 40px">
-                {{ heuristics[itemSelect].questions[questionSelect].title }}
-                <v-spacer />
-                <v-menu v-model="menuQuestions" offset-x>
+              <v-subheader class="px-2 pt-0 ma-0" style="font-size: 12px; height: 40px; display: flex; align-items: center;">
+                <div class="custom-scrollbar" style="flex: 1; overflow-y: auto; max-height: 40px; padding-right: 8px;">
+                  {{ heuristics[itemSelect].questions[questionSelect].title }}
+                </div>
+                <v-menu v-model="menuQuestions" offset-x style="flex-shrink: 0;">
                   <template v-slot:activator="{ on, attrs }">
                     <v-btn
                       icon
@@ -1061,5 +1062,22 @@ export default {
   .questionsContent {
     margin-top: 0px;
   }
+}
+
+.custom-scrollbar {
+  overflow: auto;
+}
+.custom-scrollbar::-webkit-scrollbar {
+  width: 5px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: none;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #e0e0e0;
+  border-radius: 4px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #bdbdbd;
 }
 </style>


### PR DESCRIPTION
📝 What Does this PR Do?
This PR fixes a content overflow issue in the HeuristicsTable component where long question titles were not properly handled in the subheader area. The fix implements a scrollable container for question titles that exceed the designated space.

Fixes #687  

🔄 Changes Made
Updated the styling in `src/components/molecules/HeuristicsTable.vue`

📌 Reason for Change
Previously, when question titles contained multiple lines of text, they would overflow their container, causing layout issues and poor readability. This fix ensures that:
- Question titles remain contained within their designated space
- Users can scroll to read longer titles

✅ Testing
Attaching local Testing video here

https://github.com/user-attachments/assets/d0c4f4a7-c828-4821-9e1c-6d47812cccc1
