### PR TITLE
Upgrade actions/checkout from v2 to v4 in the General Reports workflow.

### DIFF
--- a/.github/workflows/ishikawa-tools.yml
+++ b/.github/workflows/ishikawa-tools.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Closes #690 
Upgraded actions/checkout from v2 to v4 in the General Reports workflow to enhance security, performance, and compatibility with the latest Github Actions features. This improves repository checkout efficiency.