### PR TITLE
fix: users were able to visit /testslist when on signup page

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,12 +19,10 @@ router.beforeEach(async (to, from, next) => {
   const { authorize } = to.meta
   await store.dispatch('autoSignIn')
   const user = store.state.Auth.user
-
   if (
     authorize.length > 0 &&
     to.path !== '/signin' &&
-    !to.params.token &&
-    from.path !== '/signup'
+    !to.params.token
   ) {
     if (!user) {
       return next(redirect())
@@ -44,7 +42,6 @@ router.beforeEach(async (to, from, next) => {
 function redirect() {
   if (!store.state.Auth.user) return '/'
   const level = store.state.Auth.user.accessLevel
-
   if (level == 0) return '/superadmin'
   if (level == 1) return '/testslist'
   return '/'


### PR DESCRIPTION
### What Does this PR Do?

This PR addresses a security issue where unauthorized users were able to access the `/testslist` route by clicking on the `R` logo on the signup page. This unintended behavior has been fixed to ensure proper route restrictions.

Fixes #693 
### Changes Made
- Removed the `from` check in the router, which was identified as the root cause of the bug.

### Reason for Change
Unauthorized users were granted access to the `/testslist` route, which posed a security risk. This fix ensures that routing behaves as intended, maintaining proper access control.

## Testing
Verified in the development environment that the routing now works as expected. Clicking the `R` logo correctly redirects users to the homepage instead of the `/testslist` route.