### PR TITLE
fix: help page content now changes with the locale

### DIFF
--- a/src/views/public/Help.vue
+++ b/src/views/public/Help.vue
@@ -335,7 +335,12 @@ export default {
         { id: 'cooperators', name: 'Cooperators', icon: 'mdi-account-group' },
         { id: 'analytics', name: 'Analytics', icon: 'mdi-chart-bar' },
       ],
-      items: [
+    }
+  },
+
+  computed: {
+    items() {
+      return [
         {
           title: i18n.t('help.createtest'),
           content: i18n.t('help.createtestanswer'),
@@ -406,11 +411,10 @@ export default {
           isCollapsed: true,
           category: 'cooperators',
         },
-      ],
-    }
+      ];
   },
 
-  computed: {
+
     filteredItems() {
       let items = this.items
 


### PR DESCRIPTION
### What Does This PR Do?

This PR addresses an issue where the locale is not updated on the page after being changed from the toolbar.

Fixes #696 

### Changes Made
- Converted `items` from a static property to a computed property.

### Reason for Change
A previous PR attempted to fix this issue but introduced extensive changes. This PR provides a more concise solution that directly addresses the problem.

### Testing
Manually tested in the development environment. The locale on the help page now updates as expected.


### Before 
https://github.com/user-attachments/assets/024cb536-b68c-4944-bd12-bbed56660206

### After
https://github.com/user-attachments/assets/1af9e5ec-7415-4bca-9ee7-61c8b5ef8936

