### PR TITLE
feat: add persistent locale throughout the site

### DIFF
--- a/src/components/atoms/LocaleChanger.vue
+++ b/src/components/atoms/LocaleChanger.vue
@@ -56,6 +56,7 @@ export default {
   },
   watch: {
     lang: function (newValue) {
+      localStorage.setItem('locale', newValue)
       this.$i18n.locale = newValue
     },
   },

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -15,9 +15,10 @@ function loadLocaleMessages () {
   })
   return messages
 }
+const savedLocale = localStorage.getItem('locale') || process.env.VUE_APP_I18N_LOCALE || 'en'
 
 export default new VueI18n({
-  locale: process.env.VUE_APP_I18N_LOCALE || 'en',
+  locale: savedLocale,
   fallbackLocale: process.env.VUE_APP_I18N_FALLBACK_LOCALE || 'en',
   messages: loadLocaleMessages(),
 })


### PR DESCRIPTION
### What Does This PR Do?

This PR resolves an issue where the locale setting is not persisted between page reloads.

Fixes #698

### Changes Made
- Added logic to store the `locale` in `localStorage` and retrieve it on page load.
- Implemented a mechanism to save the `locale` to `localStorage` whenever it is changed.

### Reason for Change
The locale setting was being reset on page reload, causing a poor user experience. This change ensures the selected locale is preserved across sessions.

### Testing
Manually tested in the development environment. The locale now persists correctly after page reloads.

## Before

https://github.com/user-attachments/assets/24dd7b2b-efa8-468e-bf1e-469351434875



## After

https://github.com/user-attachments/assets/e8b5381b-cb77-4c43-b302-bd6c050c7675




