### PR TITLE
Fix: Replace typo + Add error handler in AuthController.js 

### DIFF
--- a/src/controllers/AuthController.js
+++ b/src/controllers/AuthController.js
@@ -27,15 +27,19 @@ export default class AuthController {
 		return signOut(auth)
 	}
 
-	async autoSignIn() {
-		return new Promise((resolve, rejecj) => {
-			const unsubscribe = onAuthStateChanged(
-				auth,
-				(user) => {
-					unsubscribe()
-					resolve(user)
-				},
-			)
-		})
-	}
+    async autoSignIn() {
+        return new Promise((resolve, reject) => {
+            const unsubscribe = onAuthStateChanged(
+                auth,
+                (user) => {
+                    unsubscribe()
+                    resolve(user)
+                },
+                (error) => {
+                    unsubscribe()
+                    reject(error)
+                }
+            )
+        })
+    }
 }


### PR DESCRIPTION
Fix the `autoSignIn` method in the `AuthController` class. Corrects a typo in the `reject` parameter and adds error handling to ensure the promise is properly rejected if an error occurs during the authentication state change.

* [`src/controllers/AuthController.js`](diffhunk://#diff-2b7f056f0df4dbe688dbd457184c1516c3f511526c974193ad24749d12d37a1aL31-R41): Corrected the typo in the `reject` parameter and added error handling to the `autoSignIn` method.

Notes:

fix typo in the Promise parameter from rejecj to reject.

Added a proper error handler to the onAuthStateChanged method, this is what it does: Calls unsubscribe() (prevent memory leaks), and properly rejects the promise with the error