### PR TITLE
Prevent memory leaks in camera stream handling

### DIFF
--- a/src/store/modules/Test.js
+++ b/src/store/modules/Test.js
@@ -461,16 +461,32 @@ export default {
         return peerConnection
       } catch (error) {
         console.error('Error creating peer connection:', error)
-      }
-    },
-    async closePeerConnection({ commit, state }) {
-      if (state.peerConnection) {
-        state.peerConnection.close()
-        commit('SET_PEER_CONNECTION', null)
-      }
-    },
-    async changeTrack({ commit, state }, stream) {
-      const newTrack = stream.getVideoTracks()[0]
+    }
+},
+async closePeerConnection({ commit, state }) {
+    try {
+        if (state.localCameraStream) {
+            state.localCameraStream.getTracks().forEach(track => track.stop())
+            commit('SET_LOCAL_STREAM', null)
+        }
+
+        if (state.remoteCameraStream) {
+            state.remoteCameraStream.getTracks().forEach(track => track.stop())
+            commit('SET_REMOTE_STREAM', null)
+        }
+
+        if (state.peerConnection) {
+            state.peerConnection.close()
+            commit('SET_PEER_CONNECTION', null)
+        }
+
+        commit('SET_DISCONNECTED', true)
+    } catch (error) {
+        console.error('Error closing connection:', error)
+    }
+},
+async changeTrack({ commit, state }, stream) {
+    const newTrack = stream.getVideoTracks()[0]
 
       if (state.peerConnection) {
         const senders = state.peerConnection.getSenders()


### PR DESCRIPTION
Camera streams were not being properly cleaned up, leading to potential memory leaks, especially during prolonged usage or frequent test cycles.

**What this PR does:**

- **Enhanced `CLEAN_TEST` mutation:**
  - Ensures that all tracks within `localCameraStream` and `remoteCameraStream` are stopped using `track.stop()` before the streams are set to `null`.
  - Closes the `peerConnection` to release associated resources.
  - Sets all stream references to null after cleanup

- **Improved `closePeerConnection` action:**
  - Wraps the stream and connection closing logic in a try/catch for robust error handling.
  - Stops all tracks in both `localCameraStream` and `remoteCameraStream` before setting them to `null`.
  - Sets the `SET_DISCONNECTED` state to `true` after cleanup.

**Why these changes are important:**

- **Prevents memory leaks:** By explicitly stopping the tracks, we release the underlying hardware resources, preventing memory leaks that could degrade performance over time.
- **Ensures proper camera release:** Properly releasing camera resources is crucial for user privacy and to avoid conflicts with other applications that might need camera access.

**To verify:**

1.  Run several tests involving camera access.
2.  Monitor memory usage in your browser's developer tools to ensure that memory consumption remains stable and doesn't continuously increase.
3.  Verify that the camera is properly released after a test is completed or a peer connection is closed.