### PR TITLE
Resolved email link issue: Email Link in "Contact Us" Section Not Functional

### DIFF
--- a/src/views/public/Help.vue
+++ b/src/views/public/Help.vue
@@ -239,9 +239,17 @@
               ></span>
             </h3>
             <p class="white--text mb-3" style="opacity: 0.7;">
-              <v-icon small class="mr-2 white--text">mdi-email</v-icon>
-              ruxailab@gmail.com
-            </p>
+  <v-icon small class="mr-2 white--text">mdi-email</v-icon>
+  <a 
+    href="mailto:ruxailab@gmail.com"
+    class="white--text"
+    style="text-decoration: none; opacity: 0.7;"
+    @mouseover="$event.target.style.opacity = '1'"
+    @mouseleave="$event.target.style.opacity = '0.7'"
+  >
+    ruxailab@gmail.com
+  </a>
+</p>
             <p class="white--text mb-3" style="opacity: 0.7;">
               <v-icon small class="mr-2 white--text">mdi-phone</v-icon> +1 (555)
               123-4567


### PR DESCRIPTION
@marcgc21  #722 closes
# Fix: Resolved email link issue: Email Link in "Contact Us" Section Not Functional 


## Description
The email link in the "Contact Us" section of the Help Center page is not clickable or functional. The email address (`ruxailab@gmail.com`) should open the user's default email client when clicked, but it currently does nothing. This prevents users from easily contacting support.

This PR fixes the issue by adding the `mailto:` protocol to the `<a>` tag's `href` attribute, making the email link functional.

## Link to the Issue
[Issue: Email Link in "Contact Us" Section Not Functional](#) *(Replace with the actual issue link)*

## Changes Made
1. Added the `mailto:` protocol to the email link in the `src/views/public/Help.vue` file.
2. Updated the `href` attribute to:
   ```html
   <a href="mailto:ruxailab@gmail.com">ruxailab@gmail.com</a>

### Screenshots 📸

##Before:

https://github.com/user-attachments/assets/ae6e8d90-bd43-404c-99ab-1699dd69aa7d


##After:

https://github.com/user-attachments/assets/6c36b73c-8c6a-47e0-bd14-4ed94a1852ce

### Additional Information ℹ️

The issue appears to be caused by the missing mailto: protocol in the <a> tag's href attribute. The current code does not include the mailto: prefix, which is necessary for the link to open the email client.


changes:


before:

 **```
`<p class="white--text mb-3" style="opacity: 0.7;">
              <v-icon small class="mr-2 white--text">mdi-email</v-icon>
              ruxailab@gmail.com
           </p>`
```**


##after:

![Image](https://github.com/user-attachments/assets/0245cf75-75d3-411a-982a-6c7cfae94f1e)