### PR TITLE
[Fix] Use dynamic copyright year

### DIFF
--- a/src/views/public/Help.vue
+++ b/src/views/public/Help.vue
@@ -305,7 +305,7 @@
           <v-col cols="12" class="text-center mt-8">
             <v-divider dark class="mb-4"></v-divider>
             <p class="text-caption white--text" style="opacity: 0.5;">
-              © 2025 Ruxailab. All rights reserved.
+              © {{ currentYear }} Ruxailab. All rights reserved.
             </p>
           </v-col>
         </v-row>
@@ -320,6 +320,7 @@ import i18n from '@/i18n'
 export default {
   data() {
     return {
+      currentYear: new Date().getFullYear(),
       searchQuery: '',
       activeCategory: null,
       selectedCategory: null,


### PR DESCRIPTION
###  [Fix] Use Dynamic Copyright Year

####  Description  
This update replaces the hardcoded copyright year (`© 2025 Ruxailab`) with a dynamic JavaScript property to ensure it updates automatically each year.  

#### Changes  
- Replaced hardcoded `2025` with `new Date().getFullYear()` in `src/views/public/Help.vue`.  
- Ensures the footer remains up-to-date without manual changes.  

#### Related Issue  
Fixes #729 

#### Testing  
- Verified that the year updates dynamically on page load.  
- No impact on other components.  

Merging this will keep the copyright year updated automatically. 
