### PR TITLE
Fix default prop handling in task object

### DIFF
--- a/src/components/atoms/TipButton.vue
+++ b/src/components/atoms/TipButton.vue
@@ -40,18 +40,17 @@
 
 <script>
 export default {
-  props: {
-    task: {
-      type: Object,
-      required: true,
-      default: function() {
-        return {
-          taskName: '',
-          taskTip: '',
-        }
-      },
-    },
+// Fix default prop handling in task object
+props: {
+  task: {
+    type: Object,
+    default: () => ({
+      taskName: '',
+      taskTip: '',
+    }),
   },
+}
+
   data: () => ({
     dialog: false,
   }),


### PR DESCRIPTION
1. Removed required: true from the task prop since a default object  is already provided.
2. Replaced the traditional function with an arrow function for better  readability.
3. This fix ensures Vue does not throw a warning when the task prop  is missing. No breaking changes; behavior remains the same.