### PR TITLE
Fix: Add validation to prevent empty CSV file upload

### DIFF
--- a/src/components/molecules/HeuristicsSenttings.vue
+++ b/src/components/molecules/HeuristicsSenttings.vue
@@ -132,7 +132,14 @@ export default {
           const reader = new FileReader()
           reader.readAsText(this.csvFile, 'UTF-8') // Use readAsText with UTF-8 encoding
           reader.onload = async () => {
-            const csv = reader.result
+            const csv = reader.result.trim()
+
+            if (!csv) {
+              this.errorMessage = this.$t('HeuristicsSettings.messages.emptyCsvFile');
+              this.loadingUpdate = false;
+              return;
+            }
+            
             const lines = csv.split('\r\n') // Split lines using '\r\n' for cross-platform compatibility
             const headers = lines[0].split(';').map((header) => header.trim()) // Trim headers
             const heuristicMap = new Map()

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -224,7 +224,8 @@
     },
     "messages": {
       "acceptCsv": "If you accept, all your present heuristics will be replaced by the ones in the .csv file",
-      "noCsvFileSelected": "No csv file selected. \nPlease select one before proceeding."
+      "noCsvFileSelected": "No csv file selected. \nPlease select one before proceeding.",
+      "emptyCsvFile": "The CSV file is empty. Please provide a file with data."
     },
     "placeHolders": {
       "importCsv": "Import your CSV testfile here."

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -224,7 +224,8 @@
     },
     "messages": {
       "acceptCsv": "Aceptar archivo CSV",
-      "noCsvFileSelected": "No se ha seleccionado ningún archivo CSV"
+      "noCsvFileSelected": "No se ha seleccionado ningún archivo CSV",
+      "emptyCsvFile": "El archivo CSV está vacío. Por favor, proporciona un archivo con datos."
     },
     "placeHolders": {
       "importCsv": "Importar CSV"

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -331,7 +331,8 @@
       },
       "messages": {
         "acceptCsv": "CSV फ़ाइल स्वीकार करें",
-        "noCsvFileSelected": "कोई CSV फ़ाइल नहीं चुनी गई"
+        "noCsvFileSelected": "कोई CSV फ़ाइल नहीं चुनी गई",
+        "emptyCsvFile": "CSV फ़ाइल खाली है। कृपया डेटा के साथ एक फ़ाइल प्रदान करें।"
       },
       "placeHolders": {
         "importCsv": "CSV आयात करें"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -224,7 +224,8 @@
     },
     "messages": {
       "acceptCsv": "Aceitar arquivo CSV",
-      "noCsvFileSelected": "Nenhum arquivo CSV selecionado"
+      "noCsvFileSelected": "Nenhum arquivo CSV selecionado",
+      "emptyCsvFile": "O arquivo CSV está vazio. Por favor, forneça um arquivo com dados."
     },
     "placeHolders": {
       "importCsv": "Importar CSV"


### PR DESCRIPTION
### **Description**  
Added validation to prevent uploading empty CSV files. Before processing, the code trims the CSV content and checks if it is empty. If empty, an error message is displayed, and execution stops.

### **Changes**  
- Trimmed the CSV content (`.trim()`) before processing..  
- If the file is empty, an error message (`this.errorMessage = this.$t('HeuristicsSettings.messages.emptyCsvFile')`) is displayed. 
- Stopped execution to prevent further processing. 
- Added error message: `"emptyCsvFile": "The CSV file is empty. Please provide a file with data."` 

### **Related Issue**  
Fixes #733 

### **Screenshots** 
#### After Fix:
  
![fix](https://github.com/user-attachments/assets/4de66d65-3db2-4d45-8b46-991510011757)


### **Testing**  
- Attempted to upload an empty CSV file → Proper error message displayed.  
- Uploaded a valid CSV file → Processed successfully without issues.  