### PR TITLE
 Fix: Update deprecated Vuetify slot syntax in tooltip activator

### DIFF
--- a/src/components/atoms/QuestionHelpBtn.vue
+++ b/src/components/atoms/QuestionHelpBtn.vue
@@ -1,13 +1,14 @@
 <template>
   <div>
     <v-tooltip v-if="question.descriptions.length > 0" bottom>
-      <template v-slot:activator="{ on, attrs }">
-        <v-btn icon>
-          <v-icon v-bind="attrs" v-on="on" @click="dialog = true">
-            mdi-help-circle-outline
-          </v-icon>
-        </v-btn>
-      </template>
+     <template v-slot:activator="{ props }">
+  <v-btn icon v-bind="props" @click="dialog = true">
+    <v-icon>
+      mdi-help-circle-outline
+    </v-icon>
+  </v-btn>
+</template>
+
       <span>{{ $t('buttons.help') }}</span>
     </v-tooltip>
 


### PR DESCRIPTION
1. Replaced the deprecated v-slot:activator="{ on, attrs }" syntax  with v-slot:activator="{ props }" in the tooltip.
2. Bound props directly to <v-btn> instead of using v-bind="attrs"  and v-on="on".
3. Ensures compatibility with Vuetify v3 and prevents potential  breaking issues.