### PR TITLE
Updated GitHub Actions workflow to allow manual execution via `workflow_dispatch`

### DIFF
--- a/.github/workflows/sonarcloud_issue_creator.yml
+++ b/.github/workflows/sonarcloud_issue_creator.yml
@@ -1,17 +1,11 @@
 name: SonarCloud Issue Creator
 
 on:
-  workflow_run:
-    workflows: ["Build"]
-    types:
-      - completed
-    branches:
-      - develop
+  workflow_dispatch:
 
 jobs:
   create-issues:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     
     steps:
       - name: Checkout code
@@ -31,4 +25,4 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-        run: python sonarcloud_to_github.py 
+        run: python sonarcloud_to_github.py


### PR DESCRIPTION
###  Summary  
Updated GitHub Actions workflow to allow manual execution via `workflow_dispatch`.

###  Changes  
- Replaced `workflow_run` trigger with `workflow_dispatch` for manual execution.  
- Ensured dependencies are installed before running the script.  

###  Related  
- Feature: [#566]
- Previous PRs: [#725 , #748]

###  How to Run  
1. Go to **GitHub → Actions**.  
2. Select **SonarCloud Issue Creator** workflow.  
3. Click **Run workflow**, choose the branch, and start the run.  

<img width="1800" alt="Screenshot 2025-03-27 at 3 07 58 PM" src="https://github.com/user-attachments/assets/398cba21-eba9-4aff-a83a-a899cc50a23f" />
<img width="1800" alt="Screenshot 2025-03-27 at 3 09 43 PM" src="https://github.com/user-attachments/assets/c249d378-77b6-46e7-b7a6-6cfee86e097c" />



