### PR TITLE
Fix missing comma in `TipButton.vue`

### DIFF
--- a/src/components/atoms/TipButton.vue
+++ b/src/components/atoms/TipButton.vue
@@ -40,16 +40,16 @@
 
 <script>
 export default {
-// Fix default prop handling in task object
-props: {
-  task: {
-    type: Object,
-    default: () => ({
-      taskName: '',
-      taskTip: '',
-    }),
+  // Fix default prop handling in task object
+  props: {
+    task: {
+      type: Object,
+      default: () => ({
+        taskName: '',
+        taskTip: '',
+      }),
+    },
   },
-}
 
   data: () => ({
     dialog: false,


### PR DESCRIPTION
Currently, the `TipButton.vue` file contains a syntax error that's blocking local development and Playwright tests in CI.

This PR fixes the above issue