### PR TITLE
[FIX] Remove browser flag and add ui command for Playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "cypress:open": "cypress open",
     "deploy-dev": "firebase use dev && firebase deploy --only hosting:ruxailab-dev",
     "deploy-prod": "firebase use prod && firebase deploy --only hosting:ruxailab-prod",
-    "test-playwright": "playwright test --browser=all",
-    "test-html-report": "playwright test --browser=all --reporter=html",
+    "test-playwright": "playwright test",
+    "test-playwright-ui": "playwright test --ui",
+    "test-html-report": "playwright test --reporter=html",
     "test-json-report": "PLAYWRIGHT_JSON_OUTPUT_NAME=results.json playwright test --browser=chromium --reporter=json"
   },
   "dependencies": {


### PR DESCRIPTION
Fix error when running Playwright npm command: 
```
Error: Cannot use --browser option when configuration file defines projects. Specify browserName in the projects instead.
```
Since `browser` options are configured in `playwright.config.js`, calling Playwright with browser flag gives an error. Remove the flag fixes this. 

Add `test-playwright-ui` command to help debugging.

![image](https://github.com/user-attachments/assets/13d4653e-1b6f-4801-b316-cb8c7d0c69ec)