### PR TITLE
Fix: Resolve mismatched v-btn tag in Help.vue #762

### DIFF
--- a/src/views/public/Help.vue
+++ b/src/views/public/Help.vue
@@ -258,7 +258,6 @@
                 @click="filterByCategory(null)"
               >
                 View All Articles
-
               </v-btn>
             </v-card-text>
           </v-card>


### PR DESCRIPTION
     ## Description
     This PR fixes issue #762 where the Help.vue template fails to compile due to a mismatched tag.

     ## Changes Made
     - Removed an empty line between the content and closing tag of a v-btn element that was causing the Vue template parser to fail

     ## Related Issue
     Closes #762