### PR TITLE
Add Forgot Password Functionality

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -28,6 +28,7 @@ import '@testing-library/cypress/add-commands'
 import { deleteUser,
   logInWithEmailAndPassword,
   logOut,
+  resetPassword,
   signUpWithEmailAndPassword }
   from './commands/auth'
 
@@ -36,3 +37,4 @@ Cypress.Commands.add('deleteUser', deleteUser)
 Cypress.Commands.add('login', logInWithEmailAndPassword)
 Cypress.Commands.add('logout', logOut)
 Cypress.Commands.add('signup', signUpWithEmailAndPassword)
+Cypress.Commands.add('resetPassword', resetPassword)

--- a/cypress/support/commands/auth.js
+++ b/cypress/support/commands/auth.js
@@ -6,6 +6,7 @@ import {
   signInWithEmailAndPassword,
   signOut,
   createUserWithEmailAndPassword,
+  sendPasswordResetEmail,
 } from 'firebase/auth'
 import {
   getFirestore,
@@ -91,6 +92,20 @@ export const signUpWithEmailAndPassword = async (email, password) => {
     console.info(`Signed up as "${email}" with user ID "${user.uid}"`)
     const { data, collection } = authUser
     await createDoc(collection, user.uid, data)
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+/**
+ * Send a password reset email
+ * @param email
+ * @returns {Promise<void>}
+ */
+export const resetPassword = async (email) => {
+  try {
+    await sendPasswordResetEmail(auth, email)
+    console.info(`Password reset email sent to "${email}"`)
   } catch (err) {
     console.error(err)
   }

--- a/src/components/molecules/Toolbar.vue
+++ b/src/components/molecules/Toolbar.vue
@@ -104,7 +104,8 @@
       v-if="
         this.$route.path == '/testslist' ||
           this.$route.path == '/signin' ||
-          this.$route.path == '/signup'
+          this.$route.path == '/signup' ||
+          this.$route.path == '/forgot-password'
       "
       text
       color="#f9a826"
@@ -119,7 +120,8 @@
         this.$route.path !== '/' &&
           this.$route.path !== '/testslist' &&
           this.$route.path !== '/signin' &&
-          this.$route.path !== '/signup'
+          this.$route.path !== '/signup' &&
+          this.$route.path !== '/forgot-password'
       "
       text
       color="#f9a826"

--- a/src/controllers/AuthController.js
+++ b/src/controllers/AuthController.js
@@ -4,6 +4,7 @@ import {
 	signInWithEmailAndPassword,
 	signOut,
 	onAuthStateChanged,
+	sendPasswordResetEmail
 } from 'firebase/auth'
 
 export default class AuthController {
@@ -25,6 +26,11 @@ export default class AuthController {
 	// Sign Out
 	async signOut() {
 		return signOut(auth)
+	}
+
+	// Reset Password
+	async resetPassword(email) {
+		return sendPasswordResetEmail(auth, email)
 	}
 
 	async autoSignIn() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5,10 +5,18 @@
     "email": "E-mail",
     "password": "Password",
     "dont-have-account": "Don't have an account yet? Sign up",
+    "forgot-password": "Forgot Password",
     "sign-up": "Sign-Up",
     "contact": "Contact No",
     "confirmPassword": "Confirm your password",
     "alreadyHaveAnAccount": "Already have an account? Sign in"
+  },
+  "FORGOT_PASSWORD": {
+    "reset_password": "Reset Password",
+    "email": "Email",
+    "instructions": "Enter your email and we'll send you a link to reset your password.",
+    "reset_button": "Send Reset Link",
+    "back_to_signin": "Back to Sign In"
   },
   "common": {
     "loading": "Loading Test",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -5,10 +5,18 @@
     "email": "Correo electrónico",
     "password": "Contraseña",
     "dont-have-account": "¿No tienes una cuenta? Regístrate",
+    "forgot-password": "Olvidé mi contraseña",
     "sign-up": "Inscribirse",
     "contact": "Número de contacto",
     "confirmPassword": "Confirmar Contraseña",
     "alreadyHaveAnAccount": "¿Ya tienes una cuenta? Iniciar sesión"
+  },
+  "FORGOT_PASSWORD": {
+    "reset_password": "Restablecer contraseña",
+    "email": "Correo electrónico",
+    "instructions": "Ingrese su correo electrónico y le enviaremos un enlace para restablecer su contraseña.",
+    "reset_button": "Enviar enlace de restablecimiento",
+    "back_to_signin": "Volver a iniciar sesión"
   },
   "common": {
     "loading": "Cargando prueba",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -5,10 +5,18 @@
     "email": "ई-मेल",
     "password": "पासवर्ड",
     "dont-have-account": "अभी तक खाता नहीं है? साइन अप करें",
+    "forgot-password": "पासवर्ड भूल गए",
     "sign-up": "साइन-अप",
     "contact": "संपर्क नंबर",
     "confirmPassword": "अपना पासवर्ड कन्फर्म करें",
     "alreadyHaveAnAccount": "पहले से ही एक खाता है? साइन इन करें"
+  },
+  "FORGOT_PASSWORD": {
+    "reset_password": "पासवर्ड रीसेट करें",
+    "email": "ईमेल",
+    "instructions": "अपना ईमेल दर्ज करें और हम आपको पासवर्ड रीसेट करने के लिए एक लिंक भेजेंगे।",
+    "reset_button": "रीसेट लिंक भेजें",
+    "back_to_signin": "साइन इन पर वापस जाएं"
   },
   "common": {
     "loading": "लोड हो रहा है",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -5,10 +5,18 @@
     "email": "E-mail",
     "password": "Senha",
     "dont-have-account": "Ainda não tem uma conta? Inscreva-se",
+    "forgot-password": "Esqueci minha senha",
     "sign-up": "Inscrever-se",
     "contact": "Número de contato",
     "confirmPassword": "Confirme sua senha",
     "alreadyHaveAnAccount": "Já tem uma conta? Entrar"
+  },
+  "FORGOT_PASSWORD": {
+    "reset_password": "Redefinir senha",
+    "email": "E-mail",
+    "instructions": "Digite seu e-mail e enviaremos um link para redefinir sua senha.",
+    "reset_button": "Enviar link de redefinição",
+    "back_to_signin": "Voltar para Entrar"
   },
   "common": {
     "loading": "Carregando Teste",

--- a/src/router/modules/public.js
+++ b/src/router/modules/public.js
@@ -1,6 +1,7 @@
 import TestView from '@/views/public/TestView.vue'
 import SignIn from '@/views/public/SignInView.vue'
 import SignUp from '@/views/public/SignUpView.vue'
+import ForgotPassword from '@/views/public/ForgotPasswordView.vue'
 import LandingPage from '@/views/public/LandingPageView.vue'
 import PageNotFound from '@/views/public/PageNotFoundView.vue'
 import Help from '@/views/public/Help.vue'
@@ -24,6 +25,12 @@ export default [
     name: 'Sign Up',
     meta: { authorize: [] },
     component: SignUp,
+  },
+  {
+    path: '/forgot-password',
+    name: 'Forgot Password',
+    meta: { authorize: [] },
+    component: ForgotPassword,
   },
   {
     path: '/help',

--- a/src/store/modules/Auth.js
+++ b/src/store/modules/Auth.js
@@ -103,5 +103,21 @@ export default {
         console.error(err)
       }
     },
+
+    async resetPassword({ commit }, payload) {
+      commit('setLoading', true)
+      try {
+        await authController.resetPassword(payload.email)
+        //console.log("If this email is registered, you'll receive a reset link")
+      } catch (err) {
+        if (err.code === 'auth/invalid-email') {
+          console.error('Error: Invalid email format')
+        } else {
+          console.error('Error sending password reset email:', err.message)
+        }
+      } finally {
+        commit('setLoading', false)
+      }
+    },
   },
 }

--- a/src/views/public/ForgotPasswordView.vue
+++ b/src/views/public/ForgotPasswordView.vue
@@ -1,0 +1,126 @@
+<template>
+  <div class="background-grey">
+    <Snackbar />
+    <v-row justify="center" style="height: 90%" align="center">
+      <v-col cols="12" md="8">
+        <v-card color="#f5f7ff" rounded="xl" flat>
+          <v-row>
+            <v-col cols="10" md="5" align-self="center" class="ma-8">
+              <div class="card-title">
+                {{ $t('FORGOT_PASSWORD.reset_password') }}
+              </div>
+
+              <div class="divider" />
+
+              <v-form ref="form" v-model="valid" lazy-validation class="mx-3">
+                <v-text-field
+                  v-model="email"
+                  :label="$t('FORGOT_PASSWORD.email')"
+                  :rules="emailRules"
+                  outlined
+                  prepend-inner-icon="mdi-email"
+                  dense
+                  required
+                />
+
+                <p class="text-caption ml-2 mb-4">
+                  {{ $t('FORGOT_PASSWORD.instructions') }}
+                </p>
+              </v-form>
+
+              <v-card-actions class="justify-center mt-4">
+                <v-btn
+                  color="#F9A826"
+                  rounded
+                  class="white--text"
+                  :loading="loading"
+                  @click="onResetRequest()"
+                >
+                  {{ $t('FORGOT_PASSWORD.reset_button') }}
+                </v-btn>
+              </v-card-actions>
+              
+              <v-card-actions class="justify-center mt-1">
+                <p>
+                  <a
+                    style="color: #F9A826; text-decoration: underline;"
+                    @click="redirectToSignin"
+                  >
+                    {{ $t('FORGOT_PASSWORD.back_to_signin') }}
+                  </a>
+                </p>
+              </v-card-actions>
+            </v-col>
+            <!--Image section-->
+          </v-row>
+        </v-card>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script>
+import Snackbar from '@/components/atoms/Snackbar'
+import i18n from '@/i18n'
+
+export default {
+  components: {
+    Snackbar,
+  },
+  data: () => ({
+    valid: false,
+    email: '',
+    emailRules: [
+      (v) => !!v || i18n.t('errors.emailIsRequired'),
+      (v) => /.+@.+\..+/.test(v) || i18n.t('errors.invalidEmail'),
+    ],
+  }),
+  computed: {
+    loading() {
+      return this.$store.getters.loading
+    },
+  },
+  methods: {
+    async onResetRequest() {
+      if (!this.$refs.form.validate()) {
+        return
+      }
+
+      try {
+        await this.$store.dispatch('resetPassword', { email: this.email })
+      } catch (error) {
+        console.error('Password reset error:', error)
+      }
+    },
+    redirectToSignin() {
+      this.$router.push('/signin')
+    },
+  },
+}
+</script>
+
+<style scoped>
+.background-grey {
+  background-color: #e8eaf2;
+  height: 100vh;
+  align-content: center;
+}
+.card-title {
+  font-style: normal;
+  font-weight: 300;
+  font-size: 48px;
+  line-height: 56px;
+  margin-left: 12px;
+  margin-bottom: 20px;
+}
+.divider {
+  margin-bottom: 40px;
+  margin-left: 8px;
+  background: linear-gradient(
+    90deg,
+    #c4c4c4,
+    rgba(196, 196, 196, 0)
+  ) !important;
+  height: 0.5px;
+}
+</style>

--- a/src/views/public/SignInView.vue
+++ b/src/views/public/SignInView.vue
@@ -45,12 +45,20 @@
                 </v-btn>
               </v-card-actions>
               <v-card-actions class="justify-center mt-1">
-                <p>
+                <p style="margin-right: 10px;">
                   <a
                     style="color: #F9A826 ;text-decoration: underline;"
                     @click="redirectToSignup"
                   >
                     {{ $t('SIGNIN.dont-have-account') }}
+                  </a>
+                </p>
+                <p>
+                  <a
+                    style="color: #F9A826; text-decoration: underline;"
+                    @click="redirectToForgotPassword"
+                  >
+                    {{ $t('SIGNIN.forgot-password') }}
                   </a>
                 </p>
               </v-card-actions>
@@ -103,6 +111,9 @@ export default {
     redirectToSignup() {
       this.$router.push('/signup')
     },
+    redirectToForgotPassword() {
+      this.$router.push('/forgot-password')
+    }
   },
 }
 </script>


### PR DESCRIPTION
## Description  
Implements the **Forgot Password** feature, allowing users to reset their password if they forget it during sign-in. It integrates Firebase Authentication to handle password reset requests securely.  

## Changes  
- Added **ForgotPasswordView.vue** for the password reset UI.  
- Updated **AuthController.js** to handle password reset logic.  
- Modified **SignInView.vue** to include a "Forgot Password?" link.  
- Updated **Cypress tests** to cover forgot password scenarios.  
- Added translations for forgot password in **locales (en, es, hi, pt_br)**.  
- Updated **Vuex store (Auth.js)** to manage reset password flow.  

## Related Issue  
Fixes #754

### **After Fix:**  
[forgotPassword.webm](https://github.com/user-attachments/assets/d872ebcc-b8e1-4fb3-abf6-eb2a6cb1be6d)

## Testing  
- Manually tested the password reset flow using Firebase.  
- Verified UI changes in different locales.  

## User Actions  
1. Clicks "Forgot Password"  
2. Submits registered email  
3. Opens email & clicks reset link  
4. Enters new password  
5. Attempts login  
