### PR TITLE
Feature1 : Automated Discord Role Assignment for GitHub Actions

### DIFF
--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - feature/discord-role-assignment
-
+#test
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -2,7 +2,7 @@ name: Trigger Assign Discord Role Workflow
 
 on:
   pull_request:
-    types: [closed]
+    types: [opened]
   issues:
     types: [opened]
   push:

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - feature/discord-role-assignment
-#test
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - feature/discord-role-assignment
-#test
+#test1 pr
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - feature/discord-role-assignment
+#uygu
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - feature/discord-role-assignment
-#test1 pr
+#test1 
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - feature/discord-role-assignment
-#test1
+#test
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -18,8 +18,7 @@ jobs:
       GITHUB_EVENT_ACTION: ${{ github.event.action }}
     secrets:
       DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-      GOOGLE_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CREDENTIALS_JSON }}
-      GOOGLE_SHEET_ID: ${{ secrets.GOOGLE_SHEET_ID }}
+      FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
       GUILD_ID: ${{ secrets.GUILD_ID }}
       ROLE_ID_PR: ${{ secrets.ROLE_ID_PR }}
       ROLE_ID_ISSUE: ${{ secrets.ROLE_ID_ISSUE }}

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - feature/discord-role-assignment
-#test1 
+#test
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - feature/discord-role-assignment
-#uygu
+#test
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -20,6 +20,14 @@ jobs:
       DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
       FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
       GUILD_ID: ${{ secrets.GUILD_ID }}
-      ROLE_ID_PR: ${{ secrets.ROLE_ID_PR }}
-      ROLE_ID_ISSUE: ${{ secrets.ROLE_ID_ISSUE }}
-      ROLE_ID_COMMIT: ${{ secrets.ROLE_ID_COMMIT }}
+      GH_STATS_TOKEN: ${{ secrets.GH_STATS_TOKEN }}
+
+      ROLE_ID_PR_1: ${{ secrets.ROLE_ID_PR_1 }}
+      ROLE_ID_PR_5: ${{ secrets.ROLE_ID_PR_5 }}
+      ROLE_ID_PR_10: ${{ secrets.ROLE_ID_PR_10 }}
+
+      ROLE_ID_ISSUE_1: ${{ secrets.ROLE_ID_ISSUE_1 }}
+      ROLE_ID_ISSUE_5: ${{ secrets.ROLE_ID_ISSUE_5 }}
+
+      ROLE_ID_COMMIT_1: ${{ secrets.ROLE_ID_COMMIT_1 }}
+      ROLE_ID_COMMIT_15: ${{ secrets.ROLE_ID_COMMIT_15 }}

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - feature/discord-role-assignment
-#test1
+#test pr final
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - feature/discord-role-assignment
-#test
+#test1
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -7,19 +7,20 @@ on:
     types: [opened]
   push:
     branches:
-      - main
+      - feature/discord-role-assignment
 
 jobs:
   assign-role:
     uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main
     with:
+      ACTOR: ${{ github.actor }}
+      GITHUB_EVENT_NAME: ${{ github.event_name }}
+      GITHUB_EVENT_ACTION: ${{ github.event.action }}
+    secrets:
       DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
       GOOGLE_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CREDENTIALS_JSON }}
       GOOGLE_SHEET_ID: ${{ secrets.GOOGLE_SHEET_ID }}
-      ACTOR: ${{ github.actor }}
       GUILD_ID: ${{ secrets.GUILD_ID }}
       ROLE_ID_PR: ${{ secrets.ROLE_ID_PR }}
       ROLE_ID_ISSUE: ${{ secrets.ROLE_ID_ISSUE }}
       ROLE_ID_COMMIT: ${{ secrets.ROLE_ID_COMMIT }}
-      GITHUB_EVENT_NAME: ${{ github.event_name }}
-      GITHUB_EVENT_ACTION: ${{ github.event.action }}

--- a/.github/workflows/discord-role.yml
+++ b/.github/workflows/discord-role.yml
@@ -1,0 +1,25 @@
+name: Trigger Assign Discord Role Workflow
+
+on:
+  pull_request:
+    types: [closed]
+  issues:
+    types: [opened]
+  push:
+    branches:
+      - main
+
+jobs:
+  assign-role:
+    uses: yashitz07/GitHub-Actions-workflow/.github/workflows/discord-role.yml@main
+    with:
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+      GOOGLE_CREDENTIALS_JSON: ${{ secrets.GOOGLE_CREDENTIALS_JSON }}
+      GOOGLE_SHEET_ID: ${{ secrets.GOOGLE_SHEET_ID }}
+      ACTOR: ${{ github.actor }}
+      GUILD_ID: ${{ secrets.GUILD_ID }}
+      ROLE_ID_PR: ${{ secrets.ROLE_ID_PR }}
+      ROLE_ID_ISSUE: ${{ secrets.ROLE_ID_ISSUE }}
+      ROLE_ID_COMMIT: ${{ secrets.ROLE_ID_COMMIT }}
+      GITHUB_EVENT_NAME: ${{ github.event_name }}
+      GITHUB_EVENT_ACTION: ${{ github.event.action }}

--- a/.github/workflows/weekly-digest.yaml
+++ b/.github/workflows/weekly-digest.yaml
@@ -1,0 +1,16 @@
+name: Trigger Weekly Digest Workflow
+
+on:
+  schedule:
+    - cron: '0 9 * * 0'  # Every Sunday at 9:00 AM UTC
+  workflow_dispatch:      # Optional: for manual testing via "Run workflow" button
+
+jobs:
+  weekly-digest:
+    uses: yashitz07/GitHub-Actions-workflow/.github/workflows/weekly-digest.yml@main
+    secrets:
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+      FIREBASE_CREDENTIALS_JSON: ${{ secrets.FIREBASE_CREDENTIALS_JSON }}
+      GUILD_ID: ${{ secrets.GUILD_ID }}
+      GH_STATS_TOKEN: ${{ secrets.GH_STATS_TOKEN }}
+      WEEKLY_DIGEST_CHANNEL_ID: ${{ secrets.WEEKLY_DIGEST_CHANNEL_ID }}


### PR DESCRIPTION
This feature enables automatic role assignment in Discord based on GitHub events like pull requests, issues, and commits. When a specific event occurs, the bot identifies the associated Discord role and assigns it to the respective user.

**Implementation Details**

- The bot listens for GitHub events (pull_request, issues, push).
- Based on the event type and action, it selects the appropriate Discord role:
- For discord-github mapping used google sheet(temporary)
- Pull Request Merged → Assigns the "PR Merged" role.
- Issue Opened → Assigns the "Issue Opened" role.
- Commit Pushed → Assigns the "Commit Pushed" role.
- The bot then sends an API request to Discord, granting the user the respective role.
- Logs have been improved to role names.

The whole implementation of this project is in repo: [https://github.com/yashitz07/GitHub-Actions-workflow](https://github.com/yashitz07/GitHub-Actions-workflow)

**Project Setup**
To run this feature locally, follow these steps:
1) Clone the Repository & Install Dependencies
2) Configure Environment Variables:
GOOGLE_CREDENTIALS_JSON
GOOGLE_SHEET_ID
DISCORD_BOT_TOKEN
GUILD_ID
ROLE_ID_PR
ROLE_ID_ISSUE
ROLE_ID_COMMIT

**To Get These Values?**
DISCORD_BOT_TOKEN → Obtain from Discord Developer Portal.
GUILD_ID → Right-click on your Discord server, go to Settings > Widget, and find the ID.
Role IDs → Enable Developer Mode in Discord, right-click a role, and copy the ID.

Implementation output:
 ![Screenshot 2025-04-01 221413](https://github.com/user-attachments/assets/30e53f68-8c75-4177-80da-68396f57016a)

Tested on my own server:
![Screenshot 2025-04-01 221430](https://github.com/user-attachments/assets/c2889a98-db80-4ccc-8c81-a63b4200fe19)
