### PR TITLE
fix: ensure userTestType is stored with normalized casing

### DIFF
--- a/src/components/dialogs/CreateTestUserDialog.vue
+++ b/src/components/dialogs/CreateTestUserDialog.vue
@@ -60,10 +60,11 @@ export default {
 
   methods: {
     setType(type) {
+      const normalizedType = type.toLowerCase()
       const test = {}
-      if (type === 'UNMODERATED') test.userTestType = type.toLowerCase()
-      if (type === 'MODERATED') {
-        test.userTestType = 'moderated'
+      if (normalizedType === 'unmoderated') test.userTestType = normalizedType
+      if (normalizedType === 'moderated') {
+        test.userTestType = normalizedType
         test.userTestStatus = {
           user: false,
           moderator: false,
@@ -74,8 +75,8 @@ export default {
       }
 
       this.$emit('setUser', test)
-    }
-  }
+    },
+  },
 }
 </script>
 


### PR DESCRIPTION
### **Summary**
This PR fixes a bug where **userTestType** (e.g., **'moderated' or 'unmoderated'**) was not being reliably stored in **Firestore** due to inconsistent casing in the **setType** method inside **CreateTestUserDialog.vue**.

**Fixes #792** 

### **Changes**
Normalize type to lowercase before setting it in **test.userTestType**.

### **Before**
User Test creation would occasionally miss **userTestType**, breaking the edit page.

##### **Bug Video 📹**
Here is a screen recording showing the issue when creating a User Test:
https://github.com/user-attachments/assets/0e36836d-fd9a-4278-9f43-c9ca029590ca

### **After**
**userTestType** is always stored as **lowercase** (**'moderated' or 'unmoderated'**) correctly.

https://github.com/user-attachments/assets/fe9bcf18-3943-44ef-9696-6fd76420ea4d

**User Test edit** pages now load as expected.