### PR TITLE
🔧 Improvement: Move items from computed to data

### DIFF
--- a/src/components/molecules/IntroEdit.vue
+++ b/src/components/molecules/IntroEdit.vue
@@ -21,7 +21,7 @@ export default {
   components: {
     IntroComp,
   },
-  data() {
+ data() {
     return {
       items: [
         {
@@ -52,7 +52,7 @@ export default {
       this.$emit('closeIntro')
     },
     callFunc(func) {
-      this[func]() // call item function dynamically
+      this[func]() //call item function
     },
   },
 }

--- a/src/components/molecules/IntroEdit.vue
+++ b/src/components/molecules/IntroEdit.vue
@@ -21,10 +21,9 @@ export default {
   components: {
     IntroComp,
   },
-  data: () => ({}),
-  computed: {
-    items() {
-      return [
+  data() {
+    return {
+      items: [
         {
           iconColor: '#D128C9',
           icon: 'mdi-file-document',
@@ -32,7 +31,6 @@ export default {
           subtitle: i18n.t('pages.intros.docSubtitle') + i18n.t('titles.test'),
           func: 'goToDoc',
         },
-
         {
           iconColor: '#D128C9',
           icon: 'mdi-emoticon-happy',
@@ -40,8 +38,8 @@ export default {
           subtitle: i18n.t('pages.intros.discSubtitle'),
           func: 'goToDisc',
         },
-      ]
-    },
+      ],
+    }
   },
   methods: {
     goToDoc() {
@@ -54,7 +52,7 @@ export default {
       this.$emit('closeIntro')
     },
     callFunc(func) {
-      this[func]() //call item function
+      this[func]() // call item function dynamically
     },
   },
 }


### PR DESCRIPTION
Refactor: Moved items from a computed property to data since it's a static array that doesn't depend on reactive state. This improves clarity, avoids unnecessary dependency tracking, and aligns better with Vue's design principles.

In the original code, items was defined as a computed property:
computed: {
  items() {
    return [/* static array */]
  }
}

   What are computed properties for?
   * computed properties are typically used when:
   * You want to derive data from other reactive data (like props, data, or store).
   * You want that derived data to automatically update when the dependencies change.

   Why is this an issue here?
   * The items list is not derived from any reactive state.
   * It is static — its values do not change unless the code changes.
   * Using computed here is unnecessary overhead — Vue will still treat it as reactive and track dependencies, even though it 
      has none.

   Why is data() better here?
  * data() is ideal for static values or values you want to initialize and possibly update later.
  * It simplifies reactivity handling.
  * It's clearer semantically: you're just declaring an array, not computing it from other values.