### PR TITLE
BUG: v-model=IsOpen - fixed

### DIFF
--- a/src/components/dialogs/CreateTestNameDialog.vue
+++ b/src/components/dialogs/CreateTestNameDialog.vue
@@ -1,6 +1,12 @@
 <template>
   <div>
-    <v-dialog v-model="isOpen" fullscreen persistent transition="dialog-bottom-transition">
+    <v-dialog
+      :value="isOpen"
+      @input="$emit('update:isOpen', $event)"
+      fullscreen
+      persistent
+      transition="dialog-bottom-transition"
+    >
       <v-card color="#f9f5f0">
         <ButtonBack @click="$emit('close')" />
 


### PR DESCRIPTION
Fixed issue #663 in the CreateTestNameDialog component where the v-model='isOpen' was directly bound to a prop. In Vue, props should not be modified directly inside a component. To resolve this, I replaced the v-model with :value and input, emitting an update:isOpen event to ensure proper one-way data flow and avoid mutating the prop directly.