### PR TITLE
Update DisconnectedCard.vue

### DIFF
--- a/src/components/atoms/DisconnectedCard.vue
+++ b/src/components/atoms/DisconnectedCard.vue
@@ -10,10 +10,10 @@
       <v-container fluid>
         <v-row no-gutters>
           <v-col class="text-center cardSubtitle">
-            <span
-              >Infelizmente ocorreu uma desconexão. Você precisará realizar a
-              conexão novamente!</span
-            >
+            <span>
+              Infelizmente ocorreu uma desconexão. Você precisará realizar a
+              conexão novamente!
+            </span>
           </v-col>
           <v-col class="text-center">
             <v-img
@@ -46,7 +46,7 @@ export default {
   data() {
     return {
       dialog: true,
-      dialogMaxWidth: '40vw', // Define o valor inicial para desktop
+      dialogMaxWidth: '40vw', // Default width for desktop
     }
   },
   methods: {
@@ -54,25 +54,21 @@ export default {
       location.reload()
     },
     updateDialogMaxWidth() {
-      // Atualiza o valor máximo do diálogo com base no tamanho da viewport
+      // Use mutually exclusive conditions for proper responsiveness
       if (window.innerWidth <= 600) {
-        this.dialogMaxWidth = '80vw' // Define o valor para telas menores que 600px de largura
-      }
-      if (window.innerWidth <= 900) {
-        this.dialogMaxWidth = '60vw' // Define o valor para telas menores que 600px de largura
+        this.dialogMaxWidth = '80vw' // phones
+      } else if (window.innerWidth <= 900) {
+        this.dialogMaxWidth = '60vw' // tablets
       } else {
-        this.dialogMaxWidth = '40vw' // Define o valor para telas maiores que 600px de largura
+        this.dialogMaxWidth = '40vw' // desktops
       }
     },
   },
   mounted() {
-    // Chama a função para definir o valor inicial de dialogMaxWidth
     this.updateDialogMaxWidth()
-    // Adiciona um listener para ajustar o dialogMaxWidth quando a tela for redimensionada
     window.addEventListener('resize', this.updateDialogMaxWidth)
   },
   beforeDestroy() {
-    // Remove o listener do evento resize para evitar vazamentos de memória
     window.removeEventListener('resize', this.updateDialogMaxWidth)
   },
 }


### PR DESCRIPTION
Replaced overlapping if conditions in updateDialogMaxWidth() with a clean if-else if-else chain to ensure mutually exclusive execution. This now correctly applies 80vw for mobile, 60vw for tablets, and 40vw for desktops, improving the component's responsiveness and expected behavior.
The method updateDialogMaxWidth() is supposed to adjust the dialog's width based on the screen size:

if (window.innerWidth <= 600) {
  this.dialogMaxWidth = '80vw'
}
if (window.innerWidth <= 900) {
  this.dialogMaxWidth = '60vw'
} else {
  this.dialogMaxWidth = '40vw'
}

❌ Why this is incorrect:
These are independent if statements, so both can execute.

For window.innerWidth = 500, both conditions <= 600 and <= 900 are true.

So, dialogMaxWidth is first set to 80vw, then overwritten to 60vw.

The intended value 80vw for small devices is never used.

✅ Solution: Use if ... else if ... else
This ensures only one block runs depending on screen width, fixing the logic bug:

updateDialogMaxWidth() {
  if (window.innerWidth <= 600) {
    this.dialogMaxWidth = '80vw' // for phones
  } else if (window.innerWidth <= 900) {
    this.dialogMaxWidth = '60vw' // for tablets
  } else {
    this.dialogMaxWidth = '40vw' // for desktops
  }
}


