### PR TITLE
fix(user-testing): Added all the lost strings for Moderated Test

### DIFF
--- a/src/components/organisms/EditModeratedUserTest.vue
+++ b/src/components/organisms/EditModeratedUserTest.vue
@@ -45,7 +45,7 @@
               outlined
               color="orange"
               class="mx-6 mt-3"
-              :placeholder="$t('ModeratedTest.welcomeMessagePlaceholder')"
+              :placeholder="$t('ModeratedTest.welcomeMessage')"
               @change="saveWelcomeState()"
             />
             <v-col cols="12" class="pb-0 px-8">
@@ -56,7 +56,7 @@
                 v-model="landingPage"
                 class="mt-3"
                 style="border-radius: 20px;"
-                :placeholder="$t('ModeratedTest.landingPagePlaceholder')"
+                :placeholder="$t('ModeratedTest.url')"
                 outlined
                 color="orange"
                 @change="saveLandingPage()"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -631,5 +631,28 @@
   "contactNumberRequired": "Contact number is required",
   "enterValidPhoneNumber": "Please enter a valid phone number (9-15 digits only)",
   "email": "Email",
-  "username": "Username"
+  "username": "Username",
+  "ModeratedTest": {
+    "preTest": "PRE-TEST",
+    "tasks": "TASKS",
+    "postTest": "POST-TEST",
+    "consentForm": "Consent Form",
+    "consentDescription": "This is a Consent Checkbox with a text to confirm consent.",
+    "welcomeMessage": "Welcome message",
+    "welcomeMessageDescription": "This message will be the first thing participants see before the session starts.",
+    "landingPage": "Landing Page",
+    "landingPageDescription": "This URL will automatically load when the participant starts the session.",
+    "participantCamera": "Participant camera",
+    "cameraOptions": {
+      "optional": "Optional",
+      "required": "Required",
+      "disabled": "Disabled"
+    },
+    "preForm": "Pre-Form",
+    "preFormDescription": "This is a pre-questionnaire to collect participant data.",
+    "postForm": "Post Form",
+    "postFormDescription": "This is a post-questionnaire to collect participant data.",
+    "finalMessage": "Final message",
+    "finalMessageDescription": "This is a final message you leave for the participant at the end of the test."
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -642,6 +642,7 @@
     "welcomeMessageDescription": "This message will be the first thing participants see before the session starts.",
     "landingPage": "Landing Page",
     "landingPageDescription": "This URL will automatically load when the participant starts the session.",
+    "url": "Your Landing Page URL",
     "participantCamera": "Participant camera",
     "cameraOptions": {
       "optional": "Optional",
@@ -653,6 +654,7 @@
     "postForm": "Post Form",
     "postFormDescription": "This is a post-questionnaire to collect participant data.",
     "finalMessage": "Final message",
-    "finalMessageDescription": "This is a final message you leave for the participant at the end of the test."
+    "finalMessageDescription": "This is a final message you leave for the participant at the end of the test.",
+    "finalMessagePlaceholder": "Enter Final message"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -470,8 +470,8 @@
     },
     "createTest": {
       "title": "Create a new test",
-      "blanckTitle": "Create a blank test",
-      "blanckSubtitle": "Create a blank test to begin with a completely new and fresh template.",
+      "blankTitle": "Create a blank test",
+      "blankSubtitle": "Create a blank test to begin with a completely new and fresh template.",
       "templateTitle": "Create from template",
       "templateSubtitle": "Create a test based on a template created by one of our users.",
       "create": "Create test",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -624,5 +624,28 @@
   "usernameMinLength": "El nombre de usuario debe tener al menos 3 caracteres",
   "countryRequired": "País es requerido",
   "contactNumberRequired": "Número de contacto es requerido",
-  "enterValidPhoneNumber": "Por favor ingrese un número de teléfono válido (solo 9-15 dígitos)"
+  "enterValidPhoneNumber": "Por favor ingrese un número de teléfono válido (solo 9-15 dígitos)",
+  "ModeratedTest": {
+    "preTest": "PRE-PRUEBA",
+    "tasks": "TAREAS",
+    "postTest": "POST-PRUEBA",
+    "consentForm": "Formulario de consentimiento",
+    "consentDescription": "Este es un cuadro de consentimiento con un texto para confirmar el consentimiento.",
+    "welcomeMessage": "Mensaje de bienvenida",
+    "welcomeMessageDescription": "Este mensaje será lo primero que los participantes verán antes de que comience la sesión.",
+    "landingPage": "Página de inicio",
+    "landingPageDescription": "Esta URL se cargará automáticamente cuando el participante inicie la sesión.",
+    "participantCamera": "Cámara del participante",
+    "cameraOptions": {
+      "optional": "Opcional",
+      "required": "Requerido",
+      "disabled": "Deshabilitado"
+    },
+    "preForm": "Pre-Formulario",
+    "preFormDescription": "Este es un cuestionario previo para recopilar datos de los participantes.",
+    "postForm": "Post-Formulario",
+    "postFormDescription": "Este es un cuestionario posterior para recopilar datos de los participantes.",
+    "finalMessage": "Mensaje final",
+    "finalMessageDescription": "Este es un mensaje final que dejas para el participante al finalizar la prueba."
+  }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -467,8 +467,8 @@
     },
     "createTest": {
       "title": "Crear una nueva prueba",
-      "blanckTitle": "Crear una prueba en blanco",
-      "blanckSubtitle": "Crea una prueba en blanco para comenzar con una plantilla completamente nueva y fresca.",
+      "blankTitle": "Crear una prueba en blanco",
+      "blankSubtitle": "Crea una prueba en blanco para comenzar con una plantilla completamente nueva y fresca.",
       "templateTitle": "Crear a partir de plantilla",
       "templateSubtitle": "Crea una prueba basada en una plantilla creada por uno de nuestros usuarios.",
       "create": "Crear prueba",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -635,6 +635,7 @@
     "welcomeMessageDescription": "Este mensaje será lo primero que los participantes verán antes de que comience la sesión.",
     "landingPage": "Página de inicio",
     "landingPageDescription": "Esta URL se cargará automáticamente cuando el participante inicie la sesión.",
+    "url": "La URL de su página de destino",
     "participantCamera": "Cámara del participante",
     "cameraOptions": {
       "optional": "Opcional",
@@ -646,6 +647,7 @@
     "postForm": "Post-Formulario",
     "postFormDescription": "Este es un cuestionario posterior para recopilar datos de los participantes.",
     "finalMessage": "Mensaje final",
-    "finalMessageDescription": "Este es un mensaje final que dejas para el participante al finalizar la prueba."
+    "finalMessageDescription": "Este es un mensaje final que dejas para el participante al finalizar la prueba.",
+    "finalMessagePlaceholder": "Ingresar mensaje final"
   }
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -540,6 +540,7 @@
     "welcomeMessageDescription": "यह संदेश सत्र शुरू होने से पहले प्रतिभागियों को सबसे पहले दिखेगा।",
     "landingPage": "लैंडिंग पेज",
     "landingPageDescription": "यह URL स्वचालित रूप से लोड होगा जब प्रतिभागी सत्र शुरू करेगा।",
+    "url": "आपका लैंडिंग पेज यूआरएल",
     "participantCamera": "प्रतिभागी कैमरा",
     "cameraOptions": {
       "optional": "वैकल्पिक",
@@ -551,7 +552,8 @@
     "postForm": "पोस्ट-फॉर्म",
     "postFormDescription": "यह एक पोस्ट-क्वेश्चनायर है जो प्रतिभागियों का डेटा एकत्र करने के लिए बनाया गया है।",
     "finalMessage": "अंतिम संदेश",
-    "finalMessageDescription": "यह एक अंतिम संदेश है जिसे आप परीक्षण समाप्त होने पर प्रतिभागी को छोड़ते हैं।"
+    "finalMessageDescription": "यह एक अंतिम संदेश है जिसे आप परीक्षण समाप्त होने पर प्रतिभागी को छोड़ते हैं।",
+    "finalMessagePlaceholder": "अंतिम संदेश दर्ज करें"
   },
   "HeuristicsCooperators": {
     "roles": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -468,8 +468,8 @@
     },
     "createTest": {
       "title": "Criar um novo teste",
-      "blanckTitle": "Criar um teste em branco",
-      "blanckSubtitle": "Crie um teste em branco para começar com um modelo completamente novo e atualizado.",
+      "blankTitle": "Criar um teste em branco",
+      "blankSubtitle": "Crie um teste em branco para começar com um modelo completamente novo e atualizado.",
       "templateTitle": "Criar a partir do modelo",
       "templateSubtitle": "Crie um teste baseado em um modelo criado por um de nossos usuários.",
       "create": "Criar teste",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -626,5 +626,28 @@
   "usernameMinLength": "O nome de usuário deve ter pelo menos 3 caracteres",
   "countryRequired": "País é obrigatório",
   "contactNumberRequired": "Número de contato é obrigatório",
-  "enterValidPhoneNumber": "Por favor, digite um número de telefone válido (apenas 9-15 dígitos)"
+  "enterValidPhoneNumber": "Por favor, digite um número de telefone válido (apenas 9-15 dígitos)",
+  "ModeratedTest": {
+    "preTest": "PRÉ-TESTE",
+    "tasks": "TAREFAS",
+    "postTest": "PÓS-TESTE",
+    "consentForm": "Termo de Consentimento",
+    "consentDescription": "Este é um campo de consentimento com um texto para confirmar o consentimento.",
+    "welcomeMessage": "Mensagem de boas-vindas",
+    "welcomeMessageDescription": "Esta mensagem será a primeira coisa que os participantes verão antes da sessão começar.",
+    "landingPage": "Página Inicial",
+    "landingPageDescription": "Este URL será carregado automaticamente quando o participante iniciar a sessão.",
+    "participantCamera": "Câmera do participante",
+    "cameraOptions": {
+      "optional": "Opcional",
+      "required": "Obrigatório",
+      "disabled": "Desativado"
+    },
+    "preForm": "Pré-Formulário",
+    "preFormDescription": "Este é um questionário prévio para coletar dados dos participantes.",
+    "postForm": "Pós-Formulário",
+    "postFormDescription": "Este é um questionário posterior para coletar dados dos participantes.",
+    "finalMessage": "Mensagem final",
+    "finalMessageDescription": "Esta é uma mensagem final que você deixa para o participante ao concluir o teste."
+  }
 }

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -637,6 +637,7 @@
     "welcomeMessageDescription": "Esta mensagem será a primeira coisa que os participantes verão antes da sessão começar.",
     "landingPage": "Página Inicial",
     "landingPageDescription": "Este URL será carregado automaticamente quando o participante iniciar a sessão.",
+    "url": "URL da sua página de destino",
     "participantCamera": "Câmera do participante",
     "cameraOptions": {
       "optional": "Opcional",
@@ -648,6 +649,7 @@
     "postForm": "Pós-Formulário",
     "postFormDescription": "Este é um questionário posterior para coletar dados dos participantes.",
     "finalMessage": "Mensagem final",
-    "finalMessageDescription": "Esta é uma mensagem final que você deixa para o participante ao concluir o teste."
+    "finalMessageDescription": "Esta é uma mensagem final que você deixa para o participante ao concluir o teste.",
+    "finalMessagePlaceholder": "Digite a mensagem final"
   }
 }


### PR DESCRIPTION
fixes #826 

Added all the lost strings for the moderated test with English, Spanish, Portuguese translation

![Screenshot from 2025-04-26 23-57-34](https://github.com/user-attachments/assets/dc50c582-6e6e-4337-be00-363f6b24c4ee)

![Screenshot from 2025-04-26 23-57-42](https://github.com/user-attachments/assets/a1cc0da7-c629-4d13-860d-94f6300a058c)

![Screenshot from 2025-04-26 23-57-50](https://github.com/user-attachments/assets/4b859b85-cca7-4982-9c17-65c6d32d27d3)
