### PR TITLE
Update InputTextEditTest.vue

### DIFF
--- a/src/components/atoms/InputTextEditTest.vue
+++ b/src/components/atoms/InputTextEditTest.vue
@@ -35,20 +35,17 @@ export default {
 
     type: {
       type: String,
-      default: 'textArea',
-      require: false
+      default: 'textArea'
     },
 
     label: {
       type: String,
-      default: '',
-      require: false,
+      default: ''
     },
 
     rows: {
       type: Number,
-      default: 1,
-      require: false,
+      default: 1
     },
   },
 


### PR DESCRIPTION
fix: correct prop option typo from require to required #836
fix: correct prop validation syntax and simplify prop definitions

This commit addresses issue #836 by making the following improvements:

1. Fixes prop validation syntax:
   - Removes incorrect `require: false` usage (Vue uses `required: false`)
   - However, since these props have default values, we've completely removed  the redundant `required: false` declarations as they're implied

2. Simplifies prop definitions:
   - For props with default values (`type`, `label`, `rows`): - Removed explicit `required: false` as it's unnecessary when default exists - This makes the code cleaner while maintaining identical functionality
   - Kept `required: true` for `value` prop as it's mandatory with no default

3. Maintains all existing functionality:
   - Component behavior remains exactly the same
   - Default values work identically:
     * type → 'textArea'
     * label → '' * rows → 1
   - The required `value` prop is still properly enforced

These changes follow Vue.js best practices where:
- Props with defaults are automatically treated as non-required
- Only explicitly mark props as required when they have no default
- Keep prop definitions clean and minimal