### PR TITLE
Update TipButton.vue

### DIFF
--- a/src/components/atoms/TipButton.vue
+++ b/src/components/atoms/TipButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" width="500">
+  <v-dialog :value="value" @input="$emit('input', $event)" width="500">
     <template v-slot:activator="{ on }">
       <v-btn
         color="green"
@@ -30,7 +30,7 @@
 
       <v-card-actions>
         <v-spacer />
-        <v-btn color="orange" text @click="dialog = false">
+        <v-btn color="orange" text @click="$emit('input', false)">
           Ok
         </v-btn>
       </v-card-actions>
@@ -40,7 +40,8 @@
 
 <script>
 export default {
-  // Fix default prop handling in task object
+  name: 'TipDialog',
+
   props: {
     task: {
       type: Object,
@@ -49,10 +50,10 @@ export default {
         taskTip: '',
       }),
     },
+    value: {  // this replaces internal `dialog`
+      type: Boolean,
+      default: false,
+    },
   },
-
-  data: () => ({
-    dialog: false,
-  }),
 }
 </script>


### PR DESCRIPTION
🚨 Problem:
This dialog is controlled internally. That means:
The parent component cannot control when it opens or closes You can’t reuse this dialog easily elsewhere without rewriting or duplicating the logic. It doesn’t follow the reusable component pattern in Vue 2 with Vuetify 2, which expects two-way binding using v-model.

✅ The Goal: Make the Dialog Reusable and Parent-Controlled Vuetify 2 v-model expects this:
You expose a prop called value.

You emit an event called input when the dialog should open or close.

This way, the parent component does:

<tip-dialog v-model="showDialog" :task="someTask" />

✅ Vue binds v-model="showDialog" to value prop and listens to @input events to update it.