### PR TITLE
Update CardForm.vue

### DIFF
--- a/src/components/molecules/CardForm.vue
+++ b/src/components/molecules/CardForm.vue
@@ -1,8 +1,11 @@
 <template>
   <v-card class="cards">
     <v-col cols="12">
+      <!-- Display the title and subtitle passed via props -->
       <p class="cardsTitle ml-3">{{ title }}</p>
       <p class="cardsSubtitle ml-3">{{ subtitle }}</p>
+
+      <!-- Slot for custom content inside the card -->
       <slot></slot>
     </v-col>
   </v-card>
@@ -13,14 +16,13 @@ export default {
   props: {
     title: {
       type: String,
-      defualt: '',
-      require: true,
+      default: '',     // ✅ Corrected from 'defualt'
+      required: true,  // ✅ Corrected from 'require'
     },
-
     subtitle: {
       type: String,
-      defualt: '',
-      require: false ,
+      default: '',     // ✅ Corrected from 'defualt'
+      required: false, // ✅ Corrected from 'require'
     },
   },
 }


### PR DESCRIPTION
This PR corrects the prop definitions for `title` and `subtitle` in the Card component by fixing typos (`defualt` ➝ `default`, `require` ➝ `required`). This ensures proper default value assignment and prop validation by Vue.

In the props section of your Vue component:

props: {
  title: {
    type: String,
    defualt: '',  // ❌ typo
    require: true,  // ❌ incorrect key
  },
  subtitle: {
    type: String,
    defualt: '',  // ❌ typo
    require: false,  // ❌ incorrect key
  },
}
There are two critical issues:

->defualt is a typo — Vue expects the key to be default. Because of this, default values won’t be applied.
->require should be required — If this is misspelled, Vue will ignore the validation, and you won’t get helpful developer 
    warnings if the required prop is missing.
    
✅ Benefits of This Fix
->Enables correct prop validation and fallback values in Vue.
->Prevents bugs or blank text when title or subtitle props are omitted.
->Improves code quality and maintainability.