### PR TITLE
Make Pre-form Question Titles Editable

### DIFF
--- a/src/components/atoms/UserVariables.vue
+++ b/src/components/atoms/UserVariables.vue
@@ -18,9 +18,15 @@
             <v-expansion-panel-content>
               <v-form>
                 <v-text-field
+                  v-model="items[i].title"
+                  label="Title"
+                  @change="saveState()"
+                />
+                <v-text-field
                   v-model="items[i].description"
                   label="Description"
                   @click:append="log"
+                  @change="saveState()"
                 />
                 <div>
                   <v-text-field


### PR DESCRIPTION
## Description
This PR adds the ability to edit the title of pre-form questions directly within the expansion panel. Previously, only the description and selection fields were editable, but the title couldn't be modified after creation.

## Screenshots

Before : 
![Screenshot from 2025-05-18 17-16-52](https://github.com/user-attachments/assets/714ea896-3527-4fba-a877-784a2b23d501)

After : 
![Screenshot from 2025-05-18 17-17-58](https://github.com/user-attachments/assets/950317b9-b408-4d53-98fb-d085bc809763)

## Related Issue

Closes #872 