### PR TITLE
Fixes title editing in post form questions

### DIFF
--- a/src/components/atoms/FormPostTest.vue
+++ b/src/components/atoms/FormPostTest.vue
@@ -10,6 +10,8 @@
             </v-expansion-panel-header>
             <v-expansion-panel-content>
               <v-form>
+               <v-text-field v-model="items[i].title" :label="$t('Title')"
+                  @click:append="log" />
                 <v-text-field v-model="items[i].description" :label="$t('UserTestTable.inputs.description')"
                   @click:append="log" />
                 <div>


### PR DESCRIPTION
## Summary
This PR adds the ability to edit question titles directly within the post form interface, improving usability and reducing friction when creating or modifying tests.

![image](https://github.com/user-attachments/assets/819d3fc0-679b-4989-8781-5712e99ba93e)

