### PR TITLE
test: add heuristic test creation scenarios

### DIFF
--- a/e2e/createHeuristicTest.spec.js
+++ b/e2e/createHeuristicTest.spec.js
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+
+const logIn = async (page) => {
+  await test.step('Navigate to signin page', async () => {
+    await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
+  });
+
+  await test.step('Fill login credentials', async () => {
+    await page.getByLabel('Email').fill('testemail@gmail.com');
+    await page.getByLabel('Password', { exact: true }).fill('password123');
+  });
+
+  await test.step('Click "Sign In" button', async () => {
+    await page.getByTestId('sign-in-button').click();
+  });
+};
+
+test.describe('Heuristic Test Case: Creation Scenarios', () => {
+  test('Create test successfully', async ({ page }) => {
+    await logIn(page);
+
+    await test.step('Create full heuristic test', async () => {
+      await page.getByTestId('create-test-btn').click();
+      await page.getByText('Create a blank test to begin').click();
+      await page.getByText('Inspection').click();
+      await page.getByText('Usability Heuristic').click();
+
+      const testName = 'Test successful';
+
+      await page.getByLabel('Test Name').fill(testName);
+      await page.getByLabel('Test Description').fill('This is the description for the test successful');
+
+      await page.getByRole('dialog').getByRole('button').nth(1).click();
+      await expect(page.locator('p', { hasText: testName })).toBeVisible({ timeout: 5000 });
+      await page.locator('p').filter({ hasText: testName }).click();
+    });
+  });
+
+  test('Create test without description', async ({ page }) => {
+    await logIn(page);
+
+    await test.step('Missing description', async () => {
+      await page.getByTestId('create-test-btn').click();
+      await page.getByText('Create a blank test Create a').click();
+      await page.getByText('Inspection').click();
+      await page.getByText('Usability Heuristic').click();
+
+      const testName = 'Test without description';
+
+      await page.getByLabel('Test Name').fill(testName);
+
+      await page.getByRole('dialog').getByRole('button').nth(1).click();
+      await expect(page.locator('p', { hasText: testName })).toBeVisible({ timeout: 5000 });
+      await page.locator('p').filter({ hasText: testName }).click();
+    });
+  });
+
+  test('Create test without name', async ({ page }) => {
+    await logIn(page);
+
+    await test.step('Missing name', async () => {
+      await page.getByTestId('create-test-btn').click();
+      await page.getByText('Create a blank test Create a').click();
+      await page.getByText('Inspection').click();
+      await page.getByText('Usability Heuristic').click();
+
+      await page.getByLabel('Test Description').fill('Test without name');
+
+      await page.getByRole('dialog').getByRole('button').nth(1).click();
+      await expect(page.getByText('Enter a Title')).toBeVisible();
+    });
+  });
+
+  test('Create test with neither name nor description', async ({ page }) => {
+    await logIn(page);
+
+    await test.step('Missing both fields', async () => {
+      await page.getByTestId('create-test-btn').click();
+      await page.getByText('Create a blank test Create a').click();
+      await page.getByText('Inspection').click();
+      await page.getByText('Usability Heuristic').click();
+
+      await page.getByRole('dialog').getByRole('button').nth(1).click();
+      await expect(page.getByText('Enter a Title')).toBeVisible();
+    });
+  });
+
+  test('Create public test with all fields filled', async ({ page }) => {
+    await logIn(page);
+
+    await test.step('Public test creation', async () => {
+      await page.getByTestId('create-test-btn').click();
+      await page.getByText('Create a blank test to begin').click();
+      await page.getByText('Category').nth(1).click();
+      await page.getByText('Test', { exact: true }).first().click();
+
+      const testName = 'Public test';
+
+      await page.getByLabel('Test Name').fill(testName);
+      await page.getByLabel('Test Description').fill('This is the description for the public test');
+      await page.locator('.v-input--selection-controls__ripple').click();
+
+      await page.getByRole('dialog').getByRole('button').nth(1).click();
+      await expect(page.locator('p', { hasText: testName })).toBeVisible({ timeout: 5000 });
+      await page.locator('p').filter({ hasText: testName }).click();
+    });
+  });
+});

--- a/e2e/createHeuristicTest.spec.js
+++ b/e2e/createHeuristicTest.spec.js
@@ -97,4 +97,4 @@ test.describe('Heuristic Test Case: Creation Scenarios', () => {
     });
   });
 });
-3
+

--- a/e2e/createHeuristicTest.spec.js
+++ b/e2e/createHeuristicTest.spec.js
@@ -97,3 +97,4 @@ test.describe('Heuristic Test Case: Creation Scenarios', () => {
     });
   });
 });
+3

--- a/e2e/createHeuristicTest.spec.js
+++ b/e2e/createHeuristicTest.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 
+// --- Reusable login function ---
 const logIn = async (page) => {
   await test.step('Navigate to signin page', async () => {
     await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
@@ -12,96 +13,86 @@ const logIn = async (page) => {
 
   await test.step('Click "Sign In" button', async () => {
     await page.getByTestId('sign-in-button').click();
+    await expect(page.getByTestId('create-test-btn')).toBeVisible({ timeout: 7000 });
   });
 };
 
+// --- Navigate to heuristic form ---
+const navigateToHeuristicTestForm = async (page, useCategoryFlow = false) => {
+  await page.getByTestId('create-test-btn').click();
+  if (useCategoryFlow) {
+    await page.getByText('Create a blank test to begin').click();
+    await page.getByText('Category').nth(1).click();
+    await page.getByText('Test', { exact: true }).first().click();
+  } else {
+    await page.getByText('Create a blank test', { exact: true }).click();
+    await page.getByText('Inspection').click();
+    await page.getByText('Usability Heuristic').click();
+  }
+};
+
+// --- Fill test form ---
+const fillTestForm = async (page, testName = '', testDescription = '', isPublic = false) => {
+  if (testName) await page.getByLabel('Test Name').fill(testName);
+  if (testDescription) await page.getByLabel('Test Description').fill(testDescription);
+  if (isPublic) await page.locator('.v-input--selection-controls__ripple').click();
+};
+
 test.describe('Heuristic Test Case: Creation Scenarios', () => {
-  test('Create test successfully', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await logIn(page);
+  });
+
+  test('Create test successfully', async ({ page }) => {
+    const testName = 'Test successful';
 
     await test.step('Create full heuristic test', async () => {
-      await page.getByTestId('create-test-btn').click();
-      await page.getByText('Create a blank test to begin').click();
-      await page.getByText('Inspection').click();
-      await page.getByText('Usability Heuristic').click();
-
-      const testName = 'Test successful';
-
-      await page.getByLabel('Test Name').fill(testName);
-      await page.getByLabel('Test Description').fill('This is the description for the test successful');
-
+      await navigateToHeuristicTestForm(page);
+      await fillTestForm(page, testName, 'This is the description for the test successful');
       await page.getByRole('dialog').getByRole('button').nth(1).click();
-      await expect(page.locator('p', { hasText: testName })).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('p', { hasText: testName })).toBeVisible();
       await page.locator('p').filter({ hasText: testName }).click();
     });
   });
 
   test('Create test without description', async ({ page }) => {
-    await logIn(page);
+    const testName = 'Test without description';
 
     await test.step('Missing description', async () => {
-      await page.getByTestId('create-test-btn').click();
-      await page.getByText('Create a blank test Create a').click();
-      await page.getByText('Inspection').click();
-      await page.getByText('Usability Heuristic').click();
-
-      const testName = 'Test without description';
-
-      await page.getByLabel('Test Name').fill(testName);
-
+      await navigateToHeuristicTestForm(page);
+      await fillTestForm(page, testName);
       await page.getByRole('dialog').getByRole('button').nth(1).click();
-      await expect(page.locator('p', { hasText: testName })).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('p', { hasText: testName })).toBeVisible();
       await page.locator('p').filter({ hasText: testName }).click();
     });
   });
 
   test('Create test without name', async ({ page }) => {
-    await logIn(page);
-
     await test.step('Missing name', async () => {
-      await page.getByTestId('create-test-btn').click();
-      await page.getByText('Create a blank test Create a').click();
-      await page.getByText('Inspection').click();
-      await page.getByText('Usability Heuristic').click();
-
-      await page.getByLabel('Test Description').fill('Test without name');
-
+      await navigateToHeuristicTestForm(page);
+      await fillTestForm(page, '', 'Test without name');
       await page.getByRole('dialog').getByRole('button').nth(1).click();
       await expect(page.getByText('Enter a Title')).toBeVisible();
     });
   });
 
   test('Create test with neither name nor description', async ({ page }) => {
-    await logIn(page);
-
     await test.step('Missing both fields', async () => {
-      await page.getByTestId('create-test-btn').click();
-      await page.getByText('Create a blank test Create a').click();
-      await page.getByText('Inspection').click();
-      await page.getByText('Usability Heuristic').click();
-
+      await navigateToHeuristicTestForm(page);
+      await fillTestForm(page);
       await page.getByRole('dialog').getByRole('button').nth(1).click();
       await expect(page.getByText('Enter a Title')).toBeVisible();
     });
   });
 
   test('Create public test with all fields filled', async ({ page }) => {
-    await logIn(page);
+    const testName = 'Public test';
 
     await test.step('Public test creation', async () => {
-      await page.getByTestId('create-test-btn').click();
-      await page.getByText('Create a blank test to begin').click();
-      await page.getByText('Category').nth(1).click();
-      await page.getByText('Test', { exact: true }).first().click();
-
-      const testName = 'Public test';
-
-      await page.getByLabel('Test Name').fill(testName);
-      await page.getByLabel('Test Description').fill('This is the description for the public test');
-      await page.locator('.v-input--selection-controls__ripple').click();
-
+      await navigateToHeuristicTestForm(page, true);
+      await fillTestForm(page, testName, 'This is the description for the public test', true);
       await page.getByRole('dialog').getByRole('button').nth(1).click();
-      await expect(page.locator('p', { hasText: testName })).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('p', { hasText: testName })).toBeVisible();
       await page.locator('p').filter({ hasText: testName }).click();
     });
   });


### PR DESCRIPTION
# ✅ Add Heuristic Test Creation Scenarios Using Playwright

This Pull Request adds a suite of automated UI tests to the RUXAILAB platform using **Playwright**, targeting the process of creating heuristic evaluation tests.

---

## 🎯 Objective

To improve automated test coverage by implementing a robust test case that validates the test creation feature from different user interaction scenarios. This ensures the form behaves correctly with both valid and invalid inputs.

---

## 🧪 Test Case: `Heuristic Test Case: Creation Scenarios`

This test case includes **five distinct test runs**, covering a variety of user flows related to heuristic test creation:

### ✅ `Create test successfully`
- Fills in both name and description.
- Confirms the test is created by searching for its title (`Test successful`) in the UI and clicking it.

### ⚠️ `Create test without description`
- Leaves the description blank.
- Still submits the test and confirms its presence in the list using the test name (`Test without description`).

### ⚠️ `Create test without name`
- Fills only the description.
- Submits the form and validates that the UI displays the error `Enter a Title`.

### ⚠️ `Create test with neither name nor description`
- Submits the form empty.
- Verifies that validation prevents the test from being created.

### 🌐 `Create public test with all fields filled`
- Fills name and description.
- Activates the public toggle.
- Confirms the test (`Public test`) appears in the list and navigates to it.

---

## 🔧 Improvements Introduced

### 1. `logIn(page)` Helper
- Abstracted the repeated login steps into a single helper function.
- This function handles navigation to `/signin`, input of credentials, sign-in, and confirmation that login was successful by checking for the visibility of the "create test" button.

### 2. Dynamic Test Name Validation
- Each test stores the test name in a `const testName` variable.
- After submitting the form, the test uses `page.locator('p', { hasText: testName })` to:
  - Assert that the test was created.
  - Navigate to the created test dynamically.
- This avoids hardcoded or brittle selectors and improves test robustness.

---
