### PR TITLE
fix(signup): show loading only on the clicked sign-up button

### DIFF
--- a/src/views/public/SignInView.vue
+++ b/src/views/public/SignInView.vue
@@ -41,7 +41,7 @@
                   color="#F9A826"
                   rounded
                   class="white--text"
-                  :loading="loading"
+                  :loading="loadingEmail"
                   @click="onSignIn()"
                 >
                   {{ $t('SIGNIN.sign-in') }}
@@ -55,7 +55,7 @@
               <div class="mx-3">
                 <google-sign-in-button 
                   :button-text="$t('SIGNIN.continueWithGoogle')"
-                  :loading="loading"
+                  :loading="loadingGoogle"
                   @google-sign-in-start="onGoogleSignInStart"
                   @google-sign-in-success="onGoogleSignInSuccess"
                   @google-sign-in-error="onGoogleSignInError"
@@ -103,6 +103,8 @@ export default {
   },
   data: () => ({
     showPassword: false,
+    loadingEmail: false,
+    loadingGoogle: false,
     email: '',
     password: '',
     emailRules: [
@@ -129,6 +131,7 @@ export default {
     async onSignIn() {
       const result = this.checkForm()
       if (result) {
+        this.loadingEmail = true
         try {
         await this.$store.dispatch('signin', {
           email: this.email,
@@ -139,6 +142,8 @@ export default {
         }
       } catch (error) {
         console.error('Erro de autenticação:', error)
+      } finally {
+        this.loadingEmail = false
       }
       }
      
@@ -148,15 +153,18 @@ export default {
     },
     onGoogleSignInStart() {
       // Event when Google sign-in starts
+      this.loadingGoogle = true
     },
     async onGoogleSignInSuccess() {
       // Event when Google sign-in is successful
+      this.loadingGoogle = false
       if (this.$store.getters.user) {
         this.$router.push('/testslist').catch(() => {})
       }
     },
     onGoogleSignInError(error) {
       // Event when Google sign-in fails
+      this.loadingGoogle = false
       console.error('Google sign-in error:', error)
       },
     redirectToForgotPassword() {

--- a/src/views/public/SignUpView.vue
+++ b/src/views/public/SignUpView.vue
@@ -56,7 +56,7 @@
                   color="#F9A826"
                   rounded
                   class="white--text"
-                  :loading="loading"
+                  :loading="loadingEmail"
                   @click="onSignUp()"
                 >
                   Sign-up
@@ -70,7 +70,7 @@
               <div class="mx-3">
                 <google-sign-in-button 
                   :button-text="$t('SIGNIN.continueWithGoogle')"
-                  :loading="loading"
+                  :loading="loadingGoogle"
                   @google-sign-in-start="onGoogleSignInStart"
                   @google-sign-in-success="onGoogleSignInSuccess"
                   @google-sign-in-error="onGoogleSignInError"
@@ -111,6 +111,8 @@ export default {
   data: () => ({
     email: '',
     password: '',
+    loadingEmail: false,
+    loadingGoogle: false,
 
     valid: true,
 
@@ -146,6 +148,7 @@ export default {
   methods: {
     async onSignUp() {
       if (this.valid) {
+        this.loadingEmail = true
         try {
           await this.$store.dispatch('signup', {
             email: this.email,
@@ -155,6 +158,8 @@ export default {
         } catch (error) {
           console.error('Signup failed:', error)
           this.errorMessage = 'Signup failed. Please check your credentials.'
+        } finally {
+          this.loadingEmail = false
         }
       }
     },
@@ -163,13 +168,16 @@ export default {
     },
     onGoogleSignInStart() {
       // Event when Google sign-in starts
+      this.loadingGoogle = true
     },
     async onGoogleSignInSuccess() {
       // Event when Google sign-in is successful
+      this.loadingGoogle = false
       await this.$router.push('/')
     },
     onGoogleSignInError(error) {
       // Event when Google sign-in fails
+      this.loadingGoogle = false
       console.error('Google sign-in error:', error)
     }
   },


### PR DESCRIPTION
## Description

Issue where **both the email/password sign-up button and the Google sign-up button** were showing the loading spinner at the same time.

Now, only the button that is clicked shows loading.  

---

## Related Issue

Fixes #926

---

## Changes

- Added local `loadingEmail` and `loadingGoogle` variables in `src/views/public/SignUpView.vue`

---

## Tested On

- ✅ Clicked Sign-up button → only that button shows loading
- ✅ Clicked Google button → only that button shows loading
