### PR TITLE
Fix: prevent crash when moderated tests have missing cooperators

### DIFF
--- a/src/views/admin/DashboardView.vue
+++ b/src/views/admin/DashboardView.vue
@@ -325,7 +325,7 @@ const filterModeratedSessions = async () => {
     const testObj = await store.dispatch('getTest', { id: testId });
 
     if (testObj) {
-      const cooperatorObj = testObj.cooperators.find(
+      const cooperatorObj = testObj.cooperators?.find(
         (coop) => coop.userDocId == user.value.id
       );
       if (cooperatorObj) {


### PR DESCRIPTION
## Description

This PR fixes an issue where the Dashboard would throw a runtime error when a user had participated in a moderated test that lacked a `cooperators` array.

Although this edge case shouldn't occur if tests are created correctly, it was triggered during development due to malformed test data.

## Related Issue

Closes #933

## Changes

- Added a defensive check to ensure `testObj.cooperators` is an array before using `.find()` inside `filterModeratedSessions()` in `DashboardView.vue`.

## Tested On

✅ Simulated a test missing `cooperators` → no error thrown  
✅ Valid sessions still load correctly  
✅ Dashboard renders smoothly even with malformed test objects

## Notes

This fix is non-breaking and simply adds a guard to make the app more robust against inconsistent test data. It improves fault tolerance without altering any business logic.