### PR TITLE
Update SignUpView.vue fix(signup): show loading only on the clicked sign-up button  Refactored the sign-up form to use a local loading state for the sign-up button.  This ensures that the loading indicator appears only on the button that was clicked,  improving user experience and addressing issue #928.

### DIFF
--- a/src/views/public/SignUpView.vue
+++ b/src/views/public/SignUpView.vue
@@ -70,7 +70,7 @@
                   rounded
                   class="text-white"
                   style="background-color: #F9A826;"
-                  :loading="loading"
+                  :loading="emailPasswordLoading"
                   @click="onSignUp"
                 >
                   Sign-up
@@ -114,6 +114,7 @@ const showPassword = ref(false)
 const showConfirmPassword = ref(false)
 const valid = ref(true)
 const form = ref(null)
+const emailPasswordLoading = ref(false)
 
 const store = useStore()
 const router = useRouter()
@@ -136,12 +137,12 @@ const comparePassword = computed(() =>
 )
 
 const user = computed(() => store.getters.user)
-const loading = computed(() => store.getters.loading)
 
 const onSignUp = async () => {
   const { valid: isValid } = await form.value.validate()
   if (isValid) {
     try {
+      emailPasswordLoading.value = true
       await store.dispatch('signup', {
         email: email.value,
         password: password.value,
@@ -149,6 +150,8 @@ const onSignUp = async () => {
       await router.push('/')
     } catch (error) {
       console.error('Signup failed:', error)
+    } finally {
+      emailPasswordLoading.value = false
     }
   }
 }


### PR DESCRIPTION
Previously, the sign-up button's loading state was tied to a global loading variable from the Vuex store. This could cause the loading indicator to appear on all sign-up buttons or be affected by other unrelated actions that modify the global loading state.

This commit introduces a local emailPasswordLoading state that is only activated when the user clicks the sign-up button and is reset after the sign-up process completes. This ensures a more accurate and user-friendly experience by showing the loading spinner exclusively on the button that was interacted with during the sign-up process.