### PR TITLE
Shows specific password validation requirements(min length/uppercase/…

### DIFF
--- a/src/views/public/SignUpView.vue
+++ b/src/views/public/SignUpView.vue
@@ -144,7 +144,12 @@ const emailRules = [
 
 const passwordRules = [
   v => !!v || t('errors.passwordRequired'),
-  v => signupSchema.shape.password.safeParse(v).success || t('errors.passwordValidate'),
+  v => {
+    const result = signupSchema.shape.password.safeParse(v)
+    if (result.success) return true
+    const firstIssue = result.error.issues?.[0]
+    return firstIssue?.message || t('errors.passwordValidate')
+  },
 ]
 
 const comparePassword = [


### PR DESCRIPTION
## feat(signup): Show specific password validation requirements message. Fixes #978 

## Summary
Updates the signup password validation to display the specific failing requirement (min length, uppercase, symbol) rather than always showing the generic “at least 8 characters” message.

## Why
Previously, any failure surfaced as a length error, misleading users when the real issue was missing uppercase or symbol.  
Improves UX and reduces signup friction.

## How it works
- `signupSchema.shape.password.safeParse(v)` is evaluated per keystroke.  
- On failure, the first issue’s message is shown, otherwise validation passes.

## Tested
- Password < 8 chars → shows “Password must be at least 8 characters”.  
- 8+ chars, no uppercase → shows “Must contain an uppercase letter”.  
- 8+ chars with uppercase, no symbol → shows “Must contain a symbol”.  
- Meets all requirements → form submits successfully.
