### PR TITLE
fix(calibration): send user ID in header for standalone calibration (#955)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,8 +8,8 @@
       "dependencies": {
         "@types/nodemailer": "^6.4.17",
         "dotenv": "^8.2.0",
-        "firebase-admin": "^13.2.0",
-        "firebase-functions": "^6.3.2",
+        "firebase-admin": "^13.5.0",
+        "firebase-functions": "^6.4.0",
         "nodemailer": "^6.4.11"
       },
       "devDependencies": {
@@ -1101,8 +1101,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
@@ -1169,9 +1168,9 @@
       "license": "MIT"
     },
     "node_modules/firebase-admin": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.4.0.tgz",
-      "integrity": "sha512-Y8DcyKK+4pl4B93ooiy1G8qvdyRMkcNFfBSh+8rbVcw4cW8dgG0VXCCTp5NUwub8sn9vSPsOwpb9tE2OuFmcfQ==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.5.0.tgz",
+      "integrity": "sha512-QZOpv1DJRJpH8NcWiL1xXE10tw3L/bdPFlgjcWrqU3ufyOJDYfxB1MMtxiVTwxK16NlybQbEM6ciSich2uWEIQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -1179,6 +1178,7 @@
         "@firebase/database-types": "^1.0.6",
         "@types/node": "^22.8.7",
         "farmhash-modern": "^1.1.0",
+        "fast-deep-equal": "^3.1.1",
         "google-auth-library": "^9.14.2",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@types/nodemailer": "^6.4.17",
     "dotenv": "^8.2.0",
-    "firebase-admin": "^13.2.0",
-    "firebase-functions": "^6.3.2",
+    "firebase-admin": "^13.5.0",
+    "firebase-functions": "^6.4.0",
     "nodemailer": "^6.4.11"
   },
   "devDependencies": {

--- a/functions/src/https/eyeTracking.js
+++ b/functions/src/https/eyeTracking.js
@@ -6,6 +6,15 @@ export const receiveCalibration = functions.onRequest({
             return res.status(405).send("Method Not Allowed");
         }
 
+
+         const userId = req.get("X-User-ID");
+        if (!userId) {
+            return res.status(400).json({ error: "Missing X-User-ID header" });
+        }
+
+        console.log("Calibration triggered by user:", userId);
+
+
         try {
             const {
                 session_id,
@@ -28,6 +37,7 @@ export const receiveCalibration = functions.onRequest({
                 screen_height,
                 screen_width,
                 k,
+                userId,
                 createdAt: admin.firestore.FieldValue.serverTimestamp(),
             };
 


### PR DESCRIPTION
### Description
Fixes issue #955 by ensuring the user's ID is sent in the request header when triggering calibration in standalone mode.

### Changes Made
- Added header extraction logic in `functions/src/https/eyeTracking.js`:
  ```js
  const userId = req.get("X-User-ID");
  if (!userId) {
      return res.status(400).json({ error: "Missing X-User-ID header" });
  }
  console.log("Calibration triggered by user:", userId);

- testing verified locally using Firebase Emulator
