### PR TITLE
Send user ID in header for calibration (closes #955)

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -514,7 +514,21 @@ function handleIrisData(data) {
 }
 
 const openCalibration = () => {
-  window.open(`http://localhost:8081/calibration/camera?auth=${user.value?.id}`, '_blank');
+  fetch('http://localhost:8081/calibration/camera', {
+  method: 'GET',
+  headers: {
+    'X-User-ID': user.value?.id,
+  },
+  credentials: 'include', // cookies if needed
+})
+  .then(res => res.blob())
+  .then(blob => {
+    const url = URL.createObjectURL(blob);
+    window.open(url, '_blank');
+  })
+  .catch(err => {
+    console.error('Calibration launch failed:', err);
+  });
   calibrationInProgress.value = true;
   console.log('calibrationInProgress.value', calibrationInProgress.value);
 }


### PR DESCRIPTION
Hi @jvJUCA 👋
This PR replaces the insecure ?auth=<userId> query string with the X-User-ID header when opening the calibration window.

    Verified locally with a mock server—header is received correctly.
    Keeps the existing UX (still opens calibration in a new tab).

Ready for your review. Thanks!