### PR TITLE
clean translation files by merging PROFILES into profiles

### DIFF
--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -50,7 +50,7 @@
     "sentBy": "مرسل من قبل",
     "new": "جديد"
   },
-  "PROFILE": {
+  "profiles": {
     "title": "الملف الشخصي",
     "editProfile": "تحرير الملف الشخصي",
     "account": "الحساب",

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -56,7 +56,7 @@
     "sentBy": "Gesendet von",
     "new": "NEU"
   },
-  "PROFILE": {
+  "profiles": {
     "title": "Profil",
     "editProfile": "Profil bearbeiten",
     "account": "Konto",

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -69,10 +69,17 @@
     "new": "NEW",
     "test": "a Study"
   },
-  "profile": {
+  "profiles": {
     "title": "Profile",
-    "username": "Username",
+    "user": "USER",
+    "yourPassword": "Your Password",
+    "usernameRequired": "Username is required",
+    "usernameMinLength": "Username must be at least 3 characters",
+    "countryRequired": "Country is required",
+    "contactNumberRequired": "Contact number is required",
+    "enterValidPhoneNumber": "Please enter a valid phone number (9-15 digits only)",
     "email": "Email",
+    "username": "Username",
     "editProfile": "Edit Profile",
     "account": "Account",
     "admin": "Admin",
@@ -755,27 +762,6 @@
     "browseAllCategories": "Browse all categories to find the help you need",
     "viewAllArticles": "View All Articles",
     "videoAltText": "FAQ demonstration video showing the visual steps to solve the frequently asked question. No audio content is present in this instructional video."
-  },
-  "PROFILE": {
-    "user": "USER",
-    "account": "Account",
-    "security": "Security",
-    "personalInfo": "Personal Info",
-    "contact": "Contact",
-    "country": "Country",
-    "editDetails": "Edit Details",
-    "typeDeleteToConfirm": "Type \"DELETE\" to confirm",
-    "pleaseTypeDeleteToConfirm": "Please type DELETE to confirm",
-    "finalStepVerifyIdentity": "Final step: Verify your identity",
-    "enterPasswordForAccountDeletion": "Enter your password to proceed with account deletion",
-    "yourPassword": "Your Password",
-    "usernameRequired": "Username is required",
-    "usernameMinLength": "Username must be at least 3 characters",
-    "countryRequired": "Country is required",
-    "contactNumberRequired": "Contact number is required",
-    "enterValidPhoneNumber": "Please enter a valid phone number (9-15 digits only)",
-    "email": "Email",
-    "username": "Username"
   },
   "ModeratedTest": {
     "preTest": "PRE-TEST",

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -69,10 +69,17 @@
     "new": "NUEVO",
     "test": "un estudio"
   },
-  "profile": {
+  "profiles": {
     "title": "Perfil",
-    "username": "Nombre de usuario",
+    "user": "USUARIO",
+    "yourPassword": "Tu contraseña",
+    "usernameRequired": "Se requiere nombre de usuario",
+    "usernameMinLength": "El nombre de usuario debe tener al menos 3 caracteres",
+    "countryRequired": "Se requiere país",
+    "contactNumberRequired": "Se requiere número de contacto",
+    "enterValidPhoneNumber": "Por favor, ingresa un número de teléfono válido (9-15 dígitos únicamente)",
     "email": "Correo electrónico",
+    "username": "Nombre de usuario",
     "editProfile": "Editar perfil",
     "account": "Cuenta",
     "admin": "Administrador",
@@ -100,7 +107,9 @@
     "passwordUppercase": "Debe contener una letra mayúscula",
     "passwordSymbol": "Debe contener un símbolo",
     "confirmPasswordRequired": "Se requiere confirmar la contraseña",
-    "passwordsMatch": "Las contraseñas deben coincidir"
+    "passwordsMatch": "Las contraseñas deben coincidir",
+    "back": "Volver",
+    "deleteForever": "Eliminar para siempre"
   },
   "titles": {
     "manager": "Gerente",
@@ -756,27 +765,6 @@
     "browseAllCategories": "Explora todas las categorías para encontrar la ayuda que necesitas",
     "viewAllArticles": "Ver todos los artículos",
     "videoAltText": "Video de demostración de preguntas frecuentes que muestra los pasos visuales para resolver la pregunta frecuente. No hay contenido de audio en este video instructivo."
-  },
-  "PROFILE": {
-    "user": "USUARIO",
-    "account": "Cuenta",
-    "security": "Seguridad",
-    "personalInfo": "Información personal",
-    "contact": "Contacto",
-    "country": "País",
-    "editDetails": "Editar detalles",
-    "typeDeleteToConfirm": "Escribe \"ELIMINAR\" para confirmar",
-    "pleaseTypeDeleteToConfirm": "Por favor, escribe ELIMINAR para confirmar",
-    "finalStepVerifyIdentity": "Paso final: Verifica tu identidad",
-    "enterPasswordForAccountDeletion": "Ingresa tu contraseña para proceder con la eliminación de la cuenta",
-    "yourPassword": "Tu contraseña",
-    "usernameRequired": "Se requiere nombre de usuario",
-    "usernameMinLength": "El nombre de usuario debe tener al menos 3 caracteres",
-    "countryRequired": "Se requiere país",
-    "contactNumberRequired": "Se requiere número de contacto",
-    "enterValidPhoneNumber": "Por favor, ingresa un número de teléfono válido (9-15 dígitos únicamente)",
-    "email": "Correo electrónico",
-    "username": "Nombre de usuario"
   },
   "ModeratedTest": {
     "preTest": "PREPRUEBA",

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -54,7 +54,7 @@
     "sentBy": "Envoyé par",
     "new": "NOUVEAU"
   },
-  "PROFILE": {
+  "profiles": {
     "title": "Profil",
     "editProfile": "Modifier le profil",
     "account": "Compte",

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -68,10 +68,17 @@
     "sentBy": "द्वारा भेजा गया",
     "new": "नया"
   },
-  "profile": {
+  "profiles": {
     "title": "प्रोफ़ाइल",
-    "username": "उपयोगकर्ता नाम",
+    "user": "उपयोगकर्ता",
+    "yourPassword": "आपका पासवर्ड",
+    "usernameRequired": "उपयोगकर्ता नाम अनिवार्य है",
+    "usernameMinLength": "उपयोगकर्ता नाम कम से कम 3 अक्षरों का होना चाहिए",
+    "countryRequired": "देश अनिवार्य है",
+    "contactNumberRequired": "संपर्क नंबर अनिवार्य है",
+    "enterValidPhoneNumber": "कृपया एक वैध फोन नंबर दर्ज करें (केवल 9-15 अंक)",
     "email": "ईमेल",
+    "username": "उपयोगकर्ता नाम",
     "editProfile": "प्रोफ़ाइल संपादित करें",
     "account": "खाता",
     "admin": "व्यवस्थापक",
@@ -99,7 +106,9 @@
     "passwordUppercase": "इसमें एक अपरकेस अक्षर होना चाहिए",
     "passwordSymbol": "इसमें एक प्रतीक होना चाहिए",
     "confirmPasswordRequired": "पासवर्ड की पुष्टि आवश्यक है",
-    "passwordsMatch": "पासवर्ड मेल खाना चाहिए"
+    "passwordsMatch": "पासवर्ड मेल खाना चाहिए",
+    "back": "पिछला",
+    "deleteForever": "हमेशा के लिए हटाएं"
   },
   "titles": {
     "manager": "प्रबंधन",
@@ -694,27 +703,6 @@
     "browseAllCategories": "आपको आवश्यक सहायता प्राप्त करने के लिए सभी श्रेणियों को ब्राउज़ करें",
     "viewAllArticles": "सभी लेख देखें",
     "videoAltText": "FAQ डेमो वीडियो जो सामान्य प्रश्न को हल करने के लिए दृश्य चरण दिखाता है। इस निर्देशात्मक वीडियो में कोई ऑडियो सामग्री मौजूद नहीं है।"
-  },
-  "PROFILE": {
-    "user": "उपयोगकर्ता",
-    "account": "खाता",
-    "security": "सुरक्षा",
-    "personalInfo": "व्यक्तिगत जानकारी",
-    "contact": "संपर्क नंबर",
-    "country": "देश",
-    "editDetails": "विवरण संपादित करें",
-    "typeDeleteToConfirm": "पुष्टि करने के लिए \"DELETE\" टाइप करें",
-    "pleaseTypeDeleteToConfirm": "कृपया पुष्टि करने के लिए DELETE टाइप करें",
-    "finalStepVerifyIdentity": "अंतिम चरण: अपनी पहचान सत्यापित करें",
-    "enterPasswordForAccountDeletion": "खाता हटाने के लिए अपना पासवर्ड दर्ज करें",
-    "yourPassword": "आपका पासवर्ड",
-    "usernameRequired": "उपयोगकर्ता नाम अनिवार्य है",
-    "usernameMinLength": "उपयोगकर्ता नाम कम से कम 3 अक्षरों का होना चाहिए",
-    "countryRequired": "देश अनिवार्य है",
-    "contactNumberRequired": "संपर्क नंबर अनिवार्य है",
-    "enterValidPhoneNumber": "कृपया एक वैध फोन नंबर दर्ज करें (केवल 9-15 अंक)",
-    "email": "ईमेल",
-    "username": "उपयोगकर्ता नाम"
   },
   "ModeratedTest": {
     "preTest": "प्री-टेस्ट",

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -47,7 +47,7 @@
     "sentBy": "送信者",
     "new": "新着"
   },
-  "PROFILE": {
+  "profiles": {
     "title": "プロフィール",
     "editProfile": "プロフィールを編集",
     "account": "アカウント",

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -68,10 +68,17 @@
     "sentBy": "Enviado por",
     "new": "NOVO"
   },
-  "profile": {
+  "profiles": {
     "title": "Perfil",
-    "username": "Nome de usuário",
+    "user": "USUÁRIO",
+    "yourPassword": "Sua senha",
+    "usernameRequired": "Nome de usuário é obrigatório",
+    "usernameMinLength": "O nome de usuário deve ter pelo menos 3 caracteres",
+    "countryRequired": "País é obrigatório",
+    "contactNumberRequired": "Número de contato é obrigatório",
+    "enterValidPhoneNumber": "Por favor, digite um número de telefone válido (apenas 9-15 dígitos)",
     "email": "E-mail",
+    "username": "Nome de usuário",
     "editProfile": "Editar perfil",
     "account": "Conta",
     "admin": "Administrador",
@@ -99,7 +106,9 @@
     "passwordUppercase": "Deve conter uma letra maiúscula",
     "passwordSymbol": "Deve conter um símbolo",
     "confirmPasswordRequired": "Confirmação de senha é obrigatória",
-    "passwordsMatch": "As senhas devem corresponder"
+    "passwordsMatch": "As senhas devem corresponder",
+    "back": "Voltar",
+    "deleteForever": "Excluir para sempre"
   },
   "titles": {
     "manager": "Gerenciamento",
@@ -695,27 +704,6 @@
     "browseAllCategories": "Navegue por todas as categorias para encontrar a ajuda que você precisa",
     "viewAllArticles": "Ver todos os artigos",
     "videoAltText": "Vídeo demonstrativo de FAQ mostrando os passos visuais para resolver a pergunta frequente. Não há conteúdo de áudio presente neste vídeo instrucional."
-  },
-  "PROFILE": {
-    "user": "USUÁRIO",
-    "account": "Conta",
-    "security": "Segurança",
-    "personalInfo": "Informações pessoais",
-    "contact": "Contato",
-    "country": "País",
-    "editDetails": "Editar detalhes",
-    "typeDeleteToConfirm": "Digite \"EXCLUIR\" para confirmar",
-    "pleaseTypeDeleteToConfirm": "Por favor, digite EXCLUIR para confirmar",
-    "finalStepVerifyIdentity": "Passo final: Verifique sua identidade",
-    "enterPasswordForAccountDeletion": "Digite sua senha para prosseguir com a exclusão da conta",
-    "yourPassword": "Sua senha",
-    "usernameRequired": "Nome de usuário é obrigatório",
-    "usernameMinLength": "O nome de usuário deve ter pelo menos 3 caracteres",
-    "countryRequired": "País é obrigatório",
-    "contactNumberRequired": "Número de contato é obrigatório",
-    "enterValidPhoneNumber": "Por favor, digite um número de telefone válido (apenas 9-15 dígitos)",
-    "email": "E-mail",
-    "username": "Nome de usuário"
   },
   "ModeratedTest": {
     "preTest": "PRÉ-TESTE",

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -47,7 +47,7 @@
     "sentBy": "Отправлено",
     "new": "НОВОЕ"
   },
-  "PROFILE": {
+  "profiles": {
     "title": "Профиль",
     "editProfile": "Редактировать профиль",
     "account": "Аккаунт",

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -47,7 +47,7 @@
     "sentBy": "发送者",
     "new": "新"
   },
-  "PROFILE": {
+  "profiles": {
     "title": "个人资料",
     "editProfile": "编辑个人资料",
     "account": "账户",

--- a/src/features/auth/components/ProfileAccountTab.vue
+++ b/src/features/auth/components/ProfileAccountTab.vue
@@ -2,7 +2,7 @@
   <v-card class="rounded-xl pa-6" elevation="2">
     <v-card-title class="text-h6 font-weight-bold mb-4">
       <v-icon start color="primary">mdi-account-details</v-icon>
-      {{ $t('profile.personalInfo') }}
+      {{ $t('profiles.personalInfo') }}
     </v-card-title>
     <v-card-text>
       <v-form>
@@ -43,7 +43,7 @@
           <v-col cols="12" sm="6">
             <v-text-field
               v-model="userprofile.country"
-              :label="$t('profile.country')"
+              :label="$t('profiles.country')"
               variant="outlined"
               density="compact"
               prepend-inner-icon="mdi-map-marker"
@@ -62,7 +62,7 @@
         <v-icon start>
           mdi-pencil
         </v-icon>
-        {{ $t('profile.editDetails') }}
+        {{ $t('profiles.editDetails') }}
       </v-btn>
       <div v-if="showEditForm" class="mt-6">
         <v-form ref="editProfileForm" v-model="editProfileValid">
@@ -88,7 +88,7 @@
           />
           <v-autocomplete
             v-model="editProfileData.country"
-            :label="$t('profile.country')"
+            :label="$t('profiles.country')"
             variant="outlined"
             density="compact"
             prepend-inner-icon="mdi-map-marker"
@@ -122,7 +122,7 @@
             <v-icon start>
               mdi-content-save
             </v-icon>
-            {{ $t('profile.saveChanges') }}
+            {{ $t('profiles.saveChanges') }}
           </v-btn>
           <v-btn
             variant="text"

--- a/src/features/auth/components/ProfileDeleteAccountDialog.vue
+++ b/src/features/auth/components/ProfileDeleteAccountDialog.vue
@@ -16,7 +16,7 @@
         >
           mdi-alert-circle
         </v-icon>
-        {{ $t('profile.deleteAccountTitle') }}
+        {{ $t('profiles.deleteAccountTitle') }}
         <v-spacer />
       </v-card-title>
 
@@ -28,14 +28,14 @@
             variant="outlined"
             class="mb-4"
           >
-            {{ $t('profile.deleteAccountConfirm') }}
+            {{ $t('profiles.deleteAccountConfirm') }}
           </v-alert>
           <p class="text-body-1 mb-4">
-            {{ $t('profile.deleteAccountWarning') }}
+            {{ $t('profiles.deleteAccountWarning') }}
           </p>
           <div class="text-center">
             <p class="font-weight-bold mb-2">
-              {{ $t('profile.typeDeleteToConfirm') }}
+              {{ $t('profiles.typeDeleteToConfirm') }}
             </p>
             <v-text-field
               v-model="deleteConfirmText"
@@ -43,7 +43,7 @@
               density="compact"
               hide-details
               class="input-field-transition"
-              :rules="[(v) => v === 'DELETE' || $t('profile.pleaseTypeDeleteToConfirm')]"
+              :rules="[(v) => v === 'DELETE' || $t('profiles.pleaseTypeDeleteToConfirm')]"
             />
           </div>
         </v-card-text>
@@ -77,20 +77,20 @@
             variant="outlined"
             class="mb-4"
           >
-            {{ $t('profile.finalStepVerifyIdentity') }}
+            {{ $t('profiles.finalStepVerifyIdentity') }}
           </v-alert>
           <p class="text-center font-weight-bold mb-4">
-            {{ $t('profile.enterPasswordForAccountDeletion') }}
+            {{ $t('profiles.enterPasswordForAccountDeletion') }}
           </p>
           <v-text-field
             v-model="userPassword"
-            :label="$t('profile.yourPassword')"
+            :label="$t('profiles.yourPassword')"
             type="password"
             variant="outlined"
             density="compact"
             prepend-inner-icon="mdi-lock"
             :disabled="isDeleting"
-            :rules="[(v) => !!v || $t('profile.passwordRequired')]"
+            :rules="[(v) => !!v || $t('profiles.passwordRequired')]"
             class="input-field-transition"
           />
         </v-card-text>
@@ -102,7 +102,7 @@
             min-width="120"
             @click="$emit('prev-step')"
           >
-            {{ $t('profile.back') }}
+            {{ $t('profiles.back') }}
           </v-btn>
           <v-btn
             color="error"
@@ -116,7 +116,7 @@
             <v-icon start>
               mdi-delete
             </v-icon>
-            {{ $t('profile.deleteForever') }}
+            {{ $t('profiles.deleteForever') }}
           </v-btn>
         </v-card-actions>
       </div>

--- a/src/features/auth/components/ProfileSecurityTab.vue
+++ b/src/features/auth/components/ProfileSecurityTab.vue
@@ -2,34 +2,34 @@
   <v-card class="rounded-xl pa-6" elevation="2">
     <v-card-title class="text-h6 font-weight-bold mb-4">
       <v-icon start color="primary">mdi-lock</v-icon>
-      {{ $t('profile.changePassword') }}
+      {{ $t('profiles.changePassword') }}
     </v-card-title>
     <v-card-text>
       <v-alert type="warning" variant="outlined" class="mb-6">
         <div class="text-subtitle-1 font-weight-medium mb-2">
-          {{ $t('profile.passwordRequirements') }}
+          {{ $t('profiles.passwordRequirements') }}
         </div>
         <div class="text-body-2 mb-3">
-          {{ $t('profile.passwordMinimumRequirements') }}
+          {{ $t('profiles.passwordMinimumRequirements') }}
         </div>
         <div>
           <div class="d-flex align-center mb-2">
             <v-icon size="small" class="mr-2" :color="newPassword.length >= 8 ? 'success' : 'grey-darken-1'">
               {{ newPassword.length >= 8 ? 'mdi-check-circle' : 'mdi-circle-outline' }}
             </v-icon>
-            <span>{{ $t('profile.passwordMinLength') }}</span>
+            <span>{{ $t('profiles.passwordMinLength') }}</span>
           </div>
           <div class="d-flex align-center mb-2">
             <v-icon size="small" class="mr-2" :color="/[A-Z]/.test(newPassword) ? 'success' : 'grey-darken-1'">
               {{ /[A-Z]/.test(newPassword) ? 'mdi-check-circle' : 'mdi-circle-outline' }}
             </v-icon>
-            <span>{{ $t('profile.passwordUppercase') }}</span>
+            <span>{{ $t('profiles.passwordUppercase') }}</span>
           </div>
           <div class="d-flex align-center">
             <v-icon size="small" class="mr-2" :color="specialCharColor">
               {{ specialCharIcon }}
             </v-icon>
-            <span>{{ $t('profile.passwordSymbol') }}</span>
+            <span>{{ $t('profiles.passwordSymbol') }}</span>
           </div>
         </div>
       </v-alert>
@@ -39,7 +39,7 @@
             <v-text-field
               v-model="newPassword"
               :rules="passwordRules"
-              :label="$t('profile.newPassword')"
+              :label="$t('profiles.newPassword')"
               :type="showPassword ? 'text' : 'password'"
               variant="outlined"
               density="compact"
@@ -53,7 +53,7 @@
             <v-text-field
               v-model="confirmPassword"
               :rules="confirmPasswordRules"
-              :label="$t('profile.confirmNewPassword')"
+              :label="$t('profiles.confirmNewPassword')"
               :type="showConfirmPassword ? 'text' : 'password'"
               variant="outlined"
               density="compact"
@@ -74,18 +74,18 @@
           <v-icon start>
             mdi-key
           </v-icon>
-          {{ $t('profile.changePassword') }}
+          {{ $t('profiles.changePassword') }}
         </v-btn>
       </v-form>
       <!-- Delete Account Section -->
       <v-card class="rounded-xl pa-6 mt-6" elevation="2">
         <v-card-title class="text-h6 font-weight-bold">
           <v-icon start color="error">mdi-alert-circle</v-icon>
-          {{ $t('profile.deleteAccountTitle') }}
+          {{ $t('profiles.deleteAccountTitle') }}
         </v-card-title>
         <v-card-text>
           <p class="text-body-1 mb-4">
-            {{ $t('profile.deleteAccountWarning') }}
+            {{ $t('profiles.deleteAccountWarning') }}
           </p>
           <v-btn
             color="error"
@@ -97,7 +97,7 @@
             <v-icon start>
               mdi-delete
             </v-icon>
-            {{ $t('profile.deleteAccountTitle') }}
+            {{ $t('profiles.deleteAccountTitle') }}
           </v-btn>
         </v-card-text>
       </v-card>

--- a/src/features/auth/views/ProfileView.vue
+++ b/src/features/auth/views/ProfileView.vue
@@ -23,14 +23,14 @@
               />
             </v-avatar>
             <h2 class="text-h6 font-weight-bold mb-2">
-              {{ userprofile.username || $t('profile.title') }}
+              {{ userprofile.username || $t('profiles.title') }}
             </h2>
             <v-chip
               size="small"
               color="primary"
               class="mb-6"
             >
-              {{ $t('profile.admin') }}
+              {{ $t('profiles.admin') }}
             </v-chip>
 
             <v-divider class="my-4" />
@@ -57,7 +57,7 @@
                     'font-weight-medium': item.value,
                   }"
                 >
-                  {{ item.value || $t('profile.missingInfo') }}
+                  {{ item.value || $t('profiles.missingInfo') }}
                 </v-list-item-title>
               </v-list-item>
             </v-list>
@@ -95,7 +95,7 @@
               >
                 mdi-account
               </v-icon>
-              {{ $t('profile.account') }}
+              {{ $t('profiles.account') }}
             </v-tab>
             <v-tab
               value="1"
@@ -107,7 +107,7 @@
               >
                 mdi-shield-lock
               </v-icon>
-              {{ $t('profile.security') }}
+              {{ $t('profiles.security') }}
             </v-tab>
           </v-tabs>
 
@@ -131,7 +131,7 @@
                   >
                     mdi-account-details
                   </v-icon>
-                  {{ $t('profile.personalInfo') }}
+                  {{ $t('profiles.personalInfo') }}
                 </v-card-title>
                 <v-card-text>
                   <v-form>
@@ -142,7 +142,7 @@
                       >
                         <v-text-field
                           v-model="userprofile.username"
-                          :label="$t('profile.username')"
+                          :label="$t('profiles.username')"
                           variant="outlined"
                           density="compact"
                           prepend-inner-icon="mdi-account"
@@ -156,7 +156,7 @@
                       >
                         <v-text-field
                           v-model="user.email"
-                          :label="$t('profile.email')"
+                          :label="$t('profiles.email')"
                           variant="outlined"
                           density="compact"
                           prepend-inner-icon="mdi-email"
@@ -170,7 +170,7 @@
                       >
                         <v-text-field
                           v-model="userprofile.contactNo"
-                          :label="$t('profile.contact')"
+                          :label="$t('profiles.contact')"
                           variant="outlined"
                           density="compact"
                           prepend-inner-icon="mdi-phone"
@@ -184,7 +184,7 @@
                       >
                         <v-text-field
                           v-model="userprofile.country"
-                          :label="$t('profile.country')"
+                          :label="$t('profiles.country')"
                           variant="outlined"
                           density="compact"
                           prepend-inner-icon="mdi-map-marker"
@@ -203,7 +203,7 @@
                     <v-icon start>
                       mdi-pencil
                     </v-icon>
-                    {{ $t('profile.editDetails') }}
+                    {{ $t('profiles.editDetails') }}
                   </v-btn>
                 </v-card-text>
               </v-card>
@@ -225,7 +225,7 @@
                   >
                     mdi-lock
                   </v-icon>
-                  {{ $t('profile.changePassword') }}
+                  {{ $t('profiles.changePassword') }}
                 </v-card-title>
                 <v-card-text>
                   <v-alert
@@ -234,10 +234,10 @@
                     class="mb-6"
                   >
                     <div class="text-subtitle-1 font-weight-medium mb-2">
-                      {{ $t('profile.passwordRequirements') }}
+                      {{ $t('profiles.passwordRequirements') }}
                     </div>
                     <div class="text-body-2 mb-3">
-                      {{ $t('profile.passwordMinimumRequirements') }}
+                      {{ $t('profiles.passwordMinimumRequirements') }}
                     </div>
                     <div>
                       <div class="d-flex align-center mb-2">
@@ -248,7 +248,7 @@
                         >
                           {{ newPassword.length >= 8 ? 'mdi-check-circle' : 'mdi-circle-outline' }}
                         </v-icon>
-                        <span>{{ $t('profile.passwordMinLength') }}</span>
+                        <span>{{ $t('profiles.passwordMinLength') }}</span>
                       </div>
                       <div class="d-flex align-center mb-2">
                         <v-icon
@@ -258,7 +258,7 @@
                         >
                           {{ /[A-Z]/.test(newPassword) ? 'mdi-check-circle' : 'mdi-circle-outline' }}
                         </v-icon>
-                        <span>{{ $t('profile.passwordUppercase') }}</span>
+                        <span>{{ $t('profiles.passwordUppercase') }}</span>
                       </div>
                       <div class="d-flex align-center">
                         <v-icon
@@ -268,7 +268,7 @@
                         >
                           {{ specialCharIcon }}
                         </v-icon>
-                        <span>{{ $t('profile.passwordSymbol') }}</span>
+                        <span>{{ $t('profiles.passwordSymbol') }}</span>
                       </div>
                     </div>
                   </v-alert>
@@ -285,7 +285,7 @@
                         <v-text-field
                           v-model="newPassword"
                           :rules="passwordRules"
-                          :label="$t('profile.newPassword')"
+                          :label="$t('profiles.newPassword')"
                           :type="showPassword ? 'text' : 'password'"
                           variant="outlined"
                           density="compact"
@@ -302,7 +302,7 @@
                         <v-text-field
                           v-model="confirmPassword"
                           :rules="confirmPasswordRules"
-                          :label="$t('profile.confirmNewPassword')"
+                          :label="$t('profiles.confirmNewPassword')"
                           :type="showConfirmPassword ? 'text' : 'password'"
                           variant="outlined"
                           density="compact"
@@ -323,7 +323,7 @@
                       <v-icon start>
                         mdi-key
                       </v-icon>
-                      {{ $t('profile.changePassword') }}
+                      {{ $t('profiles.changePassword') }}
                     </v-btn>
                   </v-form>
                 </v-card-text>
@@ -341,11 +341,11 @@
                   >
                     mdi-alert-circle
                   </v-icon>
-                  {{ $t('profile.deleteAccountTitle') }}
+                  {{ $t('profiles.deleteAccountTitle') }}
                 </v-card-title>
                 <v-card-text>
                   <p class="text-body-1 mb-4">
-                    {{ $t('profile.deleteAccountWarning') }}
+                    {{ $t('profiles.deleteAccountWarning') }}
                   </p>
                   <v-btn
                     color="error"
@@ -357,7 +357,7 @@
                     <v-icon start>
                       mdi-delete
                     </v-icon>
-                    {{ $t('profile.deleteAccountTitle') }}
+                    {{ $t('profiles.deleteAccountTitle') }}
                   </v-btn>
                 </v-card-text>
               </v-card>
@@ -384,7 +384,7 @@
           >
             mdi-account-edit
           </v-icon>
-          {{ $t('profile.editProfile') }}
+          {{ $t('profiles.editProfile') }}
         </v-card-title>
         <v-card-text>
           <div class="text-center mb-6">
@@ -419,7 +419,7 @@
           >
             <v-text-field
               v-model="editProfileData.username"
-              :label="$t('profile.username')"
+              :label="$t('profiles.username')"
               variant="outlined"
               density="compact"
               prepend-inner-icon="mdi-account"
@@ -428,7 +428,7 @@
             />
             <v-text-field
               v-model="editProfileData.contactNo"
-              :label="$t('profile.contact')"
+              :label="$t('profiles.contact')"
               variant="outlined"
               density="compact"
               prepend-inner-icon="mdi-phone"
@@ -439,7 +439,7 @@
             />
             <v-autocomplete
               v-model="editProfileData.country"
-              :label="$t('profile.country')"
+              :label="$t('profiles.country')"
               variant="outlined"
               density="compact"
               prepend-inner-icon="mdi-map-marker"
@@ -484,7 +484,7 @@
             <v-icon start>
               mdi-content-save
             </v-icon>
-            {{ $t('profile.saveChanges') }}
+            {{ $t('profiles.saveChanges') }}
           </v-btn>
         </v-card-actions>
       </v-card>
@@ -508,7 +508,7 @@
           >
             mdi-alert-circle
           </v-icon>
-          {{ $t('profile.deleteAccountTitle') }}
+          {{ $t('profiles.deleteAccountTitle') }}
           <v-spacer />
         </v-card-title>
 
@@ -520,14 +520,14 @@
               variant="outlined"
               class="mb-4"
             >
-              {{ $t('profile.deleteAccountConfirm') }}
+              {{ $t('profiles.deleteAccountConfirm') }}
             </v-alert>
             <p class="text-body-1 mb-4">
-              {{ $t('profile.deleteAccountWarning') }}
+              {{ $t('profiles.deleteAccountWarning') }}
             </p>
             <div class="text-center">
               <p class="font-weight-bold mb-2">
-                {{ $t('profile.typeDeleteToConfirm') }}
+                {{ $t('profiles.typeDeleteToConfirm') }}
               </p>
               <v-text-field
                 v-model="deleteConfirmText"
@@ -535,7 +535,7 @@
                 density="compact"
                 hide-details
                 class="input-field-transition"
-                :rules="[(v) => v === 'DELETE' || $t('profile.pleaseTypeDeleteToConfirm')]"
+                :rules="[(v) => v === 'DELETE' || $t('profiles.pleaseTypeDeleteToConfirm')]"
               />
             </div>
           </v-card-text>
@@ -571,20 +571,20 @@
               variant="outlined"
               class="mb-4"
             >
-              {{ $t('profile.finalStepVerifyIdentity') }}
+              {{ $t('profiles.finalStepVerifyIdentity') }}
             </v-alert>
             <p class="text-center font-weight-bold mb-4">
-              {{ $t('profile.enterPasswordForAccountDeletion') }}
+              {{ $t('profiles.enterPasswordForAccountDeletion') }}
             </p>
             <v-text-field
               v-model="userPassword"
-              :label="$t('profile.yourPassword')"
+              :label="$t('profiles.yourPassword')"
               type="password"
               variant="outlined"
               density="compact"
               prepend-inner-icon="mdi-lock"
               :disabled="isDeleting"
-              :rules="[(v) => !!v || $t('profile.passwordRequired')]"
+              :rules="[(v) => !!v || $t('profiles.passwordRequired')]"
               class="input-field-transition"
             />
           </v-card-text>
@@ -596,7 +596,7 @@
               min-width="120"
               @click="deleteStep = 1"
             >
-              {{ $t('profile.back') }}
+              {{ $t('profiles.back') }}
             </v-btn>
             <v-btn
               color="error"
@@ -610,7 +610,7 @@
               <v-icon start>
                 mdi-delete
               </v-icon>
-              {{ $t('profile.deleteForever') }}
+              {{ $t('profiles.deleteForever') }}
             </v-btn>
           </v-card-actions>
         </div>
@@ -681,23 +681,23 @@ const fileInput = ref(null);
 
 // Validation rules
 const usernameRules = [
-  (v) => !!v || t('PROFILE.usernameRequired'),
-  (v) => (v && v.length >= 3) || t('PROFILE.usernameMinLength'),
+  (v) => !!v || t('profiles.usernameRequired'),
+  (v) => (v && v.length >= 3) || t('profiles.usernameMinLength'),
 ];
-const countryRules = [(v) => !!v || t('PROFILE.countryRequired')];
+const countryRules = [(v) => !!v || t('profiles.countryRequired')];
 const contactRules = [
-  (v) => !!v || t('PROFILE.contactNumberRequired'),
-  (v) => /^\d{9,15}$/.test(v) || t('PROFILE.enterValidPhoneNumber'),
+  (v) => !!v || t('profiles.contactNumberRequired'),
+  (v) => /^\d{9,15}$/.test(v) || t('profiles.enterValidPhoneNumber'),
 ];
 const passwordRules = [
-  (v) => !!v || t('PROFILE.passwordRequired'),
-  (v) => v.length >= 8 || t('PROFILE.passwordMinLength'),
-  (v) => /[A-Z]/.test(v) || t('PROFILE.passwordUppercase'),
-  (v) => hasSpecialChar(v) || t('PROFILE.passwordSymbol'),
+  (v) => !!v || t('profiles.passwordRequired'),
+  (v) => v.length >= 8 || t('profiles.passwordMinLength'),
+  (v) => /[A-Z]/.test(v) || t('profiles.passwordUppercase'),
+  (v) => hasSpecialChar(v) || t('profiles.passwordSymbol'),
 ];
 const confirmPasswordRules = [
-  (v) => !!v || t('PROFILE.confirmPasswordRequired'),
-  (v) => v === newPassword.value || t('PROFILE.passwordsMatch'),
+  (v) => !!v || t('profiles.confirmPasswordRequired'),
+  (v) => v === newPassword.value || t('profiles.passwordsMatch'),
 ];
 
 const specialCharColor = computed(() =>
@@ -708,22 +708,22 @@ const specialCharIcon = computed(() =>
 );
 const profileItems = computed(() => [
   {
-    label: t('profile.username'),
+    label: t('profiles.username'),
     value: userprofile.value.username,
     icon: 'mdi-account',
   },
   {
-    label: t('profile.email'),
+    label: t('profiles.email'),
     value: user.value.email,
     icon: 'mdi-email',
   },
   {
-    label: t('profile.contact'),
+    label: t('profiles.contact'),
     value: userprofile.value.contactNo,
     icon: 'mdi-phone',
   },
   {
-    label: t('profile.country'),
+    label: t('profiles.country'),
     value: userprofile.value.country,
     icon: 'mdi-map-marker',
   },
@@ -745,7 +745,7 @@ const uploadProfileImage = async (event) => {
   try {
     const auth = getAuth();
     const user = auth.currentUser;
-    if (!user) throw new Error(t('PROFILE.noUserSignedIn'));
+    if (!user) throw new Error(t('profiles.noUserSignedIn'));
 
     const storage = getStorage();
     const storageReference = storageRef(storage, `profileImages/${user.uid}`);
@@ -759,10 +759,10 @@ const uploadProfileImage = async (event) => {
 
     userprofile.value.profileImage = downloadURL;
     editProfileData.value.profileImage = downloadURL;
-    toast.success(t('PROFILE.profileImageUpdatedSuccess'));
+    toast.success(t('profiles.profileImageUpdatedSuccess'));
   } catch (error) {
     console.error('Error uploading image:', error);
-    toast.error(t('PROFILE.profileImageUploadFailed'));
+    toast.error(t('profiles.profileImageUploadFailed'));
   }
 };
 
@@ -791,7 +791,7 @@ const fetchUserProfile = async () => {
     }
   } catch (error) {
     console.error('Error fetching profile:', error);
-    toast.error(t('PROFILE.profileLoadFailed'));
+    toast.error(t('profiles.profileLoadFailed'));
   } finally {
     loading.value = false;
   }
@@ -831,12 +831,12 @@ const saveProfile = async () => {
         country: editProfileData.value.country,
       };
 
-      toast.success(t('PROFILE.profileUpdatedSuccess'));
+      toast.success(t('profiles.profileUpdatedSuccess'));
       editProfileDialog.value = false;
     }
   } catch (error) {
     console.error('Error updating profile:', error);
-    toast.error(t('PROFILE.profileUpdateFailed'));
+    toast.error(t('profiles.profileUpdateFailed'));
   }
 };
 
@@ -848,14 +848,14 @@ const changePassword = async () => {
 
       if (user) {
         await updatePassword(user, newPassword.value);
-        toast.success(t('PROFILE.passwordChangedSuccess'));
+        toast.success(t('profiles.passwordChangedSuccess'));
         newPassword.value = '';
         confirmPassword.value = '';
         passwordForm.value.reset();
       }
     } catch (error) {
       console.error('Error changing password:', error);
-      toast.error(t('PROFILE.passwordChangeFailed'));
+      toast.error(t('profiles.passwordChangeFailed'));
     }
   }
 };
@@ -871,7 +871,7 @@ const handlerDeleteConfirmText = async (value) => {
     return await deleteAccount(user)
   } catch (error) {
     console.error('Error during account deletion:', error)
-    toast.error(t('PROFILE.accountDeletionFailed'))
+    toast.error(t('profiles.accountDeletionFailed'))
   } finally {
     isDeleting.value = false
     deleteAccountDialog.value = false
@@ -880,14 +880,14 @@ const handlerDeleteConfirmText = async (value) => {
 
 const deleteAccount = async (user) => {
   await store.dispatch('deleteAuth', user.uid)
-  toast.success(t('PROFILE.accountDeletedSuccess'))
+  toast.success(t('profiles.accountDeletedSuccess'))
   signOut()
 };
 
 const handlerDeleteAccount = async () => {
   const auth = getAuth()
   const user = auth.currentUser
-  if (!userPassword.value) return toast.error(t('PROFILE.passwordRequired'))
+  if (!userPassword.value) return toast.error(t('profiles.passwordRequired'))
 
   try {
     isDeleting.value = true
@@ -896,7 +896,7 @@ const handlerDeleteAccount = async () => {
     await deleteAccount(user)
   } catch (error) {
     console.error('Error during account deletion:', error)
-    toast.error(t('PROFILE.accountDeletionFailed'))
+    toast.error(t('profiles.accountDeletionFailed'))
   } finally {
     isDeleting.value = false
     deleteAccountDialog.value = false

--- a/src/features/super/SuperAdminView.vue
+++ b/src/features/super/SuperAdminView.vue
@@ -37,7 +37,7 @@
     </v-dialog>
 
     <h1 style="margin-left: 8%; font-weight: 300">
-      {{ $t('PROFILE.superAdmin') }}
+      {{ $t('profiles.superAdmin') }}
     </h1>
 
     <v-row
@@ -111,7 +111,7 @@
             >
               <v-card>
                 <v-card-title>
-                  <span class="text-h5">{{ $t('PROFILE.editProfile') }}</span>
+                  <span class="text-h5">{{ $t('profiles.editProfile') }}</span>
                 </v-card-title>
                 <v-card-text>
                   <v-container>
@@ -252,8 +252,8 @@ const testsHeaders = computed(() => [
 ])
 
 const accessLevels = computed(() => [
-  { title: t('PROFILE.superAdmin'), level: 0 },
-  { title: t('PROFILE.admin'), level: 1 },
+  { title: t('profiles.superAdmin'), level: 0 },
+  { title: t('profiles.admin'), level: 1 },
   { title: t('common.user'), level: 2 },
 ])
 


### PR DESCRIPTION
This PR fixes the inconsistency in the locale files where both PROFILE/PROFILES (uppercase) and profile (lowercase) were being used across different languages. This mixed naming caused missing or incorrect translations in places like the Profile view, where the code referenced keys that didn’t exist in some locale files.

To resolve this, I standardized everything to a single translation section named profiles (lowercase, plural), and updated all locale JSON files so they follow the same structure. I also went through the components that relied on the old keys and updated their translation calls to use the new, consistent naming. This includes ProfileView and the profile-related components inside the auth feature, along with a few references in SuperAdminView.

All uppercase occurrences (PROFILE / PROFILES) have now been removed from every language file, and every component now uses profiles.*. I double-checked the full codebase to confirm there are no remaining references to the old keys. The updated locale structure is now consistent across all languages, which should prevent further translation lookup issues in the profile section.