### PR TITLE
Fix: Implement Anonymous Authentication and Guest Access Flow #1010

### DIFF
--- a/src/features/auth/controllers/AuthController.js
+++ b/src/features/auth/controllers/AuthController.js
@@ -8,7 +8,8 @@ import {
   sendPasswordResetEmail,
   setPersistence,
   browserLocalPersistence,
-  browserSessionPersistence
+  browserSessionPersistence,
+  signInAnonymously
 } from 'firebase/auth'
 import { auth } from '@/app/plugins/firebase'
 import axios from 'axios';
@@ -84,6 +85,10 @@ export default class AuthController {
       )
     })
   }
+  async signInAnonymously() {
+    console.log('Signing in anonymously')
+    return signInAnonymously(auth)
+  }
   // Reset Password
   async resetPassword(email) {
     // return sendPasswordResetEmail(auth, email)
@@ -94,22 +99,22 @@ export default class AuthController {
       template: 'passwordReset',
     })
   }
-
-  async autoSignIn() {
-    return new Promise((resolve, reject) => {
-      const unsubscribe = onAuthStateChanged(
-        auth,
-        (user) => {
-          unsubscribe()
-          resolve(user)
-        },
-        (error) => {
-          unsubscribe()
-          reject(error)
-        }
-      )
-    })
-  }
+  // I think this isn't needed(two SignIn)
+  // async autoSignIn() {
+  //   return new Promise((resolve, reject) => {
+  //     const unsubscribe = onAuthStateChanged(
+  //       auth,
+  //       (user) => {
+  //         unsubscribe()
+  //         resolve(user)
+  //       },
+  //       (error) => {
+  //         unsubscribe()
+  //         reject(error)
+  //       }
+  //     )
+  //   })
+  // }
 
   async deleteAuth(userId) {
     try {

--- a/src/features/auth/store/Auth.js
+++ b/src/features/auth/store/Auth.js
@@ -132,6 +132,21 @@ export default {
         throw err
       }
     },
+    async signInAnonymously({ commit }) {
+      try {
+        const { user } = await authController.signInAnonymously()
+        // Anonymous users don't have a userController profile yet, 
+        // so we just set the Firebase user to state
+        commit('SET_USER', user)
+      } catch (err) {
+        console.error(err)
+        commit('SET_TOAST', {
+          message: 'Error signing in anonymously',
+          type: 'error',
+        })
+        throw err
+      }
+    },
 
     async logout({ commit }) {
       try {

--- a/src/shared/controllers/AnswerController.js
+++ b/src/shared/controllers/AnswerController.js
@@ -56,13 +56,8 @@ export default class AnswerController extends Controller {
 
     } else if (testType === STUDY_TYPES.USER) {
       if (!payload.userDocId) {
-
-        const taskAnswer = (await this.getAnswerById(answerDocId)).taskAnswers; // get taskAnswers
-
-        const taskAnswerCount = Object.keys(taskAnswer || {}).length; // get number of taskAnswers 
-
-        fieldToUpdate[`taskAnswers.Ev${taskAnswerCount + 1}`] = payload.toFirestore(); // add new taskAnswer with EV prefix for anonymous answers
-
+        const tempId = nanoid(16)
+        fieldToUpdate[`taskAnswers.${tempId}`] = payload.toFirestore();
       } else {
         fieldToUpdate[`taskAnswers.${payload.userDocId}`] = payload.toFirestore()
       }
@@ -84,7 +79,7 @@ export default class AnswerController extends Controller {
     });
   }
 
-    async updateTaskTranscriptionMeta({ answerDocId, userDocId, taskId, latestId, inc = 1 }) {
+  async updateTaskTranscriptionMeta({ answerDocId, userDocId, taskId, latestId, inc = 1 }) {
     const base = `taskAnswers.${userDocId}.tasks.${taskId}`
 
     const update = {

--- a/src/shared/utils/studyValidation.js
+++ b/src/shared/utils/studyValidation.js
@@ -1,0 +1,16 @@
+/**
+ * Validates if a user can access a study.
+ * @param {Object} study - The study object from Firestore
+ * @param {String} token - The token from the URL (not needed in case of Public Test)
+ * @returns {Boolean} - True if access is allowed, false otherwise
+ */
+
+
+export default function validateStudyAccess(study, token) {
+    if (study.isPublic) return true;
+
+    if (!token) return false;
+
+    const isTokenValid = study.cooperators?.some(c => c.token === token);
+    return !!isTokenValid;
+}

--- a/src/store/modules/Study.js
+++ b/src/store/modules/Study.js
@@ -32,8 +32,12 @@ export default {
       return state.testStructure
     },
     coops(state) {
-      return state.Test.coop
+      return state.Test.cooperators
     },
+    isPublic(state) {
+      console.log("isPublic from study.js store", state.Test.isPublic)
+      return state.Test.isPublic
+    }
   },
   mutations: {
     SET_TEST(state, payload) {
@@ -177,7 +181,9 @@ export default {
       try {
         const res = await studyController.getStudy(payload)
         commit('SET_TEST', res)
+        return res // Retuns the test object
       } catch (e) {
+        console.error("Failed to fetch the Study from the controller", e);
         commit('setError', true)
       } finally {
         commit('setLoading', false)

--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -32,7 +32,7 @@
       persistent
     >
       <v-card
-        v-if="user"
+        v-if="user && !user.isAnonymous"
         class="rounded-xl pa-6"
       >
         <v-row
@@ -74,6 +74,33 @@
               @click.prevent="signOut"
             >Change account</a>
           </p>
+        </v-card-actions>
+      </v-card>
+      <!-- card for guest users (both invited and public) -->
+      <v-card v-else class="rounded-xl pa-6">
+        <v-row class="ma-0 pa-0" justify="center">
+          <v-avatar color="primary-lighten-4" size="120">
+            <v-icon size="80">mdi-account-circle</v-icon>
+          </v-avatar>
+        </v-row>
+        <v-card-title class="text-center text-h6 font-weight-bold mt-4">
+          Welcome to the test!
+        </v-card-title>
+        <v-card-text class="text-center text-body-1">
+          <p class="font-weight-medium">
+            You've been invited to participate in this test.
+          </p>
+        </v-card-text>
+        <v-card-actions class="d-flex flex-column pa-0">
+          <v-btn
+            color="primary"
+            block
+            variant="flat"
+            class="my-2"
+            @click="setTest()"
+          >
+            Continue as Guest
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -357,7 +384,7 @@ import SubmitDialog from '@/ux/UserTest/components/SubmitDialog.vue';
 import { doc, onSnapshot } from "firebase/firestore";
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick, reactive, watchEffect } from 'vue';
 import { useStore } from 'vuex';
-import { useRouter } from 'vue-router'
+import { useRouter } from 'vue-router';
 import Snackbar from '@/shared/components/Snackbar';
 import { nanoid } from 'nanoid';
 import WelcomeStep from '@/ux/UserTest/components/steps/WelcomeStep.vue';
@@ -564,6 +591,8 @@ const saveAnswer = async () => {
         answerDocId: test.value.answersDocId,
         testType: test.value.testType,
       });
+      await store.dispatch('logout');
+      router.push('/signin');
     } else {
       Object.assign(currentUserTestAnswer.value, localTestAnswer);
       console.log('Generated userDocId for anonymous user:', currentUserTestAnswer.value);
@@ -631,8 +660,8 @@ const startTest = async () => {
     router.push(`/missions/${test.value.id}`);
     return;
   }
-
-  if (!isUserTestAdmin.value) {
+  // for unknown users, skip this acceptStudyCollaboration 
+  if (!isUserTestAdmin.value && user.value) {
     await store.dispatch('acceptStudyCollaboration', {
       test: test.value,
       cooperator: user.value,
@@ -640,12 +669,14 @@ const startTest = async () => {
   }
 
   // Primero añadimos la clase para la animación de salida
+  // First we add a CSS class to trigger the 'leaving'(exit) animation
   const startScreen = document.querySelector('.start-screen');
   if (startScreen) {
     startScreen.classList.add('leaving');
   }
 
   // Esperamos a que termine la animación antes de cambiar el estado
+  // We wait for the animation to complete before hiding the start screen
   setTimeout(() => {
     start.value = false;
   }, 1000);
@@ -1042,7 +1073,7 @@ onMounted(async () => {
   globalIndex.value = 0;
   // validateTest();
   await nextTick();
-  if (user.value) {
+  if (user.value && !user.value.isAnonymous) {
     await setTest();
     await autoComplete();
     calculateProgress();

--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -584,7 +584,7 @@ const saveAnswer = async () => {
       localTestAnswer.userDocId = user.value.id;
       localTestAnswer.invited = true;
     }
-    if (!user.value) {
+    if (!user.value ||  user.value.isAnonymous) {
       localTestAnswer.userDocId = nanoid(16)
       await store.dispatch('saveTestAnswer', {
         data: localTestAnswer,
@@ -593,6 +593,7 @@ const saveAnswer = async () => {
       });
       await store.dispatch('logout');
       router.push('/signin');
+      return;
     } else {
       Object.assign(currentUserTestAnswer.value, localTestAnswer);
       console.log('Generated userDocId for anonymous user:', currentUserTestAnswer.value);
@@ -1070,6 +1071,7 @@ watch(
 );
 
 onMounted(async () => {
+  fromlink.value = true;
   globalIndex.value = 0;
   // validateTest();
   await nextTick();

--- a/src/views/public/TestView.vue
+++ b/src/views/public/TestView.vue
@@ -7,7 +7,11 @@
       />
     </div>
     <div v-if="test.testType == STUDY_TYPES.USER && test.subType === USER_STUDY_SUBTYPES.UNMODERATED">
-      <UserTestView />
+      <!-- id and token were not passed to UserTestView  -->
+      <UserTestView
+        :id="id"
+        :token="token"
+      />
     </div>
     <div v-if="test.testType === STUDY_TYPES.USER && test.subType === USER_STUDY_SUBTYPES.MODERATED">
       <ModeratedTestView
@@ -21,9 +25,11 @@
 <script setup>
 import { ref, computed, onBeforeMount } from 'vue'
 import { useStore } from 'vuex'
+import { useRouter} from 'vue-router'
 import UserTestView from '@/ux/UserTest/views/UserTestView.vue'
 import ModeratedTestView from '../../ux/UserTest/views/ModeratedTestView.vue'
 import HeuristicTestView from '../../ux/Heuristic/views/HeuristicTestView.vue'
+import validateStudyAccess from '@/shared/utils/studyValidation';
 import { STUDY_TYPES, USER_STUDY_SUBTYPES } from '@/shared/constants/methodDefinitions'
 
 const props = defineProps({
@@ -32,12 +38,38 @@ const props = defineProps({
 })
 
 const store = useStore()
-
+const router = useRouter()
 const test = computed(() => store.getters.test)
 const moderatedTestViewRef = ref(null)
 
+const handleInvalidAccess = async(message) => {
+  console.error(message)
+  store.commit('SET_TOAST', {message, type: "error"});
+  await store.dispatch('logout');
+  router.push('/signin');
+}
+
 onBeforeMount(async () => {
-  await store.dispatch('getStudy', { id: props.id })
+  try {
+    const user = await store.dispatch('signInAnonymously');
+    console.log(user, "user from TestView.vue");
+  } catch (error) {
+    await handleInvalidAccess("Unable to start guest session. Please try again.");
+    return; // end here
+  }
+  const study = await store.dispatch('getStudy', { id: props.id });
+  if (!study) {
+    await handleInvalidAccess("Test not found, Invalid URL");
+    return; 
+  }
+
+  const hasAccess = validateStudyAccess(study, props.token);
+  if (!hasAccess) {
+    await handleInvalidAccess("Invalid Token, Access Denied");
+    return;
+  }
+  console.log(props.id, "id");
+  console.log(study, "study loaded successfully from TestView.vue");
   await store.dispatch('getCurrentTestAnswerDoc')
 })
 </script>


### PR DESCRIPTION
### Summary:

Fixing the issue by initially signing in the unknown user (anonymously), hence providing the access to fetch the respective Test document from firestore (only works if user is logged-in), also storing the taskAnswers using nanoId.

***

**Flow (after fix):**

Test Link → `TestView.vue` → `Auth.js` → `AuthContoller.js` → `TestView.vue` → `Study.js` → `StudyController.js` → `Firestore` → `TestView.vue` → `UserTestView.vue`


https://github.com/user-attachments/assets/460bb5d1-a922-4097-940c-34550bce82c2

https://github.com/user-attachments/assets/3a03c60f-6a10-4914-baac-5eaca1e00e89





### **Root Cause:**

The reason why an unknown user wasn’t able to take the test is that there was no implementation of sign-in for the unknown user. The user needs to be signed-in to actually access Firestore (the DB), hence we were not able to access or use the study from Firestore, and it was silently failing (which was the minor bug) and not properly handled in the catch block. That’s why unknown users were not able to access those user tests (chicken and egg problem).

**Previous flow (before fix):**

Test Link → `TestView.vue` → Tries to fetch study → Firebase blocks the request (no access) → `getStudy` from `Study.js` returns `undefined` → no Test shown.



https://github.com/user-attachments/assets/5107e60f-eaf2-478e-8891-9567b8f65022


***

**Fix:**

### Changes in `TestView.vue`

- As soon as the user accesses `/testview` with `testId` and `token` (not required in case of public test), the user is signed in anonymously.  
- Only then the user is authorized to fetch the study with `testId`, and the study is assigned in the store as globally accessible (no namespace), so the user value is used everywhere.  
- Before actually loading the userTest through the child component `<UserTestView />`, the `testId` and `token` are validated using `validateStudyAccess` (from `studyValidation.js`), and the store action `getStudy` is fetched using `testId`.  


### Changes in `UserTestView.vue`

- Added an additional dialog to distinguish between logged-in users and unknown users, using `user.isAnonymous`.  
- After an unknown user takes the test, they are signed out and pushed to the sign-in page using `router.push('/signin');` (this route can be changed if needed).

### Changes in `Auth.js`

- Defined `signInAnonymously` action in the store, which gracefully calls `authController.signInAnonymously()` and handles/shows any errors gracefully.

### Changes in `AuthController.vue`

- Handling the real implementation of `signInAnonymously` .

### Changes in `AnswerController.vue`

- Slightly changed the `userDocId` generation logic for assigning the `TaskAnswer` respectively.  
- Previously it was sequential-index based (`Ev1`, `Ev2`, …) with \(O(N)\) lookup; now it uses `const tempId = nanoid(16)` which is safer, simpler, gives \(O(1)\) lookup, and allows storing the unknown user’s data even after the user is signed out.


https://github.com/user-attachments/assets/9e8253df-522c-4fef-adc9-f997077a077b



### Changes in `Study.js`

- Added a getter `isPublic` in the store, to understand whether the Test is public or not (used in `studyValidation.js` to appropriately provide access to each type).  

### Created `studyValidation.js`

- Handles study token validation for unknown users using `validateStudyAccess`, which is called in `TestView.vue` (the parent component).  

***

I’m glad to help with this and happy to keep contributing.
While working on this fix, I also noticed a couple of small bugs and edge cases that we can look at in future PRs if you want.
If you see any better way to handle the auth or validation logic, I’m totally open to your feedback and happy to update the PR.








Fix #1010