### PR TITLE
Fix(Bug) : Logout button inaccessible on tablet and mobile views

### DIFF
--- a/src/features/navigation/components/DashboardSidebar.vue
+++ b/src/features/navigation/components/DashboardSidebar.vue
@@ -68,6 +68,24 @@
   {{ $t('Dashboard.createNewTest') }}
       </v-btn>
     </div>
+
+    <v-hover v-slot="{ isHovering }">
+      <div class="px-4 pb-4 d-lg-none">
+        <v-btn
+          color="error"
+          block
+          size="large"
+          prepend-icon="mdi-logout"
+          rounded="lg"
+          elevation="1"
+          class="logout-button"
+          :class="{ 'logout-hover': isHovering }"
+          @click="signOut"
+        >
+          {{ $t('buttons.signout') }}
+        </v-btn>
+      </div>
+    </v-hover>
   </v-navigation-drawer>
 </template>
 
@@ -75,9 +93,14 @@
 import { computed } from 'vue';
 import { useDisplay } from 'vuetify';
 import { dashboardNavigationItems } from '@/features/dashboard';
+import { useStore } from 'vuex'
+import { useRouter } from 'vue-router'
 
 // Composables
 const { mobile } = useDisplay();
+
+const store = useStore()
+const router = useRouter()
 
 // Props
 const props = defineProps({
@@ -104,6 +127,11 @@ const isOpen = computed({
     get: () => props.modelValue,
     set: (value) => emit('update:modelValue', value)
 });
+
+const signOut = async () => {
+  await store.dispatch('logout');
+  router.push('/').catch(() => {});
+};
 
 // Para el drawer: en desktop siempre true, en mobile controlado por modelValue
 const drawerState = computed({
@@ -216,4 +244,16 @@ const selectNavigation = (sectionId, childId = null) => {
     font-size: 18px;
     margin-right: 12px;
 }
+
+.logout-button {
+  text-transform: none !important;
+  letter-spacing: normal !important;
+  font-weight: 600 !important;
+  transition: transform 0.2s ease-in-out !important;
+}
+
+.logout-button:hover {
+  transform: translateY(-2px);
+}
+
 </style>


### PR DESCRIPTION
# Fix: Logout action inaccessible on medium & mobile screens

## Summary
This PR resolves [ #1030 ] an accessibility issue where users on **medium-sized screens (768px–1279px)** and **mobile dashboards** were unable to access any logout control.  
Previously, logout was only available through the top `UserMenu` on large screens, leaving users effectively stuck in sessions when the UI collapsed.

This update ensures logout is always reachable across all device sizes.

---

## Key Changes
### Navigation Drawer
- Added a responsive **Logout** button positioned at the bottom of the sidebar.
- Visible only on **mobile and medium screens** using `d-lg-none`.
- Uses identical styling and hover behavior as the existing **Create New Test** button.
- No impact on desktop UI/UX.

### UserMenu (Desktop)
- Logout option continues unchanged for `lg` and above within the navbar.

---

## Result
| Screen Size | Logout Availability |
|------------|---------------------|
| Desktop (≥1280px) | Top `UserMenu` |
| Medium (768px–1279px) | Sidebar Logout button |
| Mobile (<768px) | Sidebar Logout button |

---

## Screenshots

### Before
<img width="1920" height="926" alt="Screenshot (304)" src="https://github.com/user-attachments/assets/6fa2083a-ddbd-4a06-8169-e0352415dfff" />
<img width="1920" height="931" alt="Screenshot (300)" src="https://github.com/user-attachments/assets/fb24892c-1cfe-47b8-a289-5b32a8dcae01" />
<img width="1920" height="922" alt="Screenshot (303)" src="https://github.com/user-attachments/assets/4b9c3b18-15d9-4a4a-878b-7e45a1bbc0ba" />

### After
<img width="1920" height="921" alt="Screenshot (305)" src="https://github.com/user-attachments/assets/4f2b4514-e376-4b0d-85af-a95e9dd998ff" />
<img width="1920" height="954" alt="Screenshot (301)" src="https://github.com/user-attachments/assets/e81da6e0-e7cf-42d2-9980-aa1259711105" />
<img width="1920" height="927" alt="Screenshot (302)" src="https://github.com/user-attachments/assets/43e2ab66-118b-45ed-a5a0-dff8ec7ebd36" />

---

## Steps to Reproduce
1. Log in
2. Navigate to `/admin` (Dashboard)
3. Resize browser window to around **1000px** width or open on mobile
4. Observe missing logout control (before), now accessible (after)

---

`If maintainers prefer an alternative UI/UX approach, such as placing logout in the mobile navbar directly, I’m open to adjusting as needed`
