### PR TITLE
feat: allow inviting collaborators without existing accounts

### DIFF
--- a/src/shared/components/dialogs/InviteDialog.vue
+++ b/src/shared/components/dialogs/InviteDialog.vue
@@ -168,10 +168,6 @@ const isStringEmail = (email) => {
     return typeof email !== 'object' && email !== undefined && email.length > 0;
 };
 
-const isUserEmailValid = (email) => {
-    return props.users.find(user => user.email === email);
-};
-
 const isCoopAlreadySelected = (emailToCheck) => {
     return selectedCoops.value.find(
         coop => (typeof coop === 'object' ? coop.email : coop) === emailToCheck
@@ -188,11 +184,6 @@ const validateEmail = () => {
     if (isStringEmail(email)) {
         if (!isValidEmail(email)) {
             toast.error('Invalid email format');
-            return;
-        }
-
-        if (!isUserEmailValid(email)) {
-            toast.error(`${email} is not a valid email or does not exist`);
             return;
         }
 


### PR DESCRIPTION
Summary
This PR improves the collaborator invitation flow so that project owners can invite people by email even if they don’t have a RUXAILAB account yet.

**Fixed issue**: #1035 

### Changes

 - Updated src/shared/components/dialogs/InviteDialog.vue to allow free-text email input in the invitation combobox.
 - Relaxed validation to only check email format, without requiring the email to exist in the users list.

Existing backend/Firestore logic already supports cooperators with userDocId: null, and the email function sends invites to any email, so no backend changes were needed.