### PR TITLE
fix(profile): Country autocomplete not filtering due to incorrect customFilter signature

### DIFF
--- a/src/features/auth/views/ProfileView.vue
+++ b/src/features/auth/views/ProfileView.vue
@@ -919,11 +919,18 @@ const signOut = async () => {
   }
 };
 
-const countryFilter = (item, queryText) => {
+const countryFilter = (value, queryText, item) => {
   if (!queryText) return true;
 
-  const searchText = queryText.toLowerCase();
-  const countryName = item.name.toLowerCase();
+  const searchText = queryText.toString().toLowerCase();
+
+  const nameSource = 
+    item?.raw?.name ??
+    item?.name ??
+    (typeof value === 'string' ? value : value?.name) ??
+    '';
+
+  const countryName = nameSource.toString().toLowerCase();
   return countryName.includes(searchText);
 };
 


### PR DESCRIPTION
### Summary

This PR fixes a bug in the Edit Profile → Country selection where typing a country name (e.g., “India”) showed no results, and the console logged errors such as:

```bash
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
```

This issue occurred because Vuetify 3 passes parameters to `custom-filter` as:
```bash
(value, queryText, item)
```

but the existing filter function was written as:
```bash
(item, queryText)
```

**This mismatch caused**:

- `item` to not contain `raw.name`,
- `countryName` to be empty,
- filtering to always return `false`,
- UI showing **“No data available”**.

### Fixed issue: #1052 

### Fix Implemented

- Updated the `countryFilter()` function to correctly use the Vuetify signature.
- Extracted the country name properly using:

  - `item.raw.name`
  - fallback to `item.name` or string value

- Ensured safe `.toLowerCase()` handling.

- Verified filtering works for all countries.

### Demo Video
[Proper explanation video](https://app.screencastify.com/watch/XqXjNroT9JLfYdrtXOSa?checkOrg=949cc443-06d8-4c77-b968-497e4bd6da2a)
shows:
- Typing countries (e.g., India)
- Proper filtering
- No console errors
