### PR TITLE
fix: prevent toast on page reload

### DIFF
--- a/src/features/auth/store/Auth.js
+++ b/src/features/auth/store/Auth.js
@@ -82,10 +82,27 @@ export default {
 
     async signin({ commit }, payload) {
       commit('setLoading', true)
+
       try {
-        await authController.signIn(payload.email, payload.password, payload.rememberMe)
+        const { user } = await authController.signIn(
+          payload.email,
+          payload.password,
+          payload.rememberMe
+        )
+
+        const dbUser = await userController.getById(user.uid)
+
+        commit('SET_USER', dbUser)
+
+        commit('SET_TOAST', {
+          message: i18n.global.t('auth.loginSuccess'),
+          type: 'success',
+        })
+
       } catch (err) {
         toast.error(i18n.global.t('errors.incorrectCredential'))
+      } finally {
+        commit('setLoading', false)
       }
     },
 
@@ -159,10 +176,6 @@ export default {
 
         const dbUser = await userController.getById(user.uid)
         commit('SET_USER', dbUser)
-        commit('SET_TOAST', {
-          message: i18n.global.t('auth.loginSuccess'),
-          type: 'success',
-        })
       } catch (e) {
         console.error(e)
         commit('SET_TOAST', {


### PR DESCRIPTION
## Description
Fixes inconsistent login toast behavior by removing the toast from autoSignIn() and adding the missing success toast + user commit to the email/password login flow.

## Related Issue
Fixes #1053

## Changes
- Removed login success toast from `autoSignIn()` so it **no longer shows on page reload**.
- Updated `signin()` action to fetch the DB user, commit `SET_USER`, and display the login success toast.