### PR TITLE
make profile inputs non-focusable when readonly

### DIFF
--- a/src/features/auth/views/ProfileView.vue
+++ b/src/features/auth/views/ProfileView.vue
@@ -147,6 +147,7 @@
                           density="compact"
                           prepend-inner-icon="mdi-account"
                           readonly
+                          :class="{ 'no-interact': !editProfileDialog }"
                           class="input-field-transition"
                         />
                       </v-col>
@@ -161,6 +162,7 @@
                           density="compact"
                           prepend-inner-icon="mdi-email"
                           readonly
+                          :class="{ 'no-interact': !editProfileDialog }"
                           class="input-field-transition"
                         />
                       </v-col>
@@ -175,6 +177,7 @@
                           density="compact"
                           prepend-inner-icon="mdi-phone"
                           readonly
+                          :class="{ 'no-interact': !editProfileDialog }"
                           class="input-field-transition"
                         />
                       </v-col>
@@ -189,6 +192,7 @@
                           density="compact"
                           prepend-inner-icon="mdi-map-marker"
                           readonly
+                          :class="{ 'no-interact': !editProfileDialog }"
                           class="input-field-transition"
                         />
                       </v-col>
@@ -937,3 +941,25 @@ onUnmounted(() => {
   window.removeEventListener('resize', checkScreenSize);
 });
 </script>
+
+<style scoped>
+.no-interact {
+  pointer-events: none;
+  outline: none;
+}
+.no-interact :deep(.v-field__overlay) {
+    opacity: 0 !important;
+}
+.no-interact :deep(.v-field__outline) {
+    border-color: transparent !important;
+}
+.no-interact :deep(.v-field__outline)::before {
+    border-color: transparent !important;
+}
+.no-interact :deep(.v-field__outline)::after {
+    border-color: transparent !important;
+}
+.no-interact :deep(.v-field__input) {
+    color: inherit !important;
+}
+</style>


### PR DESCRIPTION
### **Summary**

This PR fixes a UI bug on the Profile page where input fields (username, email, contact number, country) were still focusable even when the user had not enabled Edit mode. This created a confusing experience because the cursor appeared inside the fields even though editing was not allowed.

**Fixes #1056**

### **Changes**

- Prevent input fields from receiving focus when the profile is not in Edit mode.
- Ensures that readonly fields behave consistently and feel non-interactive until Edit Details is clicked.

### **Before**

- Profile form fields could be clicked and focused.
- Cursor appeared inside readonly fields even though typing was not allowed.
- Resulted in inconsistent UX on the Profile page.

https://github.com/user-attachments/assets/62bee0ca-9625-4430-83ef-4b4ac3ba477c

### **After**

- Readonly fields no longer accept focus or interaction.
- Fields behave correctly based on whether Edit mode is enabled.
- Improved clarity and consistency in the Profile page UI.
- 

https://github.com/user-attachments/assets/5b2dd4f3-10ca-4cfe-ba2a-53d132314ecc
