### PR TITLE
fix: v-textarea label overlapping placeholder text on initial render

### DIFF
--- a/src/assets/vuetify-fixes.css
+++ b/src/assets/vuetify-fixes.css
@@ -1,0 +1,26 @@
+/*
+   V-TEXTAREA LABEL AND PLACEHOLDER FIX
+   Prevents label from overlapping placeholder on initial render
+*/
+.v-textarea .v-field:not(.v-field--focused):not(.v-field--active):not(.v-field--dirty) .v-field__input::placeholder {
+  opacity: 0 !important;
+}
+
+.v-textarea .v-field--focused .v-field__input::placeholder,
+.v-textarea .v-field--active .v-field__input::placeholder,
+.v-textarea .v-field--dirty .v-field__input::placeholder {
+  opacity: 0.6;
+  transition: opacity 0.2s ease 0.1s;
+}
+
+.v-textarea .v-label {
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.v-textarea .v-field--focused .v-label,
+.v-textarea .v-field--active .v-label,
+.v-textarea .v-field--dirty .v-label,
+.v-textarea .v-label.v-field-label--floating {
+  transform: translateY(-50%) scale(0.85) !important;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import TextClamp from 'vue3-text-clamp';
 import { quillEditor } from 'vue3-quill'
 import 'vue-toastification/dist/index.css';
 import '@vueup/vue-quill/dist/vue-quill.snow.css'
+import './assets/vuetify-fixes.css'
 
 const app = createApp(App);
 


### PR DESCRIPTION
## Description
Fixes v-textarea label overlapping placeholder text on initial render.

## Related Issue
Fixes #1065

## Changes
- `src/assets/vuetify-fixes.css` - New global styles for textarea fix
- `src/main.js` - Import global CSS

## Screenshots
<img width="366" height="163" alt="fix" src="https://github.com/user-attachments/assets/8b06cc52-1b12-42e5-bf0b-2f7daf151831" />
