### PR TITLE
fix(#1072) : UI breaks on Create Study steps and overlapping Stepper header text in small screen

### DIFF
--- a/src/features/ux_creation/Choose.vue
+++ b/src/features/ux_creation/Choose.vue
@@ -21,13 +21,15 @@
         <v-col
           v-for="category in categories"
           :key="category.id"
-          cols="3"
+          cols="12"
+          sm="6"
+          md="3"
         >
           <SelectableCard
             :selected="selectedCategory === category.id"
             :icon="category.icon"
             :title="category.title"
-            text-class="pa-8 text-center"
+            text-class="pa-4 pa-sm-8 text-center"
             :description="category.description"
             :color="category.color"
             :disabled="category.comingSoon"

--- a/src/features/ux_creation/ChooseStudyMethods.vue
+++ b/src/features/ux_creation/ChooseStudyMethods.vue
@@ -12,7 +12,7 @@
 
       <!-- Methods Grid -->
       <v-row justify="center" class="mb-8">
-        <v-col v-for="method in availableMethods" :key="method.id" cols="12" md="6" lg="5">
+        <v-col v-for="method in availableMethods" :key="method.id" cols="12" sm="6" md="6" lg="5">
           <SelectableCard
             :selected="selectedMethod === method.id"
             :icon="method.icon"

--- a/src/features/ux_creation/ChooseStudyType.vue
+++ b/src/features/ux_creation/ChooseStudyType.vue
@@ -12,7 +12,7 @@
 
       <!-- Options Grid -->
       <v-row justify="center" class="mb-8">
-        <v-col v-for="option in options" :key="option.id" cols="12" md="6" lg="5">
+        <v-col v-for="option in options" :key="option.id" cols="12" sm="6" md="6" lg="5">
           <SelectableCard
             :selected="selectedOption === option.id"
             :icon="option.icon"

--- a/src/features/ux_creation/StepperHeader.vue
+++ b/src/features/ux_creation/StepperHeader.vue
@@ -12,7 +12,7 @@
         <v-stepper-item
           :complete="step.complete"
           :value="step.value"
-          :title="step.title"
+          :title="resolvedTitle(step)"
           :color="step.complete ? 'success' : step.value === currentStep ? 'primary' : ''"
         />
         <v-divider v-if="index < steps.length - 1" />
@@ -22,8 +22,17 @@
 </template>
 
 <script setup>
-defineProps({
+import { useDisplay } from 'vuetify'
+
+const props = defineProps({
   steps: Array,
   currentStep: Number
 })
+
+const { xs } = useDisplay()
+
+const resolvedTitle = (step) =>
+  xs.value && step.value !== props.currentStep
+    ? ''
+    : step.title
 </script>

--- a/src/features/ux_creation/StudyDetailsForm.vue
+++ b/src/features/ux_creation/StudyDetailsForm.vue
@@ -134,7 +134,6 @@
                           {{ test.isPublic ? $t('studyCreation.details.visibleToEveryone') : $t('studyCreation.details.onlyInvitedUsers') }}
                         </v-list-item-subtitle>
                       </v-list-item>
-                      
                       <!-- Switch on separate row -->
                       <div class="d-flex justify-center">
                         <v-switch
@@ -156,23 +155,28 @@
             <v-col cols="12">
               <v-card class="custom-card" elevation="4">
                 <v-card-text class="pa-6">
-                  <div class="d-flex justify-space-between align-center">
-                    <BackButton
-                      :label="$t('studyCreation.backToStudyType')"
-                      adjust="start"
-                      @back="goBack"
-                    />
-                    
-                    <v-btn
-                      color="success"
-                      size="large"
-                      :loading="isLoading"
-                      prepend-icon="mdi-plus"
-                      class="px-8"
-                      @click="validate"
-                    >
-                      {{ $t('studyCreation.createStudy') }}
-                    </v-btn>
+                  <div class="d-flex flex-column-reverse flex-sm-row justify-sm-space-between align-sm-center">
+                    <!-- Back button (goes below on mobile) -->
+                    <div class="w-100 w-sm-auto mt-3 mt-sm-0">
+                      <BackButton
+                        :label="$t('studyCreation.backToStudyType')"
+                        adjust="start"
+                        @back="goBack"
+                      />
+                    </div>
+
+                    <!-- Create button (goes above on mobile) -->
+                    <div class="w-100 w-sm-auto">
+                      <v-btn
+                        color="success"
+                        size="large"
+                        :loading="isLoading"
+                        prepend-icon="mdi-plus"
+                        block
+                        @click="validate">
+                        {{ $t('studyCreation.createStudy') }}
+                      </v-btn>
+                    </div>
                   </div>
                 </v-card-text>
               </v-card>
@@ -298,7 +302,7 @@ const submitAccessibility = async () => {
 
   isLoading.value = true;
   const user = store.getters.user;
-  
+
   const rawData = {
     id: null,
     title: test.value.title,
@@ -321,10 +325,10 @@ const submitAccessibility = async () => {
   try {
     const newTest = instantiateStudyByType(testType, rawData);
     const testId = await store.dispatch('createStudy', newTest);
-    
+
     isLoading.value = false;
     store.commit('RESET_STUDY_DETAILS');
-    
+
     if (selectedMethod === 'AUTOMATIC') {
       router.push(`/accessibility/automatic/${testId}`);
     } else {

--- a/src/features/ux_creation/components/BackButton.vue
+++ b/src/features/ux_creation/components/BackButton.vue
@@ -1,9 +1,10 @@
 <template>
   <v-row :justify="adjust">
-    <v-col cols="auto">
+    <v-col cols="12" sm="auto">
       <v-btn
         variant="outlined"
         :prepend-icon="icon"
+        class="w-100 w-sm-auto"
         @click="onBack"
       >
         {{ label }}


### PR DESCRIPTION
Fixes : #1072 

Before : 
<img width="1920" height="1080" alt="Screenshot (331)" src="https://github.com/user-attachments/assets/fccb39ad-29b1-4d5c-b352-df883eb118e5" />

After :
<img width="1920" height="1080" alt="Screenshot (333)" src="https://github.com/user-attachments/assets/349b0c31-76af-4487-beaa-096679ce323a" />

Video : { in this video i make a comparsion between after and before }

https://github.com/user-attachments/assets/6700bd22-628a-44be-a283-8a1579a7f361


- Make the Create-test screen readable for small screen .
- Updated the StepperHeader to use Vuetify’s `useDisplay()` breakpoint utility.
- Ensure consistent and readable stepper behavior across all screen sizes .
- Fix grid layouts to improve alignment and spacing across breakpoints .