### PR TITLE
fix: remove duplicate autoSignIn() method

### DIFF
--- a/src/features/auth/controllers/AuthController.js
+++ b/src/features/auth/controllers/AuthController.js
@@ -95,22 +95,6 @@ export default class AuthController {
     })
   }
 
-  async autoSignIn() {
-    return new Promise((resolve, reject) => {
-      const unsubscribe = onAuthStateChanged(
-        auth,
-        (user) => {
-          unsubscribe()
-          resolve(user)
-        },
-        (error) => {
-          unsubscribe()
-          reject(error)
-        }
-      )
-    })
-  }
-
   async deleteAuth(userId) {
     try {
       await axios.post(process.env.VUE_APP_CLOUD_FUNCTIONS_URL + '/deleteAuth', { data: { userId } })


### PR DESCRIPTION
**Description:**
Removed the duplicated `autoSignIn()` method from `AuthController` to prevent silent method override and ensure predictable auth behavior.

**Related Issue:**
Fixes: #1085 