### PR TITLE
test: add unit tests for AuthController, UserController, AnswerContro…

### DIFF
--- a/tests/unit/AnswerController.spec.js
+++ b/tests/unit/AnswerController.spec.js
@@ -1,0 +1,133 @@
+import AnswerController from '@/shared/controllers/AnswerController'
+
+jest.mock('firebase/firestore', () => ({
+    doc: jest.fn(),
+    updateDoc: jest.fn(),
+    collection: jest.fn(),
+    getDocs: jest.fn(),
+    getDoc: jest.fn(),
+    addDoc: jest.fn(),
+    deleteDoc: jest.fn(),
+    increment: jest.fn((val) => ({ _increment: val }))
+}))
+
+jest.mock('@/app/plugins/firebase', () => ({
+    db: {}
+}))
+
+jest.mock('../../src/features/auth/controllers/UserController', () => {
+    return jest.fn().mockImplementation(() => ({
+        getById: jest.fn(),
+        update: jest.fn()
+    }))
+})
+
+jest.mock('@/shared/constants/methodDefinitions', () => ({
+    instantiateStudyAnswerByType: jest.fn((type, data) => data),
+    STUDY_TYPES: {
+        HEURISTIC: 'HEURISTIC',
+        USER: 'USER'
+    }
+}))
+
+jest.mock('@/ux/UserTest/models/UserStudyEvaluatorAnswer', () => {
+    return jest.fn().mockImplementation((data) => ({
+        ...data,
+        toFirestore: jest.fn().mockReturnValue(data)
+    }))
+})
+
+describe('AnswerController', () => {
+    let answerController
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        answerController = new AnswerController()
+    })
+
+    describe('Structure', () => {
+        it('should have getAnswerById method', () => {
+            expect(typeof answerController.getAnswerById).toBe('function')
+        })
+
+        it('should have createAnswer method', () => {
+            expect(typeof answerController.createAnswer).toBe('function')
+        })
+
+        it('should have updateUserAnswer method', () => {
+            expect(typeof answerController.updateUserAnswer).toBe('function')
+        })
+
+        it('should have removeUserAnswer method', () => {
+            expect(typeof answerController.removeUserAnswer).toBe('function')
+        })
+
+        it('should have saveTestAnswer method', () => {
+            expect(typeof answerController.saveTestAnswer).toBe('function')
+        })
+
+        it('should have updateTaskAnswer method', () => {
+            expect(typeof answerController.updateTaskAnswer).toBe('function')
+        })
+
+        it('should have updateTaskTranscriptionMeta method', () => {
+            expect(typeof answerController.updateTaskTranscriptionMeta).toBe('function')
+        })
+    })
+
+    describe('createAnswer', () => {
+        it('should call parent create with correct collection', async () => {
+            const mockPayload = {
+                type: 'HEURISTIC',
+                toFirestore: jest.fn().mockReturnValue({ type: 'HEURISTIC' })
+            }
+            const createSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(answerController)), 'create')
+                .mockResolvedValue({ id: 'new-answer-id' })
+
+            const result = await answerController.createAnswer(mockPayload)
+
+            expect(createSpy).toHaveBeenCalledWith('answers', { type: 'HEURISTIC' })
+            expect(result).toEqual({ id: 'new-answer-id' })
+
+            createSpy.mockRestore()
+        })
+
+        it('should throw error when create fails', async () => {
+            const mockError = new Error('Create failed')
+            const mockPayload = {
+                toFirestore: jest.fn().mockReturnValue({})
+            }
+            const createSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(answerController)), 'create')
+                .mockRejectedValue(mockError)
+
+            await expect(answerController.createAnswer(mockPayload)).rejects.toThrow(mockError)
+
+            createSpy.mockRestore()
+        })
+    })
+
+    describe('updateTaskTranscriptionMeta', () => {
+        it('should call update with correct field paths', async () => {
+            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(answerController)), 'update')
+                .mockResolvedValue()
+
+            await answerController.updateTaskTranscriptionMeta({
+                answerDocId: 'answer-123',
+                userDocId: 'user-456',
+                taskId: 'task-1',
+                latestId: 'transcription-789',
+                inc: 1
+            })
+
+            expect(updateSpy).toHaveBeenCalledWith(
+                'answers',
+                'answer-123',
+                expect.objectContaining({
+                    'taskAnswers.user-456.tasks.task-1.latestTranscriptionDocId': 'transcription-789'
+                })
+            )
+
+            updateSpy.mockRestore()
+        })
+    })
+})

--- a/tests/unit/AuthController.spec.js
+++ b/tests/unit/AuthController.spec.js
@@ -1,0 +1,158 @@
+import AuthController from '@/features/auth/controllers/AuthController'
+import {
+    createUserWithEmailAndPassword,
+    onAuthStateChanged,
+    setPersistence,
+    signInWithEmailAndPassword,
+    signInWithPopup,
+    signOut
+} from 'firebase/auth'
+
+jest.mock('firebase/auth', () => ({
+    createUserWithEmailAndPassword: jest.fn(),
+    signInWithEmailAndPassword: jest.fn(),
+    signOut: jest.fn(),
+    onAuthStateChanged: jest.fn(),
+    signInWithPopup: jest.fn(),
+    GoogleAuthProvider: jest.fn(),
+    sendPasswordResetEmail: jest.fn(),
+    setPersistence: jest.fn(),
+    browserLocalPersistence: 'local',
+    browserSessionPersistence: 'session'
+}))
+
+jest.mock('@/app/plugins/firebase', () => ({
+    auth: { currentUser: { uid: 'test-uid', email: 'test@example.com' } }
+}))
+
+jest.mock('@/shared/controllers/EmailController', () => {
+    return jest.fn().mockImplementation(() => ({
+        send: jest.fn().mockResolvedValue({ success: true })
+    }))
+})
+
+jest.mock('axios', () => ({
+    post: jest.fn()
+}))
+
+describe('AuthController', () => {
+    let authController
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        authController = new AuthController()
+    })
+
+    describe('signUp', () => {
+        it('should call createUserWithEmailAndPassword with correct parameters', async () => {
+            const mockCredential = { user: { uid: 'new-user-id' } }
+            createUserWithEmailAndPassword.mockResolvedValue(mockCredential)
+
+            const result = await authController.signUp('test@example.com', 'password123')
+
+            expect(createUserWithEmailAndPassword).toHaveBeenCalledWith(
+                expect.anything(),
+                'test@example.com',
+                'password123'
+            )
+            expect(result).toEqual(mockCredential)
+        })
+
+        it('should throw error when createUserWithEmailAndPassword fails', async () => {
+            const mockError = new Error('Email already in use')
+            createUserWithEmailAndPassword.mockRejectedValue(mockError)
+
+            await expect(authController.signUp('test@example.com', 'password123'))
+                .rejects.toThrow(mockError)
+        })
+    })
+
+    describe('signIn', () => {
+        it('should set local persistence when rememberMe is true', async () => {
+            const mockCredential = { user: { uid: 'user-id' } }
+            setPersistence.mockResolvedValue()
+            signInWithEmailAndPassword.mockResolvedValue(mockCredential)
+
+            await authController.signIn('test@example.com', 'password123', true)
+
+            expect(setPersistence).toHaveBeenCalledWith(expect.anything(), 'local')
+            expect(signInWithEmailAndPassword).toHaveBeenCalledWith(
+                expect.anything(),
+                'test@example.com',
+                'password123'
+            )
+        })
+
+        it('should set session persistence when rememberMe is false', async () => {
+            setPersistence.mockResolvedValue()
+            signInWithEmailAndPassword.mockResolvedValue({ user: {} })
+
+            await authController.signIn('test@example.com', 'password123', false)
+
+            expect(setPersistence).toHaveBeenCalledWith(expect.anything(), 'session')
+        })
+
+        it('should throw error when signIn fails', async () => {
+            const mockError = new Error('Invalid credentials')
+            setPersistence.mockResolvedValue()
+            signInWithEmailAndPassword.mockRejectedValue(mockError)
+
+            await expect(authController.signIn('test@example.com', 'wrong', false))
+                .rejects.toThrow(mockError)
+        })
+    })
+
+    describe('signInWithGoogle', () => {
+        it('should set persistence and call signInWithPopup', async () => {
+            const mockCredential = { user: { uid: 'google-user-id' } }
+            setPersistence.mockResolvedValue()
+            signInWithPopup.mockResolvedValue(mockCredential)
+
+            const result = await authController.signInWithGoogle(true)
+
+            expect(setPersistence).toHaveBeenCalledWith(expect.anything(), 'local')
+            expect(signInWithPopup).toHaveBeenCalled()
+            expect(result).toEqual(mockCredential)
+        })
+    })
+
+    describe('signOut', () => {
+        it('should call firebase signOut', async () => {
+            signOut.mockResolvedValue()
+
+            await authController.signOut()
+
+            expect(signOut).toHaveBeenCalled()
+        })
+
+        it('should throw error when signOut fails', async () => {
+            const mockError = new Error('Sign out failed')
+            signOut.mockRejectedValue(mockError)
+
+            await expect(authController.signOut()).rejects.toThrow(mockError)
+        })
+    })
+
+    describe('getCurrentUser', () => {
+        it('should return the current user from auth', async () => {
+            const result = await authController.getCurrentUser()
+
+            expect(result).toEqual({ uid: 'test-uid', email: 'test@example.com' })
+        })
+    })
+
+    describe('autoSignIn', () => {
+        it('should call onAuthStateChanged', async () => {
+            const mockUser = { uid: 'auto-user', email: 'auto@example.com' }
+            onAuthStateChanged.mockImplementation((auth, callback) => {
+                const unsubscribe = jest.fn()
+                setTimeout(() => callback(mockUser), 0)
+                return unsubscribe
+            })
+
+            const result = await authController.autoSignIn()
+
+            expect(onAuthStateChanged).toHaveBeenCalled()
+        })
+    })
+})

--- a/tests/unit/UserController.spec.js
+++ b/tests/unit/UserController.spec.js
@@ -1,0 +1,140 @@
+import UserController from '@/features/auth/controllers/UserController'
+
+jest.mock('firebase/firestore', () => ({
+    doc: jest.fn(),
+    updateDoc: jest.fn(),
+    collection: jest.fn(),
+    getDocs: jest.fn(),
+    getDoc: jest.fn(),
+    setDoc: jest.fn(),
+    deleteDoc: jest.fn(),
+    query: jest.fn(),
+    where: jest.fn(),
+    documentId: jest.fn(() => '__name__')
+}))
+
+jest.mock('firebase/auth', () => ({
+    EmailAuthProvider: {
+        credential: jest.fn()
+    },
+    reauthenticateWithCredential: jest.fn(),
+    updatePassword: jest.fn()
+}))
+
+jest.mock('@/app/plugins/firebase', () => ({
+    db: {}
+}))
+
+describe('UserController', () => {
+    let userController
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        userController = new UserController()
+    })
+
+    describe('Structure', () => {
+        it('should have create method', () => {
+            expect(typeof userController.create).toBe('function')
+        })
+
+        it('should have update method', () => {
+            expect(typeof userController.update).toBe('function')
+        })
+
+        it('should have readAll method', () => {
+            expect(typeof userController.readAll).toBe('function')
+        })
+
+        it('should have getById method', () => {
+            expect(typeof userController.getById).toBe('function')
+        })
+
+        it('should have updateProfile method', () => {
+            expect(typeof userController.updateProfile).toBe('function')
+        })
+
+        it('should have deleteUser method', () => {
+            expect(typeof userController.deleteUser).toBe('function')
+        })
+
+        it('should have changePassword method', () => {
+            expect(typeof userController.changePassword).toBe('function')
+        })
+
+        it('should have addNotification method', () => {
+            expect(typeof userController.addNotification).toBe('function')
+        })
+
+        it('should have markNotificationAsRead method', () => {
+            expect(typeof userController.markNotificationAsRead).toBe('function')
+        })
+
+        it('should have removeTestFromUser method', () => {
+            expect(typeof userController.removeTestFromUser).toBe('function')
+        })
+
+        it('should have updateLevel method', () => {
+            expect(typeof userController.updateLevel).toBe('function')
+        })
+    })
+
+    describe('updateProfile', () => {
+        it('should call update with profile data', async () => {
+            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(userController)), 'update')
+                .mockResolvedValue()
+
+            const payload = {
+                username: 'newusername',
+                contactNo: '1234567890',
+                country: 'US'
+            }
+
+            await userController.updateProfile('user-123', payload)
+
+            expect(updateSpy).toHaveBeenCalledWith('users', 'user-123', {
+                username: 'newusername',
+                contactNo: '1234567890',
+                country: 'US'
+            })
+
+            updateSpy.mockRestore()
+        })
+    })
+
+    describe('deleteUser', () => {
+        it('should call delete with user id', async () => {
+            const deleteSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(userController)), 'delete')
+                .mockResolvedValue()
+
+            await userController.deleteUser('user-123')
+
+            expect(deleteSpy).toHaveBeenCalledWith('users', 'user-123')
+
+            deleteSpy.mockRestore()
+        })
+    })
+
+    describe('updateLevel', () => {
+        it('should call update with access level', async () => {
+            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(userController)), 'update')
+                .mockResolvedValue()
+
+            await userController.updateLevel('user-123', 2)
+
+            expect(updateSpy).toHaveBeenCalledWith('users', 'user-123', { accessLevel: 2 })
+
+            updateSpy.mockRestore()
+        })
+
+        it('should throw error when update fails', async () => {
+            const mockError = new Error('Update failed')
+            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(userController)), 'update')
+                .mockRejectedValue(mockError)
+
+            await expect(userController.updateLevel('user-123', 2)).rejects.toThrow(mockError)
+
+            updateSpy.mockRestore()
+        })
+    })
+})


### PR DESCRIPTION
## Summary

This PR adds unit tests for three controllers that currently have no test coverage: AuthController, UserController, and AnswerController.

I'm new to the project and while going through the codebase, I noticed that only 2 of 12 controllers had any tests. I wanted to help improve the test coverage by adding tests for the most important controllers.


## What I Added

1. AuthController tests (tests/unit/AuthController.spec.js)
   - signUp - testing user registration
   - signIn - testing login with remember me option
   - signInWithGoogle - testing Google OAuth login
   - signOut - testing logout
   - getCurrentUser - testing getting current user
   - autoSignIn - testing automatic sign in
   - Also added error handling tests for when things fail

2. UserController tests (tests/unit/UserController.spec.js)
   - Tests that all methods exist (create, update, readAll, getById, etc.)
   - updateProfile - testing profile updates
   - deleteUser - testing user deletion
   - updateLevel - testing access level changes
   - Error handling tests

3. AnswerController tests (tests/unit/AnswerController.spec.js)
   - Tests that all methods exist
   - createAnswer - testing answer creation
   - updateTaskTranscriptionMeta - testing transcription updates
   - Error handling tests


## Test Results

All 35 new tests pass.

Run with: npm test


## Notes

I noticed there are some existing test files with .skip extension (SignIn.spec.skip, AddOption.spec.skip) that are currently disabled. I'm happy to help fix those in a follow-up PR if that would be useful.

Let me know if any changes are needed. Thanks for reviewing!