### PR TITLE
Improve notifications tab UI and active/hover states 

### DIFF
--- a/src/features/notifications/views/NotificationPage.vue
+++ b/src/features/notifications/views/NotificationPage.vue
@@ -8,17 +8,22 @@
           class="rounded-xxl"
           flat
         >
-          <v-row class="ma-0 " justify="space-between">
-            <v-card-title class="text-h5 pl-0"> {{ $t('common.notifications') }}</v-card-title>
-            <v-btn v-if="activeTab === 'unread'"
+          <v-row class="ma-0 mb-4" justify="end">
+            <v-btn
+              v-if="activeTab === 'unread'"
               color="primary"
               :disabled="allRead"
               @click="markAllAsRead"
             >
               Mark all as read
             </v-btn>
-            </v-row>
-          <v-tabs v-model="activeTab" bg-color="secondary">
+          </v-row>
+           <v-tabs
+              v-model="activeTab"
+              bg-color="transparent"
+              hide-slider
+              class="notification-tabs"
+            >
             <v-tab value="unread">{{ $t('common.unread') }}</v-tab>
             <v-tab value="inbox">{{ $t('common.inbox') }}</v-tab>
           </v-tabs>
@@ -223,3 +228,84 @@ const goBack = () => {
   router.go(-1)
 }
 </script>
+<style scoped>
+
+/* Tabs container (pill) */
+:deep(.notification-tabs) {
+  height: 64px;
+  border: 2px solid #cbd5e1;
+  border-radius: 12px;
+  overflow: hidden;
+  background-color: #ffffff;
+  width: 960px;
+  max-width: 100%;
+  margin: 24px auto;
+  ;
+}
+
+/* Slide group fills height */
+:deep(.notification-tabs .v-slide-group),
+:deep(.notification-tabs .v-slide-group__content) {
+  height: 100%;
+}
+
+/* Individual tabs */
+:deep(.notification-tabs .v-tab) {
+  flex: 1;
+  height: 100%;
+  padding: 0 24px !important;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+
+  color: #1f2937;
+  background-color: transparent;
+  border-radius: 0;
+}
+
+/* Inactive hover */
+:deep(.notification-tabs .v-tab:hover:not(.v-tab--selected)) {
+  background-color: #f3f4f6;
+}
+
+/* Active tab */
+:deep(.notification-tabs .v-tab--selected) {
+  background-color: #e53935 !important;
+  color: #ffffff !important;
+}
+
+/* Active + hover */
+:deep(.notification-tabs .v-tab--selected:hover) {
+  background-color: #d32f2f !important;
+}
+
+/* Remove Vuetify overlays */
+:deep(.notification-tabs .v-tab::before),
+:deep(.notification-tabs .v-tab::after) {
+  display: none !important;
+}
+
+/* Remove slider */
+:deep(.v-tabs-slider),
+:deep(.v-tabs-slider-wrapper) {
+  display: none !important;
+}
+
+
+
+:deep(.notification-tabs .v-tab) {
+  font-size: 15px;          /* increase from default */
+  font-weight: 700;
+  letter-spacing: 0.12em;  /* improves readability for uppercase */
+}
+
+/* Active tab text slightly bolder */
+:deep(.notification-tabs .v-tab--selected) {
+  font-size: 16px;
+}
+</style>


### PR DESCRIPTION
Description

This PR improves the Notifications page tab UI to make the active state clearer, more accessible, and visually consistent.
This PR solves issue #1092 

 Changes
	•	Replaced sliding tab indicator with a solid pill-style active tab
	•	Improved Unread / Inbox visual distinction
	•	Fixed active + hover state so the selected tab remains visible
	•	Increased tab width and typography for better layout balance
	•	Removed redundant secondary “Notifications” heading
	•	Scoped styles to avoid affecting tabs elsewhere in the app

 Tested
	•	Verified tab switching between Unread and Inbox
	•	Confirmed hover and active states behave correctly
	•	Checked layout responsiveness on desktop

 Notes
	•	No functional logic changes
	•	UI-only update scoped to NotificationPage.vue

BEFORE
<img width="1512" height="833" alt="image" src="https://github.com/user-attachments/assets/c51a95fd-ffa4-4afa-9f08-a046a79c1aa2" />
<img width="1512" height="833" alt="image" src="https://github.com/user-attachments/assets/7217e078-15bc-4d53-9f20-d8e7528c0f10" />



AFTER
<img width="1506" height="822" alt="Screenshot 2025-12-15 at 6 24 19 PM" src="https://github.com/user-attachments/assets/40f3d293-9e6d-4f96-be36-41ff62c2f653" />
<img width="1506" height="822" alt="Screenshot 2025-12-15 at 6 25 14 PM" src="https://github.com/user-attachments/assets/2e196609-0ba5-46dc-bb91-95aa6c53444b" />
