### PR TITLE
fix: prevent sign-in form submission when fields are empty

### DIFF
--- a/src/features/auth/views/SignInView.vue
+++ b/src/features/auth/views/SignInView.vue
@@ -137,26 +137,26 @@ const rules = {
   required: (v) => !!v || t('errors.passwordRequired'),
 }
 
-const checkForm = () => form.value?.validate()
-
 const onSignIn = async () => {
-  const isValid = await checkForm()
-  if (isValid) {
-    try {
-      store.commit('setLoading', true)
-      loadingType.value = 'signin'
-      await store.dispatch('signin', {
-        email: email.value,
-        password: password.value,
-        rememberMe: rememberMe.value,
-      })
-      await router.push('/admin')
-    } catch (error) {
-      console.error('Authentication error:', error)
-    } finally {
-      loadingType.value = ''
-      store.commit('setLoading', false)
-    }
+  if (!form.value) return
+  
+  const { valid } = await form.value.validate()
+  if (!valid) return
+  
+  try {
+    store.commit('setLoading', true)
+    loadingType.value = 'signin'
+    await store.dispatch('signin', {
+      email: email.value,
+      password: password.value,
+      rememberMe: rememberMe.value,
+    })
+    await router.push('/admin')
+  } catch (error) {
+    console.error('Authentication error:', error)
+  } finally {
+    loadingType.value = ''
+    store.commit('setLoading', false)
   }
 }
 


### PR DESCRIPTION
## Description
Fixes sign-in form validation to properly prevent submission when email/password fields are empty or invalid.

## Related Issue
Fixes: #1098

## Changes
- Updated `onSignIn` function in `SignInView.vue` to properly handle Vuetify 3 validation
- Removed unused `checkForm` helper function