### PR TITLE
fix(security): implement zod schema validation for study data retrival

### DIFF
--- a/src/controllers/StudyController.js
+++ b/src/controllers/StudyController.js
@@ -11,6 +11,21 @@ const COLLECTION = 'tests'
 const answerController = new AnswerController()
 const userController = new UserController()
 
+
+const StudySchema = z.object({
+  id: z.string(),
+
+  testType: z.enum(['USER', 'HEURISTIC', 'CARD_SORTING', 'MANUAL', 'AUTOMATIC']),
+  testTitle: z.string().min(1),
+  testAdmin: z.object({
+    email: z.string().email(),
+    userDocId: z.string()
+  }).passthrough(),
+  creationDate: z.number().optional(),
+  updateDate: z.number().optional(),
+  status: z.string().optional()
+}).passthrough();
+
 export default class StudyController extends Controller {
   constructor() {
     super()
@@ -119,7 +134,14 @@ export default class StudyController extends Controller {
     if (!res.exists()) return null
 
     const rawData = Object.assign({ id: res.id }, res.data())
-    return instantiateStudyByType(rawData.testType, rawData)
+
+    try {
+      const validData = StudySchema.parse(rawData);
+      return instantiateStudyByType(validData.testType, validData)
+    } catch (error) {
+      console.error("CRITICAL: Invalid Study Data found in DB", error);
+      throw new Error(`Study data is corrupted: ${error.message}`);
+    }
   }
 
   async getPublicStudies() {


### PR DESCRIPTION
### Fixes https://github.com/ruxailab/RUXAILAB/issues/1100

### Summary
I added a simple **Zod** check in the controller to validate study data before we use it. This stops the app from crashing if the database returns a broken or missing record, turning a white-screen error into a handled log.

### Addtional changes
**Note:** we could also split this out into a dedicated `schemas/` folder with a global validation helper, but that would be a much larger refactor (around ~250 lines). I stuck to this simpler version for now to fix the security hole quickly, but **I'm happy to switch to the full structure if you prefer that approach. i would like to get the approval before this change..** 
