### PR TITLE
fix: prevent date shifting by using local date formatting

### DIFF
--- a/src/shared/views/SettingsView.vue
+++ b/src/shared/views/SettingsView.vue
@@ -549,7 +549,7 @@ const datePickerModel = computed({
   },
   set(newDate) {
     if (newDate && object.value) {
-      const formattedDate = newDate.toISOString().split('T')[0];
+      const formattedDate = newDate.toLocaleDateString('sv-SE');
       object.value.endDate = formattedDate;
       store.commit('SET_LOCAL_CHANGES', true);
     }


### PR DESCRIPTION
fixes #1112 

This was because the date was being formatted due to `toISOString()` , as it convert the date to utc and timezone shiftes.
fixed this by using local date formatting.




https://github.com/user-attachments/assets/6af6454a-35da-4947-8cd6-9a96479b357f

