### PR TITLE
Fix: incorrect date range when multiple dates are selected 

### DIFF
--- a/src/features/navigation/components/navbarSections/CommunityStudiesSection.vue
+++ b/src/features/navigation/components/navbarSections/CommunityStudiesSection.vue
@@ -56,10 +56,10 @@
                   density="compact"
                   hide-details
                   :placeholder="creationDateRange.length > 1
-                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[1]).toLocaleDateString()}`
+                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[creationDateRange.length - 1]).toLocaleDateString()}`
                     : 'Select range'"
-                  :model-value="creationDateRange[0] && creationDateRange[1]
-                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[1]).toLocaleDateString()}`
+                  :model-value="creationDateRange.length > 1
+                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[creationDateRange.length - 1]).toLocaleDateString()}`
                     : ''"
                   prepend-inner-icon="mdi-calendar"
                 />
@@ -276,10 +276,10 @@ const filteredTests = computed(() => {
 
     // Filter by creation date range
     let inCreationRange = true;
-    if (creationDateRange.value?.length > 2 && test.creationDate) {
+    if (creationDateRange.value?.length > 1 && test.creationDate) {
       const creation = new Date(test.creationDate);
       const start = new Date(creationDateRange.value[0]);
-      const end = new Date(creationDateRange.value.at(-1));
+      const end = new Date(creationDateRange.value[creationDateRange.value.length - 1]);
       inCreationRange = creation >= start && creation <= end;
     }
 

--- a/src/features/navigation/components/navbarSections/CommunityTemplatesSection.vue
+++ b/src/features/navigation/components/navbarSections/CommunityTemplatesSection.vue
@@ -60,10 +60,10 @@
                   density="compact"
                   hide-details
                   :placeholder="creationDateRange.length > 1
-                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[1]).toLocaleDateString()}`
+                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[creationDateRange.length - 1]).toLocaleDateString()}`
                     : 'Select range'"
-                  :model-value="creationDateRange[0] && creationDateRange[1]
-                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[1]).toLocaleDateString()}`
+                  :model-value="creationDateRange.length > 1
+                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[creationDateRange.length - 1]).toLocaleDateString()}`
                     : ''"
                   prepend-inner-icon="mdi-calendar"
                 />
@@ -187,7 +187,7 @@ const filteredTemplates = computed(() =>
     // 📅 Date range filter
     const creationDate = temp.header?.creationDate;
     let inDateRange = true;
-    if (creationDateRange.value.length > 2 && creationDate) {
+    if (creationDateRange.value.length > 1 && creationDate) {
       const date = new Date(creationDate);
       const start = new Date(creationDateRange.value[0]);
       const end = new Date(creationDateRange.value[creationDateRange.value.length - 1]);

--- a/src/features/navigation/components/navbarSections/SessionsSection.vue
+++ b/src/features/navigation/components/navbarSections/SessionsSection.vue
@@ -92,7 +92,7 @@
                   density="compact"
                   hide-details
                   :placeholder="selectedSessionDateRange.length > 1
-                    ? `${new Date(selectedSessionDateRange[0]).toLocaleDateString()} - ${new Date(selectedSessionDateRange[1]).toLocaleDateString()}`
+                    ? `${new Date(selectedSessionDateRange[0]).toLocaleDateString()} - ${new Date(selectedSessionDateRange[selectedSessionDateRange.length - 1]).toLocaleDateString()}`
                     : 'Select range'"
                   prepend-inner-icon="mdi-calendar"
                 />
@@ -240,7 +240,7 @@ const filteredSessions = computed(() => {
 
     // 📅 Date range filter
     let inDateRange = true;
-    if (selectedSessionDateRange.value.length > 2 && session.testDate) {
+    if (selectedSessionDateRange.value.length > 1 && session.testDate) {
       const date = new Date(session.testDate);
       const start = new Date(selectedSessionDateRange.value[0]);
       const end = new Date(selectedSessionDateRange.value[selectedSessionDateRange.value.length - 1]);

--- a/src/features/navigation/components/navbarSections/StudiesSection.vue
+++ b/src/features/navigation/components/navbarSections/StudiesSection.vue
@@ -56,10 +56,10 @@
                   density="compact"
                   hide-details
                   :placeholder="creationDateRange.length > 1
-                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[1]).toLocaleDateString()}`
+                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[creationDateRange.length - 1]).toLocaleDateString()}`
                     : 'Select range'"
-                  :model-value="creationDateRange[0] && creationDateRange[1]
-                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[1]).toLocaleDateString()}`
+                  :model-value="creationDateRange.length > 1
+                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[creationDateRange.length - 1]).toLocaleDateString()}`
                     : ''"
                   prepend-inner-icon="mdi-calendar"
                 />
@@ -305,11 +305,10 @@ const filteredTests = computed(() => {
 
     // 📅 Creation date
     let inCreationRange = true
-    if (creationDateRange.value?.length > 2 && test.creationDate) {
-      const creation = new Date(test.creationDate)
+    if (creationDateRange.value?.length > 1 && test.creationDate) {
       const start = new Date(creationDateRange.value[0])
       const end = new Date(creationDateRange.value[creationDateRange.value.length - 1])
-      inCreationRange = creation >= start && creation <= end
+      inCreationRange = new Date(test.creationDate) >= start && new Date(test.creationDate) <= end
     }
 
     return (

--- a/src/features/navigation/components/navbarSections/TemplatesSection.vue
+++ b/src/features/navigation/components/navbarSections/TemplatesSection.vue
@@ -54,10 +54,10 @@
                   density="compact"
                   hide-details
                   :placeholder="creationDateRange.length > 1
-                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[1]).toLocaleDateString()}`
+                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[creationDateRange.length - 1]).toLocaleDateString()}`
                     : 'Select range'"
-                  :model-value="creationDateRange[0] && creationDateRange[1]
-                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[1]).toLocaleDateString()}`
+                  :model-value="creationDateRange.length > 1
+                    ? `${new Date(creationDateRange[0]).toLocaleDateString()} - ${new Date(creationDateRange[creationDateRange.length - 1]).toLocaleDateString()}`
                     : ''"
                   prepend-inner-icon="mdi-calendar"
                 />
@@ -164,10 +164,10 @@ const filteredTemplates = computed(() =>
 
     const creationDate = temp.header?.creationDate
     let inDateRange = true;
-    if (creationDateRange.value.length > 2 && creationDate) {
+    if (creationDateRange.value.length > 1 && creationDate) {
       const date = new Date(creationDate);
       const start = new Date(creationDateRange.value[0]);
-      const end = new Date(creationDateRange.value[creationDateRange.value.length -1]);
+      const end = new Date(creationDateRange.value[creationDateRange.value.length - 1]);
       inDateRange = date >= start && date <= end;
     }
 


### PR DESCRIPTION
### Summary
This PR fixes the issue of the incorrect date range.
### What was wrong 
The code used `creationDateRange[1]` as the end date, which is incorrect when more than two dates are selected, as the Date range display logic breaks for long selections

### What is changed
The start date is taken from the earliest selected date.
The end date is taken from the latest selected date.
## Applied this change across:
    CommunityStudiesSection.vue
	CommunityTemplatesSection.vue
	SessionsSection.vue
	StudiesSection.vue
	TemplatesSection.vue
### Result 
Correct date range filtering for long selections.
<img width="1080" height="1080" alt="BEFORE (1)" src="https://github.com/user-attachments/assets/2ce49809-f491-45ab-89a4-c6de21188719" />
