### PR TITLE
Fix: Critical Privacy and db vulnerability in add cooperators.

### DIFF
--- a/src/shared/components/dialogs/InviteDialog.vue
+++ b/src/shared/components/dialogs/InviteDialog.vue
@@ -8,13 +8,9 @@
                 {{ title || 'Send Invitation' }}
             </v-card-title>
             <v-card-text class="pt-4">
-                <v-combobox :key="comboboxKey" ref="combobox" v-model="comboboxModel" :items="users.filter(user => user?.email != null)" item-title="email"
+                <v-combobox :key="comboboxKey" ref="combobox" v-model="comboboxModel"
                     :label="selectLabel || 'Select cooperator'" multiple variant="outlined" density="comfortable"
                     @update:model-value="validateEmail">
-                    <template #no-data>
-                        {{ noDataText || 'There are no users registered with that email, press enter to select anyways.'
-                        }}
-                    </template>
                 </v-combobox>
 
                 <v-chip-group>


### PR DESCRIPTION
Currently when we attempt to add cooperators we are presented with a huge list to choose from, apart from reasons like privacy, it is not optimal for us to render thousands of users(and potentially lakhs as the db grows) everytime we render this page from the ruxailab users database.
From Ruxailab Prod  thousands of emails are exposed:
<img width="1421" height="811" alt="Screenshot 2025-12-21 at 6 20 43 PM" src="https://github.com/user-attachments/assets/c2a8699c-65b2-41c0-8f6f-9cb8b31b6365" />

In this PR i have replaced the dropdown with a textbox and toast for invalid emails.

https://github.com/user-attachments/assets/1aa9bb49-01b6-4836-8544-4cc90a5081ca

