### PR TITLE
fix(bug): reset navigation guard state after successful save (#1132)

### DIFF
--- a/src/shared/views/SettingsView.vue
+++ b/src/shared/views/SettingsView.vue
@@ -642,6 +642,7 @@ const validate = (valid, index) => {
 const onSubmit = async () => {
   await submit();
   store.commit('SET_LOCAL_CHANGES', false);
+  store.commit('SET_DIALOG_LEAVE', false);
   router.push({ name: store.state.pathTo });
 };
 


### PR DESCRIPTION
## Fixes #1132 

### Summary: 
**The Fix:** Updated `SettingsView` to explicitly set `dialogLeave` to `false` after a successful save operation.

### Before Fix:

https://github.com/user-attachments/assets/9e18c4e1-031c-400e-b95c-af1368edf29c

### After fix:


https://github.com/user-attachments/assets/d8fd0747-52af-45b9-9647-7059de161eaa

