### PR TITLE
fix(Bug): eliminate category fragmentation in Help Center pagination (#1137)

### DIFF
--- a/src/shared/views/public/Help.vue
+++ b/src/shared/views/public/Help.vue
@@ -303,7 +303,12 @@ const filteredItems = computed(() => {
     filtered = filtered.filter((item) => item && item.category === selectedCategory.value);
   }
 
-  return filtered;
+  return filtered.sort((a, b) => {
+    const indexA = categories.value.findIndex(cat => cat.id === a.category);
+    const indexB = categories.value.findIndex(cat => cat.id === b.category);
+    
+    return indexA - indexB;
+  });
 });
 
 const pageCount = computed(() => {


### PR DESCRIPTION

## Fixes [#1137](https://github.com/ruxailab/RUXAILAB/issues/1137)
### Summary
**The Fix**: Updated the Help Center logic to strictly group FAQ items by their category **before** the pagination cuts them off.

**Before fix:** 

https://github.com/user-attachments/assets/7e5328f2-6dc2-4725-b370-16cd66a499a9

**After fix:** 

https://github.com/user-attachments/assets/a3840dd7-3c09-4593-b3c7-3175d0288911

### Additional Notes

**I think the Pages section is not visible to the user in the Web page ( help) unless we scroll it**