### PR TITLE
fix: store Google displayName and photoURL in Firestore users collection

### DIFF
--- a/src/features/auth/controllers/UserController.js
+++ b/src/features/auth/controllers/UserController.js
@@ -11,8 +11,8 @@ export default class UserController extends Controller {
   async create(payload) {
     const user = new User({
       email: payload.email,
-      username: payload.username || '',
-      contactNo: payload.contactNo || '',
+      username: payload.displayName || payload.username || '',
+      profileImage: payload.profileImage || '',
       country: payload.country || '',
       accessLevel: 1,
       myTests: {},

--- a/src/features/auth/store/Auth.js
+++ b/src/features/auth/store/Auth.js
@@ -130,6 +130,7 @@ export default {
             id: user.uid,
             email: user.email,
             displayName: user.displayName || '',
+            profileImage: user.photoURL || '',
             createdAt: new Date().toISOString(),
             authProvider: 'google',
           })


### PR DESCRIPTION
**Description**

User profile data from Google authentication is correctly synced to the Firestore `users` collection on first sign-in.

**Changes:**

* Map Google `displayName` → `username`
* Map Google `photoURL` → `profileImage`
* Persist profile fields when creating a new user document

**Related Issue**

Fixes: #1148

**Result:**
Firestore user documents now store  `username` and `profileImage` correctly after Google sign-in.