### PR TITLE
fix(docker): replace deprecated openjdk:11 in firebase emulator

### DIFF
--- a/firebase-emulator/Dockerfile
+++ b/firebase-emulator/Dockerfile
@@ -2,7 +2,7 @@
 # As from now node-16 is currently in beta for firebase functions
 # But if you want to run the beta you can change node:14-alpine to node:16-alpine
 # https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version
-FROM openjdk:11
+FROM eclipse-temurin:11-jdk
 
 # Instala Node.js
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \


### PR DESCRIPTION
### Summary

The firebase-emulator Docker build was failing due to the use of the deprecated `openjdk:11` base image, which has been removed from Docker Hub.

Fixed Issue: #1155

### Changes

- Replaced `openjdk:11` with `eclipse-temurin:11-jdk`, the official and supported successor.

### Impact

- Fixes Docker build failures for the firebase-emulator service.
- No runtime behavior changes; this only affects the build environment.

### DEPRECATION NOTICE [Link](https://hub.docker.com/_/openjdk#deprecation-notice)

This image is officially deprecated and all users are recommended to find and use suitable replacements ASAP. Some examples of other Official Image alternatives (listed in alphabetical order with no intentional or implied preference):

- [amazoncorretto](https://hub.docker.com/_/amazoncorretto)
- [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin)
- [ibm-semeru-runtimes](https://hub.docker.com/_/ibm-semeru-runtimes)
- [ibmjava](https://hub.docker.com/_/ibmjava)
- [sapmachine](https://hub.docker.com/_/sapmachine)

### Context

Docker Hub has deprecated and removed `openjdk` images, which caused the build to fail with:
`failed to resolve source metadata for docker.io/library/openjdk:11`

Happy to adjust further if needed.
