### PR TITLE
Fix #1141: making the navigation buttons actually work

### DIFF
--- a/src/composables/useGoBack.js
+++ b/src/composables/useGoBack.js
@@ -1,0 +1,17 @@
+import { useRouter } from 'vue-router'
+
+export function useGoBack() {
+  const router = useRouter()
+
+  const goBackOrRedirect = (fallbackRoute = '/') => {
+    if (window.history.state && window.history.state.back) {
+      router.back()
+    } else {
+      router.push(fallbackRoute)
+    }
+  }
+
+  return {
+    goBackOrRedirect
+  }
+}

--- a/src/features/notifications/views/NotificationPage.vue
+++ b/src/features/notifications/views/NotificationPage.vue
@@ -100,12 +100,14 @@
 import { ref, computed } from 'vue'
 import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
+import { useGoBack } from '@/composables/useGoBack'
 import NotificationList from '@/features/notifications/components/NotificationList.vue'
 import AcceptInvitationDialog from '@/shared/components/dialogs/AcceptInvitationDialog.vue'
 import StudyController from '@/controllers/StudyController'
 
 const store = useStore()
 const router = useRouter()
+const { goBackOrRedirect } = useGoBack()
 
 const activeTab = ref('unread')
 
@@ -220,6 +222,6 @@ const markAllAsRead = async () => {
 }
 
 const goBack = () => {
-  router.go(-1)
+  goBackOrRedirect('/')
 }
 </script>

--- a/src/shared/components/introduction_cards/IntroAnalytics.vue
+++ b/src/shared/components/introduction_cards/IntroAnalytics.vue
@@ -44,7 +44,7 @@ const goToCoops = () => {
 }
 
 const goToDoc = () => {
-  router.push('/analytics/documentation').catch(() => {})
+  router.push('/help').catch(() => {})
 }
 
 const goToDisc = () => {

--- a/src/shared/components/introduction_cards/IntroAnswer.vue
+++ b/src/shared/components/introduction_cards/IntroAnswer.vue
@@ -44,7 +44,7 @@ const goToCoops = () => {
 }
 
 const goToDoc = () => {
-  router.push('/answers/documentation').catch(() => {})
+  router.push('/help').catch(() => {})
 }
 
 const goToDisc = () => {

--- a/src/shared/components/introduction_cards/IntroCoops.vue
+++ b/src/shared/components/introduction_cards/IntroCoops.vue
@@ -40,7 +40,7 @@ const items = computed(() => [
 ])
 
 const goToDoc = () => {
-  router.push('/cooperators/documentation').catch(() => {})
+  router.push('/help').catch(() => {})
 }
 
 const goToDisc = () => {

--- a/src/shared/components/introduction_cards/IntroReports.vue
+++ b/src/shared/components/introduction_cards/IntroReports.vue
@@ -32,7 +32,7 @@ const items = computed(() => [
 ])
 
 const goToDoc = () => {
-  router.push('/reports/documentation').catch(() => {})
+  router.push('/help').catch(() => {})
 }
 
 const goToCoops = () => {

--- a/src/shared/views/public/PageNotFoundView.vue
+++ b/src/shared/views/public/PageNotFoundView.vue
@@ -39,17 +39,15 @@
 <script setup>
 import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { useGoBack } from '@/composables/useGoBack'
 
 const router = useRouter()
 const route = useRoute()
+const { goBackOrRedirect } = useGoBack()
 const prevRoute = ref(null)
 
 const sendHome = () => {
-  if (prevRoute.value !== null) {
-    router.push(prevRoute.value.path).catch(() => {})
-  } else {
-    router.push(1)
-  }
+  goBackOrRedirect('/')
 }
 
 defineOptions({

--- a/src/ux/Heuristic/components/IntroFinalReport.vue
+++ b/src/ux/Heuristic/components/IntroFinalReport.vue
@@ -32,7 +32,7 @@ const items = computed(() => [
 ])
 
 const goToDoc = () => {
-  router.push('/reports/documentation').catch(() => {})
+  router.push('/help').catch(() => {})
 }
 
 const goToCoops = () => {

--- a/src/ux/Heuristic/views/HeuristicTestView.vue
+++ b/src/ux/Heuristic/views/HeuristicTestView.vue
@@ -124,12 +124,22 @@
           >
             {{ test.testDescription }}
           </p>
+          <v-alert
+            v-if="heuristics.length === 0"
+            type="warning"
+            class="mb-6 text-left"
+            variant="tonal"
+            density="compact"
+            icon="mdi-alert"
+          >
+            Configuration Error: This test has no heuristics configured. Please add heuristics to proceed.
+          </v-alert>
           <v-btn
             color="white"
             variant="outlined"
             size="large"
             rounded
-            :disabled="!user"
+            :disabled="!user || heuristics.length === 0"
             @click="startTest()"
           >
             {{ $t('HeuristicsTestView.actions.startTest') }}

--- a/src/ux/UserTest/components/UserTestAnswer.vue
+++ b/src/ux/UserTest/components/UserTestAnswer.vue
@@ -59,7 +59,7 @@
       </ShowInfo>
     </v-row>
     <div v-else>
-      <IntroAnswer />
+      <IntroAnswer @go-to-coops="goToCoops" />
     </div>
   </div>
 </template>
@@ -67,6 +67,7 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue';
 import { useStore } from 'vuex';
+import { useRouter } from 'vue-router';
 import { statistics } from '@/ux/Heuristic/utils/statistics';
 import ShowInfo from '@/shared/components/ShowInfo.vue';
 import IntroAnswer from '@/shared/components/introduction_cards/IntroAnswer';
@@ -88,14 +89,15 @@ defineProps({
 const emit = defineEmits(['goToCoops']);
 
 const store = useStore();
+const router = useRouter();
 
 const tab = ref(0);
 const ind = ref(0);
 const intro = ref(null);
 
 const testAnswerDocument = computed(() => store.state.Answer.testAnswerDocument);
-const study = computed(() => store.state.Tests.Test);
-const testStructure = computed(() => store.state.Tests.Test.testStructure);
+const study = computed(() => store.getters.test || {});
+const testStructure = computed(() => store.getters.test?.testStructure || {});
 
 const hasAnswers = computed(() => {
   const answers = testAnswerDocument.value?.taskAnswers;
@@ -153,6 +155,12 @@ const allIrisTrackingData = computed(() => {
 });
 
 const goToCoops = () => {
+  if (!study.value?.id) return;
+  
+  const isModerated = study.value.subType === 'Moderated';
+  const routeBase = isModerated ? '/userTest/moderated' : '/userTest/unmoderated';
+  
+  router.push(`${routeBase}/edit/${study.value.id}`);
   emit('goToCoops');
 };
 


### PR DESCRIPTION
## Fixes #1141 

### Video link:
 https://drive.google.com/file/d/1T0-jNp7y4QpBg3LbDVEakJMEB1oS3F70/view?usp=sharing
### What's Fixed?
*   **The "Click Here" button is finally clickable**: It was missing an event listener in the User Test "Answer" view, so clicking it did nothing. It's hooked up now.
*   **"Go Back" actually works**: If you opened a Notification or 404 page in a new tab, "Go Back" would fail silently. Added a smart fallback so it takes you Home instead of leaving you stuck.
*   **Fixed broken Doc links(simple change)** : All the empty state cards (Coops, Analytics, Reports) pointed to documentation pages that don't exist yet. Redirected them all to `/help` so users actually get support.
*   **Safety Guard**: You can no longer mistakenly "Start" a Heuristic test if you haven't added any heuristics yet. Added a warning alert and disabled the button to prevent crashes.
