### PR TITLE
fix #1170: stop camera from activating on preview (privacy fix) 

### DIFF
--- a/src/ux/UserTest/components/IrisTracker.vue
+++ b/src/ux/UserTest/components/IrisTracker.vue
@@ -68,7 +68,11 @@ const initWebcam = async () => {
     if (videoRef.value) {
         videoRef.value.srcObject = mediaStream.value
         // Kick the video to play even if hidden (for tracking-only mode)
-        try { await videoRef.value.play() } catch (e) { /* ignore play/autoplay errors */ }
+        try { await videoRef.value.play() } catch (e) {
+            // Kick failed, likely due to browser autoplay policies.
+            // This is expected behavior for hidden videos in some contexts.
+            console.warn('Silent video play failed:', e)
+        }
         await waitForVideoReady()
     }
 }

--- a/src/ux/UserTest/components/IrisTracker.vue
+++ b/src/ux/UserTest/components/IrisTracker.vue
@@ -67,6 +67,8 @@ const initWebcam = async () => {
     mediaStream.value = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 }, audio: false })
     if (videoRef.value) {
         videoRef.value.srcObject = mediaStream.value
+        // Kick the video to play even if hidden (for tracking-only mode)
+        try { await videoRef.value.play() } catch (e) { /* ignore play/autoplay errors */ }
         await waitForVideoReady()
     }
 }
@@ -84,7 +86,10 @@ const loadModel = async () => {
 }
 
 const startTracking = async () => {
+    // Ensure webcam is initialized (critical for tracking-only mode)
     if (!mediaStream.value) await initWebcam()
+    // Ensure model is loaded before starting tracking loop
+    if (!model.value) await loadModel()
     if (!model.value) return
     const loop = async () => {
         if (!props.isRunning) return

--- a/src/ux/UserTest/components/IrisTracker.vue
+++ b/src/ux/UserTest/components/IrisTracker.vue
@@ -40,8 +40,6 @@ const recordingWebcamIndex = ref(null)
 onMounted(async () => {
     await tf.setBackend('webgl')
     await tf.ready()
-    await initWebcam()
-    await waitForVideoReady()
     await loadModel()
     if (props.isRunning) startTracking()
     if (props.recordScreen) {
@@ -65,8 +63,12 @@ onBeforeUnmount(() => {
 })
 
 const initWebcam = async () => {
+    if (mediaStream.value) return
     mediaStream.value = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 }, audio: false })
-    if (videoRef.value) videoRef.value.srcObject = mediaStream.value
+    if (videoRef.value) {
+        videoRef.value.srcObject = mediaStream.value
+        await waitForVideoReady()
+    }
 }
 
 const waitForVideoReady = () => new Promise(resolve => {
@@ -82,6 +84,7 @@ const loadModel = async () => {
 }
 
 const startTracking = async () => {
+    if (!mediaStream.value) await initWebcam()
     if (!model.value) return
     const loop = async () => {
         if (!props.isRunning) return
@@ -105,7 +108,16 @@ const startTracking = async () => {
     loop()
 }
 
-const stopTracking = () => { if (trackingLoop) { clearTimeout(trackingLoop); trackingLoop = null } }
+const stopTracking = () => {
+    if (trackingLoop) {
+        clearTimeout(trackingLoop)
+        trackingLoop = null
+    }
+    if (mediaStream.value) {
+        mediaStream.value.getTracks().forEach(track => track.stop())
+        mediaStream.value = null
+    }
+}
 
 // ---------- Screen Recording ----------
 const startScreenRecording = async () => {

--- a/src/ux/UserTest/components/VideoRecorder.vue
+++ b/src/ux/UserTest/components/VideoRecorder.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onBeforeUnmount } from 'vue'
 import { useStore } from 'vuex'
 import { useToast } from 'vue-toastification'
 import { useI18n } from 'vue-i18n'
@@ -144,7 +144,9 @@ const startRecording = async () => {
         console.error('Task not found at index:', correctTaskIndex, 'Available tasks:', currentUserTestAnswer.value.tasks?.length);
       }
 
-      videoStream.value.getTracks().forEach((track) => track.stop())
+      if (videoStream.value) {
+        videoStream.value.getTracks().forEach((track) => track.stop())
+      }
       recording.value = false
 
       emit('stopShowLoading')
@@ -162,6 +164,12 @@ const stopRecording = () => {
     mediaRecorder.value.stop()
   }
 }
+
+onBeforeUnmount(() => {
+  if (videoStream.value) {
+    videoStream.value.getTracks().forEach((track) => track.stop())
+  }
+})
 
 defineExpose({ startRecording, stopRecording })
 </script>

--- a/src/ux/UserTest/components/steps/PreTestStep.vue
+++ b/src/ux/UserTest/components/steps/PreTestStep.vue
@@ -83,7 +83,7 @@ const props = defineProps({
 
 const emit = defineEmits(["done", "update:preTestAnswer"]);
 
-const localAnswers = ref([...props.preTestAnswer]);
+const localAnswers = ref(props.preTest.map((_, i) => props.preTestAnswer[i] || { answer: '' }));
 
 watch(
   () => props.preTestAnswer,

--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -420,7 +420,7 @@ function toggleTracking(trackingValue, recordingValue) {
   console.log('toggleTracking', { trackingValue, recordingValue });
 
   isTracking.value = trackingValue;
-  isRecording.value = recordingValue !== undefined ? recordingValue : trackingValue;
+  isRecording.value = recordingValue === undefined ? trackingValue : recordingValue;
 }
 
 function saveIrisDataIntoTask() {
@@ -433,7 +433,7 @@ function saveIrisDataIntoTask() {
   const task = test.value.testStructure.userTasks[taskIndex.value]
 
   if (task?.hasEye === true && globalIndex.value >= 5) {
-    const shouldRecord = task.recordScreen !== false; 
+    const shouldRecord = task.recordScreen === undefined || task.recordScreen; 
     toggleTracking(true, shouldRecord);
   } else {
     toggleTracking(false, false);

--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -416,11 +416,11 @@ const closeCalibration = () => {
   completeStep(taskIndex.value, 'eyeCalibration');
 }
 
-function toggleTracking(value) {
-  console.log('toggleTracking', value);
+function toggleTracking(trackingValue, recordingValue) {
+  console.log('toggleTracking', { trackingValue, recordingValue });
 
-  isTracking.value = value;
-  isRecording.value = value;
+  isTracking.value = trackingValue;
+  isRecording.value = recordingValue !== undefined ? recordingValue : trackingValue;
 }
 
 function saveIrisDataIntoTask() {
@@ -433,9 +433,10 @@ function saveIrisDataIntoTask() {
   const task = test.value.testStructure.userTasks[taskIndex.value]
 
   if (task?.hasEye === true && globalIndex.value >= 5) {
-    toggleTracking(true);
+    const shouldRecord = task.recordScreen !== false; 
+    toggleTracking(true, shouldRecord);
   } else {
-    toggleTracking(false);
+    toggleTracking(false, false);
   }
 }
 


### PR DESCRIPTION
## Fixes #1170 
### Summary
This PR fixes the privacy issue where the webcam activated immediately on the Usability Test Preview page. I implemented **lazy loading** so the camera only turns on when the user explicitly clicks "Start Task".

**Before fix:**
https://drive.google.com/file/d/1JESxDGUMRpyeH3MopbZDx3Iby8t0g0p5/view?usp=sharing
**After fix:** 
https://drive.google.com/file/d/1Wx4i73eosAVRBby3d6tRNw5QNk602IFM/view?usp=sharing

### Also Fixed:
*   **Cleanup:** Added strict `track.stop()` to both [`IrisTracker.vue`](cci:7://file:///Users/sanhub/RUXAILAB/src/ux/UserTest/components/IrisTracker.vue:0:0-0:0) and [`VideoRecorder.vue`](cci:7://file:///Users/sanhub/RUXAILAB/src/ux/UserTest/components/VideoRecorder.vue:0:0-0:0) to Stop the Video Stream
*   **Stability:** Patched `PreTestStep.vue` to prevent crashes when answer data is missing.