### PR TITLE
Fix: NASA-TLX Analytics tab not showing active underline when selected

### DIFF
--- a/src/ux/UserTest/components/UserTestAnswer.vue
+++ b/src/ux/UserTest/components/UserTestAnswer.vue
@@ -16,32 +16,33 @@
             v-model="tab"
             bg-color="transparent"
             color="#FCA326"
+            slider-size="4"
           >
-            <v-tab @click="tab = 0">
+            <v-tab value="0">
               {{ $t('analytics.generalAnalytics') }}
             </v-tab>
-            <v-tab @click="tab = 1">
+            <v-tab value="1">
               {{ $t('analytics.individualAnalytics') }}
             </v-tab>
-            <v-tab v-if="showSentiment" @click="tab = 2">
+            <v-tab v-if="showSentiment" value="2">
               Sentiment Analysis
             </v-tab>
             <v-tab
               v-if="showSUS"
-              @click="tab = 3"
+              value="3"
             >
               {{ $t('analytics.susAnalytics') }}
             </v-tab>
             <v-tab
               v-if="showNasa"
-              @click="tab = 4"
+              value="4"
             >
               {{ $t('analytics.nasaTlxAnalytics') }}
             </v-tab>
-            <v-tab v-if="showEye" @click="tab = 4">
+            <v-tab v-if="showEye" value="4">
               {{ $t('analytics.eyeTrackingAnalytics') }}
             </v-tab>
-            <v-tab v-if="showTranscription" @click="tab = 5">
+            <v-tab v-if="showTranscription" value="5">
               {{ $t('analytics.transcriptions') }}
             </v-tab>
           </v-tabs>
@@ -51,12 +52,12 @@
           <div
             class="ma-0 pa-0"
           >
-            <GeneralAnalytics v-if="tab === 0" />
-            <UserAnalytics v-if="tab === 1" />
-            <SentimentAnalysisView v-if="tab === 2" />
-            <SusAnalytics v-if="tab === 3" />
-            <NasaTlxAnalytics v-if="tab === 4" />
-            <TranscriptionTool v-if="tab === 5" />
+            <GeneralAnalytics v-if="tab === '0'" />
+            <UserAnalytics v-if="tab === '1'" />
+            <SentimentAnalysisView v-if="tab === '2'" />
+            <SusAnalytics v-if="tab === '3'" />
+            <NasaTlxAnalytics v-if="tab === '4'" />
+            <TranscriptionTool v-if="tab === '5'" />
           </div>
         </template>
       </ShowInfo>


### PR DESCRIPTION
When the user opens the NASA-TLX Analytics tab, the tab content loads correctly, but the active underline/highlight style is missing for this tab.
Other analytics tabs display the active underline properly, but NASA-TLX Analytics does not follow the same pattern. This makes the tab styling inconsistent across the analytics navigation.



<img width="1080" height="1080" alt="BEFORE (3)" src="https://github.com/user-attachments/assets/cc9c4ca0-7347-4c23-8ba6-aa39e2cf687e" />
