### PR TITLE
fix(user-test): fix timeline answers start date (#1206)

### DIFF
--- a/src/ux/UserTest/components/answers/DateChart.vue
+++ b/src/ux/UserTest/components/answers/DateChart.vue
@@ -209,7 +209,14 @@ const processDataForChart = () => {
   });
 
   const testsPerDay = {};
-  const iterator = new Date(oneMonthsAgo);
+  
+  let startDate = new Date(oneMonthsAgo);
+  if (validAnswers.length > 0) {
+    const timestamps = validAnswers.map(a => new Date(a.lastUpdate).getTime());
+    startDate = new Date(Math.min(...timestamps));
+  }
+
+  const iterator = new Date(startDate);
   while (iterator <= currentDate) {
     const dateStr = iterator.toISOString().split('T')[0];
     testsPerDay[dateStr] = 0;


### PR DESCRIPTION
## Fixes 1206

### PR Summary

Fixed the Answers Timeline to dynamically start from the first valid answer date instead of a hardcoded 1-month lookback. This removes the misleading flat line at the start of the chart when data is recent. Logic gracefully falls back to the default window if no data is present.