### PR TITLE
fix(i18n) #1183 : externalize calibration strings

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -591,6 +591,15 @@
       "audioRecording": "Audio",
       "eyeTracking": "Eye Tracking",
       "recordingNote": "You will be notified before any recording begins. All data is collected solely for research purposes and handled according to privacy guidelines."
+    },
+    "CalibrationStep": {
+      "title": "Eye Tracking Calibration",
+      "heading": "Before starting calibration",
+      "description": "We are going to prepare your device to <strong>record your eye movement</strong>. This will allow us to understand how you navigate the screen during the test.",
+      "process": "Calibration involves following points that will appear on the screen with your eyes. It is important that you are in a well-lit place, sit comfortably, and keep your head stable.",
+      "instruction": "When you are ready, press the button to start calibration.",
+      "startButton": "Start calibration",
+      "inProgress": "In progress..."
     }
   },
   "AccessNotAllowed": {

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -587,6 +587,15 @@
       "audioRecording": "Audio",
       "eyeTracking": "Seguimiento ocular",
       "recordingNote": "Se te notificará antes de que comience cualquier grabación. Todos los datos se recopilan únicamente con fines de investigación y se manejan de acuerdo con las directrices de privacidad."
+    },
+    "CalibrationStep": {
+      "title": "Calibración de Eye Tracking",
+      "heading": "Antes de comenzar la calibración",
+      "description": "Vamos a preparar tu dispositivo para <strong>registrar el movimiento de tus ojos</strong>. Esto nos permitirá entender cómo navegas por la pantalla durante el test.",
+      "process": "La calibración consiste en seguir con la mirada unos puntos que aparecerán en la pantalla. Es importante que te sitúes en un lugar bien iluminado, te sientes cómodamente y mantengas la cabeza estable.",
+      "instruction": "Cuando estés listo o lista, pulsa el botón para empezar la calibración.",
+      "startButton": "Comenzar calibración",
+      "inProgress": "En progreso..."
     }
   },
   "AccessNotAllowed": {

--- a/src/components/UserTest/steps/EyeTrackingCalibrationStep.vue
+++ b/src/components/UserTest/steps/EyeTrackingCalibrationStep.vue
@@ -2,24 +2,20 @@
 
     <CalibrationInProgressModal @close="emit('closeCalibration')" @openCalibration="emit('openCalibration')"
         :isOpen="calibrationInProgress" :isCompleted="calibrationCompleted" />
-    <ShowInfo title="Calibración de Eye Tracking">
+    <ShowInfo :title="$t('UserTestView.CalibrationStep.title')">
         <template #content>
             <div class="test-content pa-6 rounded-xl text-center">
                 <v-icon size="96" color="primary">mdi-eye</v-icon>
                 <h2 class="text-h5 font-weight-bold mt-4 text-secondary">
-                    Antes de comenzar la calibración
+                    {{ $t('UserTestView.CalibrationStep.heading') }}
                 </h2>
-                <p class="text-body-1 mt-4 mb-4 text-grey-darken-1">
-                    Vamos a preparar tu dispositivo para <strong>registrar el movimiento de tus ojos</strong>.
-                    Esto nos permitirá entender cómo navegas por la pantalla durante el test.
-                </p>
+                <p class="text-body-1 mt-4 mb-4 text-grey-darken-1"
+                    v-html="$t('UserTestView.CalibrationStep.description')"></p>
                 <p class="text-body-1 mb-4 text-grey-darken-1">
-                    La calibración consiste en seguir con la mirada unos puntos que aparecerán en la pantalla.
-                    Es importante que te sitúes en un lugar bien iluminado, te sientes cómodamente y mantengas la cabeza
-                    estable.
+                    {{ $t('UserTestView.CalibrationStep.process') }}
                 </p>
                 <p class="text-body-1 mb-6 text-grey-darken-1">
-                    Cuando estés listo o lista, pulsa el botón para empezar la calibración.
+                    {{ $t('UserTestView.CalibrationStep.instruction') }}
                 </p>
                 <StartCalibrationButton :calibrationInProgress="calibrationInProgress"
                     @openCalibration="emit('openCalibration')" />

--- a/src/ux/UserTest/components/StartCalibrationButton.vue
+++ b/src/ux/UserTest/components/StartCalibrationButton.vue
@@ -2,10 +2,10 @@
     <v-col cols="12" class="text-center">
         <v-btn v-if="!calibrationInProgress" color="primary" variant="flat" size="large"
             @click="$emit('openCalibration')">
-            Comenzar calibración
+            {{ $t('UserTestView.CalibrationStep.startButton') }}
         </v-btn>
         <v-btn v-else disabled color="primary" variant="flat" size="large">
-            En progreso...
+            {{ $t('UserTestView.CalibrationStep.inProgress') }}
         </v-btn>
     </v-col>
 </template>


### PR DESCRIPTION
## Fixes #1183 

### 🛠️ The Fix
1.  **Extract Strings:** Moved hardcoded text to [`en.json`](cci:7://file:///Users/sanhub/RUXAILAB/src/app/plugins/locales/en.json:0:0-0:0) and [`es.json`](cci:7://file:///Users/sanhub/RUXAILAB/src/app/plugins/locales/es.json:0:0-0:0) under `UserTestView.CalibrationStep`.
2.  **Refactor Component:** Updated [EyeTrackingCalibrationStep.vue](cci:7://file:///Users/sanhub/RUXAILAB/src/components/UserTest/steps/EyeTrackingCalibrationStep.vue:0:0-0:0) to use `$t()` calls.
### Verification
[before fix](https://drive.google.com/file/d/1ngRUm-u2J0xALkYkg-3r6AGB4bDGg4sH/view?usp=sharing)
[after fix](https://drive.google.com/file/d/1-EHVLsbruBq0GVaVid9h4lmiU6hs_6o0/view?usp=sharing)
###  Future Note
Other languages (`fr`, `de`, etc.) will currently fallback to default english for these keys. I can add them in a follow-up PR if needed.