### PR TITLE
Fix: handle NaN values when no answers are provided

### DIFF
--- a/src/ux/UserTest/utils/nasaTlxData.js
+++ b/src/ux/UserTest/utils/nasaTlxData.js
@@ -1,4 +1,14 @@
 export function getNASATLXData(nasaTlxData) {
+    if (!nasaTlxData || nasaTlxData.length === 0) {
+    return {
+      averageOverallScore: NaN,
+      totalRespondents: 0,
+      mostStressfulDimension: NaN,
+      leastStressfulDimension: NaN,
+      dimensionAverages: { mentalDemand: NaN, physicalDemand: NaN, temporalDemand: NaN, performance: NaN, effort: NaN, frustration: NaN },
+      responses: []
+    }
+  }
   const dimensionTotals = {
     mentalDemand: 0,
     physicalDemand: 0,


### PR DESCRIPTION
Prevents showing incorrect Most/Least Stressful dimensions when no NASA-TLX responses exist.
<img width="1080" height="1080" alt="BEFORE (4)" src="https://github.com/user-attachments/assets/ff41e138-aeb6-49da-9768-a533a62d0216" />
