### PR TITLE
test: add unit tests for EmailController and ReportController

### DIFF
--- a/tests/unit/EmailController.spec.js
+++ b/tests/unit/EmailController.spec.js
@@ -1,0 +1,98 @@
+import EmailController from '@/shared/controllers/EmailController'
+import axios from 'axios'
+
+jest.mock('axios', () => ({
+    post: jest.fn()
+}))
+
+describe('EmailController', () => {
+    let emailController
+    const originalEnv = process.env
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        emailController = new EmailController()
+        process.env = {
+            ...originalEnv,
+            VUE_APP_CLOUD_FUNCTIONS_URL: 'https://cloud-functions.example.com'
+        }
+    })
+
+    afterEach(() => {
+        process.env = originalEnv
+    })
+
+    describe('Structure', () => {
+        it('should have send method', () => {
+            expect(typeof emailController.send).toBe('function')
+        })
+    })
+
+    describe('send', () => {
+        it('should call axios.post with correct URL and payload', async () => {
+            axios.post.mockResolvedValue({ data: {} })
+
+            const payload = {
+                to: 'test@example.com',
+                subject: 'Test Subject',
+                template: 'invitation',
+                data: { name: 'Test User' }
+            }
+
+            await emailController.send(payload)
+
+            expect(axios.post).toHaveBeenCalledWith(
+                'https://cloud-functions.example.com/sendEmail',
+                { data: payload }
+            )
+        })
+
+        it('should return success response when email is sent successfully', async () => {
+            axios.post.mockResolvedValue({ data: {} })
+
+            const payload = {
+                to: 'test@example.com',
+                subject: 'Test Subject',
+                template: 'invitation'
+            }
+
+            const result = await emailController.send(payload)
+
+            expect(result).toEqual({
+                success: true,
+                message: 'Email sent successfully.'
+            })
+        })
+
+        it('should return error response when axios fails', async () => {
+            const mockError = new Error('Network error')
+            axios.post.mockRejectedValue(mockError)
+
+            const payload = {
+                to: 'test@example.com',
+                subject: 'Test Subject',
+                template: 'invitation'
+            }
+
+            const result = await emailController.send(payload)
+
+            expect(result).toEqual({
+                success: false,
+                message: 'Network error'
+            })
+        })
+
+        it('should handle server error responses', async () => {
+            const mockError = new Error('Internal Server Error')
+            axios.post.mockRejectedValue(mockError)
+
+            const result = await emailController.send({
+                to: 'invalid@test.com',
+                subject: 'Test'
+            })
+
+            expect(result.success).toBe(false)
+            expect(result.message).toBe('Internal Server Error')
+        })
+    })
+})

--- a/tests/unit/EmailController.spec.js
+++ b/tests/unit/EmailController.spec.js
@@ -7,6 +7,7 @@ jest.mock('axios', () => ({
 
 describe('EmailController', () => {
     let emailController
+    let consoleErrorSpy
     const originalEnv = process.env
 
     beforeEach(() => {
@@ -16,10 +17,12 @@ describe('EmailController', () => {
             ...originalEnv,
             VUE_APP_CLOUD_FUNCTIONS_URL: 'https://cloud-functions.example.com'
         }
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
     })
 
     afterEach(() => {
         process.env = originalEnv
+        consoleErrorSpy.mockRestore()
     })
 
     describe('Structure', () => {

--- a/tests/unit/ReportController.spec.js
+++ b/tests/unit/ReportController.spec.js
@@ -1,4 +1,5 @@
 import ReportController from '@/shared/controllers/ReportController'
+import { createControllerSpies, createMockDoc } from './helpers/testUtils'
 
 jest.mock('firebase/firestore', () => ({
     doc: jest.fn(),
@@ -22,10 +23,20 @@ jest.mock('@/shared/constants/methodDefinitions', () => ({
 
 describe('ReportController', () => {
     let reportController
+    let spies
+
+    const mockReport = { userDocId: 'user-123' }
+    const mockTestHeuristic = { id: 'test-456', answersDocId: 'answer-789', testType: 'HEURISTIC' }
+    const mockTestUser = { id: 'test-456', answersDocId: 'answer-789', testType: 'USER' }
 
     beforeEach(() => {
         jest.clearAllMocks()
         reportController = new ReportController()
+        spies = createControllerSpies(reportController)
+    })
+
+    afterEach(() => {
+        spies.restore()
     })
 
     describe('Structure', () => {
@@ -35,190 +46,59 @@ describe('ReportController', () => {
     })
 
     describe('removeReport', () => {
-        const mockReport = {
-            userDocId: 'user-123'
-        }
-
-        const mockTestHeuristic = {
-            id: 'test-456',
-            answersDocId: 'answer-789',
-            testType: 'HEURISTIC'
-        }
-
-        const mockTestUser = {
-            id: 'test-456',
-            answersDocId: 'answer-789',
-            testType: 'USER'
+        const setupMocks = (userExists = true, answerExists = true) => {
+            spies.mockReadOne(createMockDoc(userExists))
+            spies.mockReadOne(createMockDoc(answerExists))
+            spies.mockUpdate()
+            spies.mockDeleteField()
         }
 
         it('should use heuristicAnswers for HEURISTIC test type', async () => {
-            const mockUserDoc = { exists: () => true }
-            const mockAnswerDoc = { exists: () => true }
+            setupMocks()
+            const result = await reportController.removeReport({ report: mockReport, test: mockTestHeuristic })
 
-            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
-                .mockResolvedValueOnce(mockUserDoc)
-                .mockResolvedValueOnce(mockAnswerDoc)
-
-            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'update')
-                .mockResolvedValue()
-
-            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'getDeleteField')
-                .mockReturnValue('DELETE_FIELD_SENTINEL')
-
-            const result = await reportController.removeReport({
-                report: mockReport,
-                test: mockTestHeuristic
-            })
-
-            expect(updateSpy).toHaveBeenCalledWith(
-                'answers',
-                'answer-789',
-                { 'heuristicAnswers.user-123': 'DELETE_FIELD_SENTINEL' }
-            )
+            expect(spies.update).toHaveBeenCalledWith('answers', 'answer-789', { 'heuristicAnswers.user-123': 'DELETE_FIELD_SENTINEL' })
             expect(result).toEqual({ success: true })
-
-            readOneSpy.mockRestore()
-            updateSpy.mockRestore()
         })
 
         it('should use taskAnswers for USER test type', async () => {
-            const mockUserDoc = { exists: () => true }
-            const mockAnswerDoc = { exists: () => true }
+            setupMocks()
+            const result = await reportController.removeReport({ report: mockReport, test: mockTestUser })
 
-            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
-                .mockResolvedValueOnce(mockUserDoc)
-                .mockResolvedValueOnce(mockAnswerDoc)
-
-            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'update')
-                .mockResolvedValue()
-
-            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'getDeleteField')
-                .mockReturnValue('DELETE_FIELD_SENTINEL')
-
-            const result = await reportController.removeReport({
-                report: mockReport,
-                test: mockTestUser
-            })
-
-            expect(updateSpy).toHaveBeenCalledWith(
-                'answers',
-                'answer-789',
-                { 'taskAnswers.user-123': 'DELETE_FIELD_SENTINEL' }
-            )
+            expect(spies.update).toHaveBeenCalledWith('answers', 'answer-789', { 'taskAnswers.user-123': 'DELETE_FIELD_SENTINEL' })
             expect(result).toEqual({ success: true })
-
-            readOneSpy.mockRestore()
-            updateSpy.mockRestore()
         })
 
         it('should remove user reference when user document exists', async () => {
-            const mockUserDoc = { exists: () => true }
-            const mockAnswerDoc = { exists: () => true }
+            setupMocks()
+            await reportController.removeReport({ report: mockReport, test: mockTestHeuristic })
 
-            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
-                .mockResolvedValueOnce(mockUserDoc)
-                .mockResolvedValueOnce(mockAnswerDoc)
-
-            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'update')
-                .mockResolvedValue()
-
-            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'getDeleteField')
-                .mockReturnValue('DELETE_FIELD_SENTINEL')
-
-            await reportController.removeReport({
-                report: mockReport,
-                test: mockTestHeuristic
-            })
-
-            expect(updateSpy).toHaveBeenCalledWith(
-                'users',
-                'user-123',
-                { 'myAnswers.test-456': 'DELETE_FIELD_SENTINEL' }
-            )
-
-            readOneSpy.mockRestore()
-            updateSpy.mockRestore()
+            expect(spies.update).toHaveBeenCalledWith('users', 'user-123', { 'myAnswers.test-456': 'DELETE_FIELD_SENTINEL' })
         })
 
         it('should not update user when user document does not exist', async () => {
-            const mockUserDoc = { exists: () => false }
-            const mockAnswerDoc = { exists: () => true }
+            setupMocks(false, true)
+            await reportController.removeReport({ report: mockReport, test: mockTestHeuristic })
 
-            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
-                .mockResolvedValueOnce(mockUserDoc)
-                .mockResolvedValueOnce(mockAnswerDoc)
-
-            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'update')
-                .mockResolvedValue()
-
-            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'getDeleteField')
-                .mockReturnValue('DELETE_FIELD_SENTINEL')
-
-            await reportController.removeReport({
-                report: mockReport,
-                test: mockTestHeuristic
-            })
-
-            // Should only be called once for answers, not for users
-            expect(updateSpy).toHaveBeenCalledTimes(1)
-            expect(updateSpy).toHaveBeenCalledWith(
-                'answers',
-                'answer-789',
-                expect.anything()
-            )
-
-            readOneSpy.mockRestore()
-            updateSpy.mockRestore()
+            expect(spies.update).toHaveBeenCalledTimes(1)
+            expect(spies.update).toHaveBeenCalledWith('answers', 'answer-789', expect.anything())
         })
 
         it('should not update answer when answer document does not exist', async () => {
-            const mockUserDoc = { exists: () => true }
-            const mockAnswerDoc = { exists: () => false }
+            setupMocks(true, false)
+            await reportController.removeReport({ report: mockReport, test: mockTestHeuristic })
 
-            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
-                .mockResolvedValueOnce(mockUserDoc)
-                .mockResolvedValueOnce(mockAnswerDoc)
-
-            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'update')
-                .mockResolvedValue()
-
-            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'getDeleteField')
-                .mockReturnValue('DELETE_FIELD_SENTINEL')
-
-            await reportController.removeReport({
-                report: mockReport,
-                test: mockTestHeuristic
-            })
-
-            // Should only be called once for users, not for answers
-            expect(updateSpy).toHaveBeenCalledTimes(1)
-            expect(updateSpy).toHaveBeenCalledWith(
-                'users',
-                'user-123',
-                expect.anything()
-            )
-
-            readOneSpy.mockRestore()
-            updateSpy.mockRestore()
+            expect(spies.update).toHaveBeenCalledTimes(1)
+            expect(spies.update).toHaveBeenCalledWith('users', 'user-123', expect.anything())
         })
 
         it('should return error when operation fails', async () => {
             const mockError = new Error('Firestore error')
+            spies.readOne.mockRejectedValue(mockError)
 
-            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
-                .mockRejectedValue(mockError)
+            const result = await reportController.removeReport({ report: mockReport, test: mockTestHeuristic })
 
-            const result = await reportController.removeReport({
-                report: mockReport,
-                test: mockTestHeuristic
-            })
-
-            expect(result).toEqual({
-                success: false,
-                error: mockError
-            })
-
-            readOneSpy.mockRestore()
+            expect(result).toEqual({ success: false, error: mockError })
         })
     })
 })

--- a/tests/unit/ReportController.spec.js
+++ b/tests/unit/ReportController.spec.js
@@ -24,6 +24,7 @@ jest.mock('@/shared/constants/methodDefinitions', () => ({
 describe('ReportController', () => {
     let reportController
     let spies
+    let consoleErrorSpy
 
     const mockReport = { userDocId: 'user-123' }
     const mockTestHeuristic = { id: 'test-456', answersDocId: 'answer-789', testType: 'HEURISTIC' }
@@ -33,10 +34,12 @@ describe('ReportController', () => {
         jest.clearAllMocks()
         reportController = new ReportController()
         spies = createControllerSpies(reportController)
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
     })
 
     afterEach(() => {
         spies.restore()
+        consoleErrorSpy.mockRestore()
     })
 
     describe('Structure', () => {

--- a/tests/unit/ReportController.spec.js
+++ b/tests/unit/ReportController.spec.js
@@ -1,0 +1,224 @@
+import ReportController from '@/shared/controllers/ReportController'
+
+jest.mock('firebase/firestore', () => ({
+    doc: jest.fn(),
+    updateDoc: jest.fn(),
+    collection: jest.fn(),
+    getDocs: jest.fn(),
+    getDoc: jest.fn(),
+    deleteField: jest.fn(() => 'DELETE_FIELD_SENTINEL')
+}))
+
+jest.mock('@/app/plugins/firebase', () => ({
+    db: {}
+}))
+
+jest.mock('@/shared/constants/methodDefinitions', () => ({
+    STUDY_TYPES: {
+        HEURISTIC: 'HEURISTIC',
+        USER: 'USER'
+    }
+}))
+
+describe('ReportController', () => {
+    let reportController
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        reportController = new ReportController()
+    })
+
+    describe('Structure', () => {
+        it('should have removeReport method', () => {
+            expect(typeof reportController.removeReport).toBe('function')
+        })
+    })
+
+    describe('removeReport', () => {
+        const mockReport = {
+            userDocId: 'user-123'
+        }
+
+        const mockTestHeuristic = {
+            id: 'test-456',
+            answersDocId: 'answer-789',
+            testType: 'HEURISTIC'
+        }
+
+        const mockTestUser = {
+            id: 'test-456',
+            answersDocId: 'answer-789',
+            testType: 'USER'
+        }
+
+        it('should use heuristicAnswers for HEURISTIC test type', async () => {
+            const mockUserDoc = { exists: () => true }
+            const mockAnswerDoc = { exists: () => true }
+
+            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
+                .mockResolvedValueOnce(mockUserDoc)
+                .mockResolvedValueOnce(mockAnswerDoc)
+
+            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'update')
+                .mockResolvedValue()
+
+            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'getDeleteField')
+                .mockReturnValue('DELETE_FIELD_SENTINEL')
+
+            const result = await reportController.removeReport({
+                report: mockReport,
+                test: mockTestHeuristic
+            })
+
+            expect(updateSpy).toHaveBeenCalledWith(
+                'answers',
+                'answer-789',
+                { 'heuristicAnswers.user-123': 'DELETE_FIELD_SENTINEL' }
+            )
+            expect(result).toEqual({ success: true })
+
+            readOneSpy.mockRestore()
+            updateSpy.mockRestore()
+        })
+
+        it('should use taskAnswers for USER test type', async () => {
+            const mockUserDoc = { exists: () => true }
+            const mockAnswerDoc = { exists: () => true }
+
+            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
+                .mockResolvedValueOnce(mockUserDoc)
+                .mockResolvedValueOnce(mockAnswerDoc)
+
+            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'update')
+                .mockResolvedValue()
+
+            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'getDeleteField')
+                .mockReturnValue('DELETE_FIELD_SENTINEL')
+
+            const result = await reportController.removeReport({
+                report: mockReport,
+                test: mockTestUser
+            })
+
+            expect(updateSpy).toHaveBeenCalledWith(
+                'answers',
+                'answer-789',
+                { 'taskAnswers.user-123': 'DELETE_FIELD_SENTINEL' }
+            )
+            expect(result).toEqual({ success: true })
+
+            readOneSpy.mockRestore()
+            updateSpy.mockRestore()
+        })
+
+        it('should remove user reference when user document exists', async () => {
+            const mockUserDoc = { exists: () => true }
+            const mockAnswerDoc = { exists: () => true }
+
+            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
+                .mockResolvedValueOnce(mockUserDoc)
+                .mockResolvedValueOnce(mockAnswerDoc)
+
+            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'update')
+                .mockResolvedValue()
+
+            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'getDeleteField')
+                .mockReturnValue('DELETE_FIELD_SENTINEL')
+
+            await reportController.removeReport({
+                report: mockReport,
+                test: mockTestHeuristic
+            })
+
+            expect(updateSpy).toHaveBeenCalledWith(
+                'users',
+                'user-123',
+                { 'myAnswers.test-456': 'DELETE_FIELD_SENTINEL' }
+            )
+
+            readOneSpy.mockRestore()
+            updateSpy.mockRestore()
+        })
+
+        it('should not update user when user document does not exist', async () => {
+            const mockUserDoc = { exists: () => false }
+            const mockAnswerDoc = { exists: () => true }
+
+            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
+                .mockResolvedValueOnce(mockUserDoc)
+                .mockResolvedValueOnce(mockAnswerDoc)
+
+            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'update')
+                .mockResolvedValue()
+
+            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'getDeleteField')
+                .mockReturnValue('DELETE_FIELD_SENTINEL')
+
+            await reportController.removeReport({
+                report: mockReport,
+                test: mockTestHeuristic
+            })
+
+            // Should only be called once for answers, not for users
+            expect(updateSpy).toHaveBeenCalledTimes(1)
+            expect(updateSpy).toHaveBeenCalledWith(
+                'answers',
+                'answer-789',
+                expect.anything()
+            )
+
+            readOneSpy.mockRestore()
+            updateSpy.mockRestore()
+        })
+
+        it('should not update answer when answer document does not exist', async () => {
+            const mockUserDoc = { exists: () => true }
+            const mockAnswerDoc = { exists: () => false }
+
+            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
+                .mockResolvedValueOnce(mockUserDoc)
+                .mockResolvedValueOnce(mockAnswerDoc)
+
+            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'update')
+                .mockResolvedValue()
+
+            jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'getDeleteField')
+                .mockReturnValue('DELETE_FIELD_SENTINEL')
+
+            await reportController.removeReport({
+                report: mockReport,
+                test: mockTestHeuristic
+            })
+
+            // Should only be called once for users, not for answers
+            expect(updateSpy).toHaveBeenCalledTimes(1)
+            expect(updateSpy).toHaveBeenCalledWith(
+                'users',
+                'user-123',
+                expect.anything()
+            )
+
+            readOneSpy.mockRestore()
+            updateSpy.mockRestore()
+        })
+
+        it('should return error when operation fails', async () => {
+            const mockError = new Error('Firestore error')
+
+            const readOneSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(reportController)), 'readOne')
+                .mockRejectedValue(mockError)
+
+            const result = await reportController.removeReport({
+                report: mockReport,
+                test: mockTestHeuristic
+            })
+
+            expect(result).toEqual({
+                success: false,
+                error: mockError
+            })
+
+            readOneSpy.mockRestore()
+        })
+    })
+})

--- a/tests/unit/helpers/testUtils.js
+++ b/tests/unit/helpers/testUtils.js
@@ -1,0 +1,43 @@
+export function createControllerSpies(controller) {
+    const parentProto = Object.getPrototypeOf(Object.getPrototypeOf(controller))
+    
+    const spies = {
+        readOne: jest.spyOn(parentProto, 'readOne'),
+        update: jest.spyOn(parentProto, 'update'),
+        create: jest.spyOn(parentProto, 'create'),
+        delete: jest.spyOn(parentProto, 'delete'),
+        getDeleteField: jest.spyOn(parentProto, 'getDeleteField')
+    }
+
+    return {
+        ...spies,
+        mockReadOne: (value) => spies.readOne.mockResolvedValueOnce(value),
+        mockUpdate: () => spies.update.mockResolvedValue(),
+        mockDeleteField: (value = 'DELETE_FIELD_SENTINEL') => spies.getDeleteField.mockReturnValue(value),
+        restore: () => Object.values(spies).forEach(spy => spy.mockRestore())
+    }
+}
+
+export function createMockDoc(exists = true) {
+    return { exists: () => exists }
+}
+
+export const firestoreMock = {
+    doc: jest.fn(),
+    updateDoc: jest.fn(),
+    collection: jest.fn(),
+    getDocs: jest.fn(),
+    getDoc: jest.fn(),
+    deleteField: jest.fn(() => 'DELETE_FIELD_SENTINEL')
+}
+
+export const firebaseAppMock = {
+    db: {}
+}
+
+export const studyTypesMock = {
+    STUDY_TYPES: {
+        HEURISTIC: 'HEURISTIC',
+        USER: 'USER'
+    }
+}


### PR DESCRIPTION
## Summary
Continuation of #1089 - adding unit tests for the remaining untested controllers as suggested by @marcgc21.

This PR adds **12 new unit tests** for:
- EmailController (5 tests) - axios-based email sending
- ReportController (7 tests) - Firestore report removal

## Changes
| File | Status |
|------|--------|
| tests/unit/EmailController.spec.js| NEW |
| tests/unit/ReportController.spec.js | NEW |

## Test Coverage

### EmailController
- Structure verification
- Axios POST with correct URL/payload
- Success/error response handling

### ReportController  
- HEURISTIC type → `heuristicAnswers` field
- USER type → `taskAnswers` field
- User/answer document existence checks
- Error handling

## Testing
```bash
npm test -- --testPathPattern="EmailController|ReportController"