### PR TITLE
chore: remove redundant Go to Home navigation

### DIFF
--- a/src/features/navigation/components/GlobalToolbar.vue
+++ b/src/features/navigation/components/GlobalToolbar.vue
@@ -50,15 +50,6 @@
       {{ $t('buttons.goToConsole') }}
     </v-btn>
 
-    <v-btn
-      v-if="['/admin', '/signin', '/signup'].includes($route.path)"
-      variant="text"
-      color="#f9a826"
-      class="console-button mx-1 d-none d-lg-flex"
-      @click="goTo('/')"
-    >
-      {{ $t('AccessNotAllowed.goHome') }}
-    </v-btn>
 
     <v-btn
       v-if="!['/', '/admin', '/signin', '/signup'].includes($route.path)"

--- a/src/shared/views/AccessNotAllowed.vue
+++ b/src/shared/views/AccessNotAllowed.vue
@@ -34,7 +34,8 @@
             style="color: #f9a826"
             variant="outlined"
             rounded
-            @click="goBack"
+            :aria-label="$t('AccessNotAllowed.goHome')"
+            @click="goToAdmin"
           >
             {{ $t('AccessNotAllowed.goHome') }}
           </v-btn>
@@ -50,9 +51,9 @@ import { useRouter } from 'vue-router';
 // Initialize router
 const router = useRouter();
 
-// Define goBack function
-const goBack = () => {
-  router.push('/admin');
+// Define goToAdmin function
+const goToAdmin = () => {
+  router.push('/admin').catch(() => {});
 };
 </script>
 


### PR DESCRIPTION
 Summary
Removed redundant header navigation actions that redirected to the same destination
as the sidebar navigation.

Changes
- Removed “Go to Home”  actions from the header.
- Cleaned up unused navigation handlers.
- Sidebar navigation remains the primary way to access Dashboard and Console.

Why
- Multiple header actions were redirecting to the same destination.
- Sidebar already provides persistent and clear navigation.
- Reduces confusion and improves UX consistency.


BEFORE
<img width="3020" height="1670" alt="image" src="https://github.com/user-attachments/assets/0f0a577b-b5bd-4399-8ed2-bda6348eea15" />

AFTER
<img width="3020" height="1670" alt="image" src="https://github.com/user-attachments/assets/dbe54bb1-38f1-476b-88a2-e3226c8f8bf1" />

Closes #1280