### PR TITLE
fix: skip description validation for bot PRs

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -111,40 +111,47 @@ jobs:
             // 5. PR Description Validation
             const descriptionIssues = [];
 
-            // Check minimum description length (at least 20 characters)
-            if (prBody.trim().length < 20) {
-              descriptionIssues.push("- Description is too short (minimum 20 characters)");
-            }
+            // Detect bot PRs
+            const botLogins = ['dependabot[bot]', 'github-actions[bot]'];
+            const isBot = botLogins.includes(pr.user.login) || pr.user.type === 'Bot';
 
-            // Check for issue reference
-            const hasIssueRef = /(?:fixes|closes|resolves|close|fix|resolve|fixed|closed|resolved)[\s\w:]*#\d+/i.test(prBody);
-            if (!hasIssueRef) {
-              descriptionIssues.push("- Missing issue reference (e.g., 'Fixes #123')");
-            }
+            // Skip validation for bot PRs
+            if (!isBot) {
+              // Check minimum description length (at least 20 characters)
+              if (prBody.trim().length < 20) {
+                descriptionIssues.push("- Description is too short (minimum 20 characters)");
+              }
 
-            // If there are validation issues, comment and add label
-            if (descriptionIssues.length > 0) {
-              labelsToAdd.push("needs-description");
-              
-              const warningComment = `⚠️ **PR Description Issues Detected**\n\n${descriptionIssues.join("\n")}\n\nPlease update the PR description to address these issues.`;
-              
-              // Check if we already commented
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-              });
-              
-              const alreadyCommented = comments.some(c => c.body.includes("PR Description Issues Detected"));
-              
-              if (!alreadyCommented) {
-                await github.rest.issues.createComment({
+              // Check for issue reference
+              const hasIssueRef = /(?:fixes|closes|resolves|close|fix|resolve|fixed|closed|resolved)[\s\w:]*#\d+/i.test(prBody);
+              if (!hasIssueRef) {
+                descriptionIssues.push("- Missing issue reference (e.g., 'Fixes #123')");
+              }
+
+              // If there are validation issues, comment and add label
+              if (descriptionIssues.length > 0) {
+                labelsToAdd.push("needs-description");
+                
+                const warningComment = `⚠️ **PR Description Issues Detected**\n\n${descriptionIssues.join("\n")}\n\nPlease update the PR description to address these issues.`;
+                
+                // Check if we already commented
+                const { data: comments } = await github.rest.issues.listComments({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: prNumber,
-                  body: warningComment,
                 });
-                console.log("Posted description validation comment");
+                
+                const alreadyCommented = comments.some(c => c.body.includes("PR Description Issues Detected"));
+                
+                if (!alreadyCommented) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: warningComment,
+                  });
+                  console.log("Posted description validation comment");
+                }
               }
             }
 

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -112,8 +112,8 @@ jobs:
             const descriptionIssues = [];
 
             // Detect bot PRs
-            const botLogins = ['dependabot[bot]', 'github-actions[bot]'];
-            const isBot = botLogins.includes(pr.user.login) || pr.user.type === 'Bot';
+            const BOT_LOGINS = new Set(['dependabot[bot]', 'github-actions[bot]']);
+            const isBot = BOT_LOGINS.has(pr.user.login) || pr.user.type === 'Bot';
 
             // Skip validation for bot PRs
             if (!isBot) {


### PR DESCRIPTION
Dependabot PRs were incorrectly flagged for missing issue references. Added bot detection to skip validation for automated PRs while keeping it for human PRs.

Changes:
- Detect bot PRs (dependabot, github-actions)
- Skip description/issue reference validation for bots
- Maintain validation for human-created PRs