### PR TITLE
fix(header): logo redirect to home page instead of admin

### DIFF
--- a/src/features/navigation/components/GlobalToolbar.vue
+++ b/src/features/navigation/components/GlobalToolbar.vue
@@ -17,8 +17,7 @@
     <v-toolbar-title
       style="cursor: pointer"
       class="d-flex align-center"
-      @click="goTo('/admin')"
-    >
+@click="goTo('/')"    >
       <img
         :src="xs ? logoSmall : logoFull"
         alt="RUXAILAB Logo"


### PR DESCRIPTION
Fixes #1282

The RUXAILAB logo in the header was redirecting to '/admin' instead of the home page '/'. now its point to home/landing page, Please review and approve the changes