### PR TITLE
Add global loading component to main layout

### DIFF
--- a/src/app/layouts/DefaultLayout.vue
+++ b/src/app/layouts/DefaultLayout.vue
@@ -4,6 +4,7 @@
     <GlobalErrorHandler />
 
     <GlobalToastHandler />
+    <Loading />
     <v-main>
       <v-container
         fluid
@@ -19,12 +20,14 @@
 import { GlobalToolbar } from '@/features/navigation/utils'
 import GlobalErrorHandler from '@/app/layouts/components/GlobalErrorHandler.vue'
 import GlobalToastHandler from '@/app/layouts/components/GlobalToastHandler.vue'
+import Loading from '@/shared/components/Loading.vue'
 
 export default {
   components: {
     GlobalToolbar,
     GlobalErrorHandler,
     GlobalToastHandler,
+    Loading,
   },
 }
 </script>


### PR DESCRIPTION
This PR integrates the shared Loading component into the DefaultLayout.

Changes made:
- Imported the shared Loading component into DefaultLayout.vue.
- Rendered the <Loading /> component at the layout level so it is available across all main views.

https://github.com/user-attachments/assets/3e5f8d28-d193-415f-809b-cb21ade5d358

