### PR TITLE
feat: implement SART instrument and analytics dashboard visualization #1211

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -180,6 +180,7 @@
     "overallAnalyticsDescription": "View the aggregated analytics for your test.",
     "individualAnalytics": "Individual Analytics",
     "nasaTlxAnalytics": "NASA-TLX Analytics",
+    "sartAnalytics": "SART Analytics",
     "finalReport": "Add additional data to your test.",
     "intro": {
       "reports": "Keep track of your evaluators progress and answering status while they complete your test.",
@@ -785,7 +786,12 @@
     "audioRecord": "Audio Record",
     "postForm": "Post Form",
     "nasa": "NASA-TLX",
-    "sart": "SART"
+    "sart": "SART",
+    "sartLong": "Situational Awareness Rating Technique",
+    "sartDemand": "Demand on Attentional Resources",
+    "sartSupply": "Supply of Attentional Resources",
+    "sartUnderstanding": "Understanding of the Situation",
+    "sartCalculationExplanation": "Score = Understanding - (Demand - Supply)"
   },
   "inputs": {
     "consentForm": "Consent Form",

--- a/src/components/UserTest/steps/EyeTrackingCalibrationStep.vue
+++ b/src/components/UserTest/steps/EyeTrackingCalibrationStep.vue
@@ -1,7 +1,8 @@
 <template>
 
-    <CalibrationInProgressModal @close="emit('closeCalibration')" @openCalibration="emit('openCalibration')"
-        :isOpen="calibrationInProgress" :isCompleted="calibrationCompleted" />
+    <CalibrationInProgressModal
+:is-open="calibrationInProgress" :is-completed="calibrationCompleted"
+        @close="emit('closeCalibration')" @open-calibration="emit('openCalibration')" />
     <ShowInfo :title="$t('UserTestView.CalibrationStep.title')">
         <template #content>
             <div class="test-content pa-6 rounded-xl text-center">
@@ -9,7 +10,8 @@
                 <h2 class="text-h5 font-weight-bold mt-4 text-secondary">
                     {{ $t('UserTestView.CalibrationStep.heading') }}
                 </h2>
-                <p class="text-body-1 mt-4 mb-4 text-grey-darken-1"
+                <p
+class="text-body-1 mt-4 mb-4 text-grey-darken-1"
                     v-html="$t('UserTestView.CalibrationStep.description')"></p>
                 <p class="text-body-1 mb-4 text-grey-darken-1">
                     {{ $t('UserTestView.CalibrationStep.process') }}
@@ -17,8 +19,9 @@
                 <p class="text-body-1 mb-6 text-grey-darken-1">
                     {{ $t('UserTestView.CalibrationStep.instruction') }}
                 </p>
-                <StartCalibrationButton :calibrationInProgress="calibrationInProgress"
-                    @openCalibration="emit('openCalibration')" />
+                <StartCalibrationButton
+:calibration-in-progress="calibrationInProgress"
+                    @open-calibration="emit('openCalibration')" />
             </div>
         </template>
     </ShowInfo>

--- a/src/features/auth/components/ChangePasswordForm.vue
+++ b/src/features/auth/components/ChangePasswordForm.vue
@@ -50,26 +50,30 @@
         </v-alert>
         <v-row dense>
           <v-col v-if="!isGoogleUser" cols="12">
-            <v-text-field v-model="currentPassword" :rules="currentPasswordRules" :label="$t('profile.currentPassword')"
+            <v-text-field
+v-model="currentPassword" :rules="currentPasswordRules" :label="$t('profile.currentPassword')"
               :type="showCurrentPassword ? 'text' : 'password'" variant="outlined" density="compact"
               prepend-inner-icon="mdi-lock-check" :append-inner-icon="showCurrentPassword ? 'mdi-eye' : 'mdi-eye-off'"
               class="input-field-transition" @click:append-inner="toggleCurrentPasswordVisibility()" />
           </v-col>
           <v-col cols="12" sm="6">
-            <v-text-field v-model="newPassword" :rules="passwordRules" :label="$t('profile.newPassword')"
+            <v-text-field
+v-model="newPassword" :rules="passwordRules" :label="$t('profile.newPassword')"
               :type="showPassword ? 'text' : 'password'" variant="outlined" density="compact"
               prepend-inner-icon="mdi-lock" :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
               class="input-field-transition" @click:append-inner="togglePasswordVisibility()" />
           </v-col>
           <v-col cols="12" sm="6">
-            <v-text-field v-model="confirmPassword" :rules="confirmPasswordRules"
+            <v-text-field
+v-model="confirmPassword" :rules="confirmPasswordRules"
               :label="$t('profile.confirmNewPassword')" :type="showConfirmPassword ? 'text' : 'password'"
               variant="outlined" density="compact" prepend-inner-icon="mdi-lock-check"
               :append-inner-icon="showConfirmPassword ? 'mdi-eye' : 'mdi-eye-off'" class="input-field-transition"
               @click:append-inner="toggleConfirmPasswordVisibility()" />
           </v-col>
         </v-row>
-        <v-btn :disabled="!valid || isChanging" :loading="isChanging" color="primary" variant="flat"
+        <v-btn
+:disabled="!valid || isChanging" :loading="isChanging" color="primary" variant="flat"
           class="mt-4 text-capitalize" @click="handleChangePassword">
           <v-icon start>
             mdi-key

--- a/src/features/auth/components/DeleteAccountSection.vue
+++ b/src/features/auth/components/DeleteAccountSection.vue
@@ -10,7 +10,8 @@
                 <p class="text-body-1 mb-4">
                     {{ $t('profile.deleteAccountWarning') }}
                 </p>
-                <v-btn color="error" variant="flat" class="text-capitalize" :block="isSmallScreen"
+                <v-btn
+color="error" variant="flat" class="text-capitalize" :block="isSmallScreen"
                     @click="showDialog = true">
                     <v-icon start>mdi-delete</v-icon>
                     {{ $t('profile.deleteAccountTitle') }}
@@ -40,18 +41,21 @@
                             <p class="font-weight-bold mb-2">
                                 {{ $t('profile.typeDeleteToConfirm') }}
                             </p>
-                            <v-text-field v-model="deleteAccount.deleteConfirmText" variant="outlined" density="compact"
+                            <v-text-field
+v-model="deleteAccount.deleteConfirmText" variant="outlined" density="compact"
                                 hide-details class="input-field-transition" :rules="[
                                     (v) => v === 'DELETE' || $t('profile.pleaseTypeDeleteToConfirm'),
                                 ]" />
                         </div>
                     </v-card-text>
                     <v-card-actions class="justify-center">
-                        <v-btn variant="outlined" class="text-capitalize" min-width="120"
+                        <v-btn
+variant="outlined" class="text-capitalize" min-width="120"
                             :disabled="deleteAccount.isDeleting" @click="handleClose">
                             {{ $t('common.cancel') }}
                         </v-btn>
-                        <v-btn color="error" variant="flat" class="text-capitalize" min-width="120"
+                        <v-btn
+color="error" variant="flat" class="text-capitalize" min-width="120"
                             :loading="deleteAccount.isDeleting" :disabled="deleteAccount.deleteConfirmText !== 'DELETE'"
                             @click="deleteAccount.handleDeleteConfirmText">
                             {{ $t('Proceed') }}
@@ -68,17 +72,20 @@
                         <p class="text-center font-weight-bold mb-4">
                             {{ $t('profile.enterPasswordForAccountDeletion') }}
                         </p>
-                        <v-text-field v-model="deleteAccount.userPassword" :label="$t('profile.yourPassword')"
+                        <v-text-field
+v-model="deleteAccount.userPassword" :label="$t('profile.yourPassword')"
                             type="password" variant="outlined" density="compact" prepend-inner-icon="mdi-lock"
                             :disabled="deleteAccount.isDeleting" :rules="[(v) => !!v || $t('profile.passwordRequired')]"
                             class="input-field-transition" />
                     </v-card-text>
                     <v-card-actions class="justify-center">
-                        <v-btn variant="outlined" class="text-capitalize" :disabled="deleteAccount.isDeleting"
+                        <v-btn
+variant="outlined" class="text-capitalize" :disabled="deleteAccount.isDeleting"
                             min-width="120" @click="deleteAccount.deleteStep = 1">
                             {{ $t('profile.back') }}
                         </v-btn>
-                        <v-btn color="error" variant="flat" class="text-capitalize" :loading="deleteAccount.isDeleting"
+                        <v-btn
+color="error" variant="flat" class="text-capitalize" :loading="deleteAccount.isDeleting"
                             :disabled="!deleteAccount.userPassword || deleteAccount.isDeleting" min-width="120"
                             @click="handleDelete">
                             <v-icon start>mdi-delete</v-icon>

--- a/src/features/auth/components/EditProfileDialog.vue
+++ b/src/features/auth/components/EditProfileDialog.vue
@@ -1,5 +1,6 @@
 <template>
-    <v-dialog :model-value="modelValue" max-width="600px" transition="dialog-bottom-transition"
+    <v-dialog
+:model-value="modelValue" max-width="600px" transition="dialog-bottom-transition"
         @update:model-value="$emit('update:modelValue', $event)">
         <v-card class="rounded-xl pa-6" elevation="6">
             <v-card-title class="text-h6 font-weight-bold">
@@ -33,20 +34,24 @@
                             class="upload-indicator"
                         />
                     </v-avatar>
-                    <v-btn icon size="small" class="ml-2" @click="selectImage" :disabled="isUploadingImage">
+                    <v-btn icon size="small" class="ml-2" :disabled="isUploadingImage" @click="selectImage">
                         <v-icon>mdi-camera</v-icon>
                     </v-btn>
-                    <input ref="fileInput" type="file" accept="image/*" style="display: none"
+                    <input
+ref="fileInput" type="file" accept="image/*" style="display: none"
                         @change="handleImageUpload">
                 </div>
                 <v-form ref="formRef" v-model="isValid">
-                    <v-text-field v-model="localProfileData.username" :label="$t('profile.username')" variant="outlined"
+                    <v-text-field
+v-model="localProfileData.username" :label="$t('profile.username')" variant="outlined"
                         density="compact" prepend-inner-icon="mdi-account" :rules="usernameRules"
                         class="mb-4 input-field-transition" />
-                    <v-text-field v-model="localProfileData.contactNo" :label="$t('profile.contact')" variant="outlined"
+                    <v-text-field
+v-model="localProfileData.contactNo" :label="$t('profile.contact')" variant="outlined"
                         density="compact" prepend-inner-icon="mdi-phone" :rules="contactRules"
                         :hint="$t('profile.enterValidPhoneNumber')" persistent-hint class="mb-4 input-field-transition" />
-                    <v-autocomplete v-model="localProfileData.country" :label="$t('profile.country')" variant="outlined"
+                    <v-autocomplete
+v-model="localProfileData.country" :label="$t('profile.country')" variant="outlined"
                         density="compact" prepend-inner-icon="mdi-map-marker" :rules="countryRules" :items="countries"
                         item-title="name" item-value="name" :custom-filter="countryFilter" clearable
                         :menu-props="{ maxHeight: '400px' }" class="input-field-transition">
@@ -68,7 +73,8 @@
                 <v-btn variant="text" class="text-capitalize" @click="handleCancel">
                     {{ $t('common.cancel') }}
                 </v-btn>
-                <v-btn color="primary" variant="flat" class="text-capitalize" :disabled="!isValid || isSaving"
+                <v-btn
+color="primary" variant="flat" class="text-capitalize" :disabled="!isValid || isSaving"
                     :loading="isSaving" @click="handleSave">
                     <v-icon start>mdi-content-save</v-icon>
                     {{ $t('profile.saveChanges') }}

--- a/src/features/auth/components/PasswordStrength.vue
+++ b/src/features/auth/components/PasswordStrength.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="password-strength mb-4" v-if="password">
+  <div v-if="password" class="password-strength mb-4">
     <div class="d-flex justify-space-between align-center mb-1">
       <span class="text-caption text-medium-emphasis">{{ $t('auth.passwordStrength') }}</span>
       <span class="text-caption font-weight-bold" :class="colorTextClass">{{ strengthLabel }}</span>

--- a/src/features/auth/components/UserProfileCard.vue
+++ b/src/features/auth/components/UserProfileCard.vue
@@ -27,7 +27,8 @@
             <v-divider class="my-4" />
 
             <v-list density="compact">
-                <v-list-item v-for="(item, index) in profileItems" :key="index"
+                <v-list-item
+v-for="(item, index) in profileItems" :key="index"
                     class="rounded-lg pa-2 list-item-transition">
                     <v-list-item-subtitle class="text-caption text-uppercase text-grey-darken-1">
                         <v-icon size="small" color="grey-darken-1">
@@ -35,7 +36,8 @@
                         </v-icon>
                         {{ item.label }}:
                     </v-list-item-subtitle>
-                    <v-list-item-title v-if="!loading" :class="{
+                    <v-list-item-title
+v-if="!loading" :class="{
                         'font-italic text-error': !item.value,
                         'font-weight-medium': item.value,
                     }">

--- a/src/features/auth/views/ProfileView.vue
+++ b/src/features/auth/views/ProfileView.vue
@@ -212,7 +212,7 @@
               <v-img :src="editProfileData.profileImage" alt="No Image" />
             </v-avatar>
             <div class="d-flex justify-center align-center gap-2 mt-3">
-              <v-btn icon size="small" @click="selectImage" color="primary">
+              <v-btn icon size="small" color="primary" @click="selectImage">
                 <v-icon>mdi-camera</v-icon>
                 <v-tooltip activator="parent" location="bottom">
                   {{ t('profile.uploadProfilePicture') }}
@@ -222,8 +222,8 @@
                 v-if="editProfileData.profileImage"
                 icon
                 size="small"
-                @click="removeProfilePicture"
                 color="error"
+                @click="removeProfilePicture"
               >
                 <v-icon>mdi-delete</v-icon>
                 <v-tooltip activator="parent" location="bottom">
@@ -282,8 +282,8 @@
               </template>
               <template #item="{ item, props }">
                 <v-list-item
-                  v-bind="{ ...props, title: undefined }"
                   v-if="item.raw && item.raw.emoji"
+                  v-bind="{ ...props, title: undefined }"
                 >
                   <v-list-item-title>
                     {{ item.raw.emoji }} {{ item.raw.name }}

--- a/src/features/dashboard/components/ActiveStudies.vue
+++ b/src/features/dashboard/components/ActiveStudies.vue
@@ -39,8 +39,8 @@
             variant="outlined"
             rounded="lg"
             class="study-card"
-            @click="goToStudy(study)"
             hover
+            @click="goToStudy(study)"
           >
             <v-card-text class="pa-4">
               <div class="d-flex align-center justify-space-between mb-3">
@@ -84,7 +84,6 @@
                 </p>
                 <v-btn
                   v-if="study.isLongDescription"
-                  @click.stop="toggleExpand(study.id)"
                   variant="text"
                   size="small"
                   color="primary"
@@ -94,6 +93,7 @@
                       ? 'mdi-chevron-up'
                       : 'mdi-chevron-down'
                   "
+                  @click.stop="toggleExpand(study.id)"
                 >
                   {{ expandedStudies[study.id] ? 'Show less' : 'Show more' }}
                 </v-btn>

--- a/src/features/dashboard/components/BlogPosts.vue
+++ b/src/features/dashboard/components/BlogPosts.vue
@@ -19,8 +19,8 @@
           variant="text"
           size="small"
           color="primary"
-          @click="openBlog"
           target="_blank"
+          @click="openBlog"
         >
           View Blog
         </v-btn>

--- a/src/features/dashboard/components/NextSession.vue
+++ b/src/features/dashboard/components/NextSession.vue
@@ -84,8 +84,8 @@
         rounded="lg"
         prepend-icon="mdi-play-circle"
         :disabled=" getStatus(nextSession) === SESSION_STATUSES.COMPLETED"
-        @click="goto(nextSession)"
         class="action-button mt-6"
+        @click="goto(nextSession)"
       >
         {{ getStatus(nextSession) !== SESSION_STATUSES.COMPLETED ? 'Join Now' : 'Completed' }}
       </v-btn>

--- a/src/features/dashboard/components/UpcomingWebinar.vue
+++ b/src/features/dashboard/components/UpcomingWebinar.vue
@@ -2,7 +2,8 @@
   <v-card elevation="2" rounded="lg" class="upcoming-webinar-card position-relative">
     <!-- Status Overlay -->
     <div v-if="webinarStatus.show" class="coming-soon-overlay">
-      <v-chip :color="webinarStatus.color" variant="elevated" size="small" class="coming-soon-chip"
+      <v-chip
+:color="webinarStatus.color" variant="elevated" size="small" class="coming-soon-chip"
         :class="{ 'pulse-animation': webinarStatus.text === 'Live' }">
         <v-icon v-if="webinarStatus.icon" :icon="webinarStatus.icon" size="16" class="mr-1" />
         {{ webinarStatus.text }}
@@ -56,7 +57,8 @@
       </v-row>
 
       <!-- Join Button -->
-      <v-btn :color="buttonConfig.color" variant="flat" size="large" block rounded="lg" class="join-button"
+      <v-btn
+:color="buttonConfig.color" variant="flat" size="large" block rounded="lg" class="join-button"
         :prepend-icon="buttonConfig.icon" :disabled="buttonConfig.disabled" @click="buttonConfig.action">
         {{ buttonConfig.text }}
       </v-btn>

--- a/src/features/dashboard/views/DashboardView.vue
+++ b/src/features/dashboard/views/DashboardView.vue
@@ -37,7 +37,7 @@
         <UpcomingWebinar :webinar-data="upcomingWebinar || {}" />
       </v-col>
       <v-col cols="12" lg="4">
-        <TopMethods :methodsData="topMethodsData" />
+        <TopMethods :methods-data="topMethodsData" />
       </v-col>
       <v-col cols="12" lg="4">
         <NextSession :next-session="nextSession" />

--- a/src/features/navigation/components/MobileNavigationDrawer.vue
+++ b/src/features/navigation/components/MobileNavigationDrawer.vue
@@ -53,7 +53,8 @@
 
         <!-- Test Navigation Items -->
         <v-list class="test-nav-list" nav>
-          <v-list-item v-for="item in filteredTestItems" :key="item.id" :title="item.title" :prepend-icon="item.icon"
+          <v-list-item
+v-for="item in filteredTestItems" :key="item.id" :title="item.title" :prepend-icon="item.icon"
             :active="activeStep === item.id" :disabled="item.disabled" class="nav-item" rounded="lg"
             @click="navigateToStep(item)">
             <template v-if="item.status" #append>
@@ -80,7 +81,8 @@
             </div>
 
             <!-- Navigation Items -->
-            <v-list-item v-else :title="item.title" :subtitle="item.subtitle" :prepend-icon="item.icon"
+            <v-list-item
+v-else :title="item.title" :subtitle="item.subtitle" :prepend-icon="item.icon"
               :active="activeSection === item.id" class="nav-item" rounded="lg" @click="navigateToSection(item)">
               <template v-if="item.badge" #append>
                 <v-chip :color="item.badge.color" size="x-small" variant="flat">
@@ -94,12 +96,14 @@
 
       <!-- Action Buttons -->
       <div class="action-section pa-4 mt-auto">
-        <v-btn v-if="!isInTest" color="primary" block size="large" prepend-icon="mdi-plus" rounded="lg"
+        <v-btn
+v-if="!isInTest" color="primary" block size="large" prepend-icon="mdi-plus" rounded="lg"
           class="create-button mb-3" @click="createStudy">
           Create New Study
         </v-btn>
 
-        <v-btn v-if="isInTest" variant="outlined" color="primary" block prepend-icon="mdi-arrow-left" rounded="lg"
+        <v-btn
+v-if="isInTest" variant="outlined" color="primary" block prepend-icon="mdi-arrow-left" rounded="lg"
           class="mb-3" @click="exitTest">
           Exit Test
         </v-btn>

--- a/src/features/navigation/components/NotificationButton.vue
+++ b/src/features/navigation/components/NotificationButton.vue
@@ -42,7 +42,7 @@
       <v-card class="notification-dropdown" elevation="6">
         <!-- Header -->
         <div class="dropdown-header">
-          <span class="title">{{ $t('common.notifications') }}</span>
+          <span class="text-h6">{{ $t('common.notifications') }}</span>
 
           <div class="actions">
             <v-btn

--- a/src/features/navigation/components/TestNavigationDrawer.vue
+++ b/src/features/navigation/components/TestNavigationDrawer.vue
@@ -1,5 +1,6 @@
 <template>
-  <v-navigation-drawer v-model="isOpen" :width="drawerWidth" :temporary="isMobile" :permanent="!isMobile && isPermanent"
+  <v-navigation-drawer
+v-model="isOpen" :width="drawerWidth" :temporary="isMobile" :permanent="!isMobile && isPermanent"
     :location="isMobile ? 'left' : 'right'" elevation="0" class="test-drawer">
     <!-- Test Header -->
     <div class="test-header pa-4">
@@ -47,7 +48,8 @@
           </div>
 
           <!-- Navigation Items -->
-          <v-list-item v-else :title="item.title" :subtitle="item.subtitle" :prepend-icon="item.icon"
+          <v-list-item
+v-else :title="item.title" :subtitle="item.subtitle" :prepend-icon="item.icon"
             :active="activeStep === item.id" :disabled="item.disabled" class="nav-item mb-1" rounded="lg"
             @click="navigateToStep(item)">
             <template v-if="item.status" #append>
@@ -59,7 +61,8 @@
 
       <!-- Action Buttons -->
       <div class="action-buttons pa-4 mt-auto">
-        <v-btn v-if="canGoBack" variant="outlined" color="primary" block class="mb-2" prepend-icon="mdi-arrow-left"
+        <v-btn
+v-if="canGoBack" variant="outlined" color="primary" block class="mb-2" prepend-icon="mdi-arrow-left"
           @click="goBack">
           Previous Step
         </v-btn>

--- a/src/features/navigation/components/navbarSections/StorageSection.vue
+++ b/src/features/navigation/components/navbarSections/StorageSection.vue
@@ -49,7 +49,7 @@
 
         <!-- Study Name (clickable for preview) -->
         <template #[`item.studyName`]="{ item }">
-          <a href="#" @click.prevent="openPreview(item)" class="text-decoration-none text-high-emphasis font-weight-medium">
+          <a href="#" class="text-decoration-none text-high-emphasis font-weight-medium" @click.prevent="openPreview(item)">
             {{ item.studyName }}
           </a>
         </template>
@@ -114,11 +114,13 @@
           {{ previewFile?.studyName }} - {{ previewFile?.type }}
         </v-card-title>
         <v-card-text class="pa-4 bg-black d-flex justify-center align-center" style="min-height: 300px;">
-          <video v-if="['video', 'webcam', 'screen'].includes(previewFile?.type)" 
+          <video
+v-if="['video', 'webcam', 'screen'].includes(previewFile?.type)" 
                  :src="previewFile?.url" 
                  controls 
                  style="width: 100%; max-height: 600px;" />
-          <audio v-else-if="previewFile?.type === 'audio'" 
+          <audio
+v-else-if="previewFile?.type === 'audio'" 
                  :src="previewFile?.url" 
                  controls 
                  style="width: 100%;" />

--- a/src/features/notifications/components/NotificationItem.vue
+++ b/src/features/notifications/components/NotificationItem.vue
@@ -19,7 +19,7 @@
       <!-- Content -->
       <div class="content">
         <div class="title-row">
-          <div class="title">
+          <div class="text-h6">
             {{ notification.title || 'Notification' }}
             <span
               v-if="notification.type"

--- a/src/features/notifications/views/NotificationPage.vue
+++ b/src/features/notifications/views/NotificationPage.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="py-4">
-    <v-row justify="center" v-if="user">
+    <v-row v-if="user" justify="center">
       <v-col 
         cols="12" 
         md="10" 
@@ -31,11 +31,11 @@
               size="small"
               variant="flat"
               color="primary"
-              @click="markAllAsRead"
               :loading="markingAllAsRead"
               prepend-icon="mdi-email-open-outline"
               class="elevation-0 text-capitalize"
               :class="{'flex-shrink-0': true}"
+              @click="markAllAsRead"
             >
               Mark all read
             </v-btn>
@@ -146,8 +146,8 @@
                   'active': activeIndex === index,
                   'border-start-4': !n.read
                 }"
-                @click="handleNotificationClick(n)"
                 :style="!n.read ? 'border-left-color: var(--v-primary-base) !important' : ''"
+                @click="handleNotificationClick(n)"
               >
                 <div class="d-flex align-start gap-3">
                   <!-- AVATAR/ICON -->
@@ -203,8 +203,8 @@
                           icon
                           size="x-small"
                           variant="text"
-                          @click.stop="toggleRead(n)"
                           :aria-label="n.read ? 'Mark unread' : 'Mark read'"
+                          @click.stop="toggleRead(n)"
                         >
                           <v-icon size="18" :color="n.read ? 'grey' : 'primary'">
                             {{ n.read ? 'mdi-email-outline' : 'mdi-email-open-outline' }}
@@ -245,8 +245,8 @@
           <v-btn
             variant="text"
             prepend-icon="mdi-arrow-left"
-            @click="goBack"
             class="text-capitalize"
+            @click="goBack"
           >
             {{ $t('buttons.back') || 'Go Back' }}
           </v-btn>
@@ -256,9 +256,9 @@
             variant="tonal"
             size="small"
             prepend-icon="mdi-refresh"
-            @click="refreshNotifications"
             :loading="refreshing"
             class="text-capitalize"
+            @click="refreshNotifications"
           >
             Refresh
             <template #loader>

--- a/src/features/ux_creation/ChooseStudyType.vue
+++ b/src/features/ux_creation/ChooseStudyType.vue
@@ -20,8 +20,8 @@
             :description="option.description"
             :color="option.color"
             :badge="option.recommended ? { text: $t('studyCreation.comingSoon'), color: 'warning' } : null"
-            @click="() => selectOption(option.id)"
             :disabled="option.disabled"
+            @click="() => selectOption(option.id)"
           >
             <template #extra>
               <v-list class="bg-transparent pl-8 text-start" density="compact">

--- a/src/shared/components/CardsManager.vue
+++ b/src/shared/components/CardsManager.vue
@@ -2,9 +2,10 @@
   <v-container>
     <v-row justify="center" justify-md="space-around">
       <v-col v-for="(item, n) in cards" :key="n" cols="12" :md="12 / perRow">
-        <v-card :ripple="false" @click="$emit('click', item.path)"  :style="backgroundImage" elevation="3" rounded="lg">
+        <v-card :ripple="false" :style="backgroundImage"  elevation="3" rounded="lg" @click="$emit('click', item.path)">
           <div class="d-flex justify-center align-center pa-2">
-            <v-img height="180" max-width="180" max-height="200" :style="item.imageStyle"
+            <v-img
+height="180" max-width="180" max-height="200" :style="item.imageStyle"
               :src="require('../../assets/manager/' + item.image)" class="mx-auto" />
           </div>
           <v-divider></v-divider>

--- a/src/shared/components/TestConfigForm.vue
+++ b/src/shared/components/TestConfigForm.vue
@@ -1,10 +1,12 @@
 <template>
   <v-row>
     <v-col cols="12">
-      <TextareaForm v-model="welcomeMessageComputed" :title="$t('ModeratedTest.welcomeMessage')"
+      <TextareaForm
+v-model="welcomeMessageComputed" :title="$t('ModeratedTest.welcomeMessage')"
         :subtitle="$t('ModeratedTest.welcomeMessageDescription')" />
 
-      <TextareaForm v-model="finalMessageComputed" :title="$t('ModeratedTest.finalMessage')"
+      <TextareaForm
+v-model="finalMessageComputed" :title="$t('ModeratedTest.finalMessage')"
         :subtitle="$t('ModeratedTest.finalMessageDescription')" />
     </v-col>
   </v-row>

--- a/src/shared/components/TextareaForm.vue
+++ b/src/shared/components/TextareaForm.vue
@@ -5,7 +5,8 @@
         <v-row class="pa-4 pa-0">
           <v-col>
 
-            <v-card-title class="text-h5 font-weight-bold pa-0"
+            <v-card-title
+class="text-h5 font-weight-bold pa-0"
               :style="{ color: $vuetify.theme.current.colors['on-surface'] }">
               {{ title }}
             </v-card-title>

--- a/src/shared/components/UserVariables.vue
+++ b/src/shared/components/UserVariables.vue
@@ -3,7 +3,8 @@
     <v-row justify="center">
       <v-col cols="12" md="10" lg="12">
         <v-card class="elevation-2 rounded-lg pa-6">
-          <v-card-title class="text-h5 font-weight-bold mb-4"
+          <v-card-title
+class="text-h5 font-weight-bold mb-4"
             :style="{ color: $vuetify.theme.current.colors['on-surface'] }">
             {{ type === 'pre-test' ? $t('ModeratedTest.preTestVariables') : $t('ModeratedTest.postTestVariables') }}
           </v-card-title>
@@ -11,7 +12,8 @@
             <p class="text-body-1 mb-6" style="color: #4B5563;">
               {{ $t('ModeratedTest.configureVariables', { type: type }) }}
             </p>
-            <v-expansion-panels v-if="items.length > 0" variant="accordion" class="elevation-0"
+            <v-expansion-panels
+v-if="items.length > 0" variant="accordion" class="elevation-0"
               style="border: 1px solid #E5E7EB; border-radius: 12px;">
               <v-expansion-panel v-for="(item, i) in items" :key="i" class="rounded-lg mb-2" :disabled="isSaving">
                 <v-expansion-panel-title class="py-3 px-4">
@@ -19,15 +21,18 @@
                 </v-expansion-panel-title>
                 <v-expansion-panel-text class="pa-4">
                   <v-form @submit.prevent>
-                    <v-text-field v-model="item.title" :label="$t('UserTestTable.inputs.variableName')"
+                    <v-text-field
+v-model="item.title" :label="$t('UserTestTable.inputs.variableName')"
                       variant="outlined" density="comfortable" :rules="[v => !!v || $t('errors.fieldRequired')]"
                       color="primary" class="mb-4" @update:model-value="markDirty" />
-                    <v-textarea v-model="item.description" :label="$t('UserTestTable.inputs.description')"
+                    <v-textarea
+v-model="item.description" :label="$t('UserTestTable.inputs.description')"
                       variant="outlined" density="comfortable" color="primary" rows="3" class="mb-4"
                       @update:model-value="markDirty" />
                     <div v-if="item.selectionField">
                       <div v-for="(field, index) in item.selectionFields" :key="index" class="d-flex align-center mb-2">
-                        <v-text-field v-model="item.selectionFields[index]"
+                        <v-text-field
+v-model="item.selectionFields[index]"
                           :label="$t('UserTestTable.inputs.selection') + ` ${index + 1}`" variant="outlined"
                           density="comfortable" :rules="[v => !!v || $t('errors.fieldRequired')]" color="primary"
                           class="mr-2" @update:model-value="markDirty">
@@ -35,7 +40,8 @@
                             <v-icon color="accent" class="mr-2" @click="newSelection(i)">
                               mdi-plus-circle
                             </v-icon>
-                            <v-icon v-if="item.selectionFields.length > 1" color="error"
+                            <v-icon
+v-if="item.selectionFields.length > 1" color="error"
                               @click="deleteSelection(i, index)">
                               mdi-trash-can-outline
                             </v-icon>
@@ -54,11 +60,13 @@
                     </div>
                     <v-row align="center" class="mt-2">
                       <v-col cols="12" sm="6">
-                        <v-checkbox v-model="item.selectionField" :label="$t('UserTestTable.checkboxes.selectionField')"
+                        <v-checkbox
+v-model="item.selectionField" :label="$t('UserTestTable.checkboxes.selectionField')"
                           color="primary" @update:model-value="selectField(i); markDirty()" />
                       </v-col>
                       <v-col cols="12" sm="5">
-                        <v-checkbox v-model="item.textField" :label="$t('UserTestTable.checkboxes.textField')"
+                        <v-checkbox
+v-model="item.textField" :label="$t('UserTestTable.checkboxes.textField')"
                           color="primary" @update:model-value="selectText(i); markDirty()" />
                       </v-col>
                       <v-col cols="12" sm="1" class="text-right">
@@ -71,11 +79,13 @@
                 </v-expansion-panel-text>
               </v-expansion-panel>
             </v-expansion-panels>
-            <v-alert v-else type="info" icon="mdi-information-outline" class="mt-4 rounded-lg"
+            <v-alert
+v-else type="info" icon="mdi-information-outline" class="mt-4 rounded-lg"
               :text="$t('UserTestTable.messages.noVariables')" />
           </v-card-text>
           <v-card-actions>
-            <v-card class="border-dashed text-center py-6" width="100%" variant="outlined"
+            <v-card
+class="border-dashed text-center py-6" width="100%" variant="outlined"
               style="cursor: pointer; border-style: dashed !important; border-color: #D1D5DB;" @click="showModal">
               <v-card-text>
                 <v-icon icon="mdi-plus-circle" size="24" class="mb-2" />
@@ -92,13 +102,15 @@
     <!-- New Variable Dialog -->
     <v-dialog v-model="show" max-width="600" persistent transition="dialog-bottom-transition">
       <v-card class="rounded-lg pa-6">
-        <v-card-title class="text-h6 font-weight-bold mb-4"
+        <v-card-title
+class="text-h6 font-weight-bold mb-4"
           :style="{ color: $vuetify.theme.current.colors['on-surface'] }">
           {{ $t('ModeratedTest.createNewVariableTitle') }}
         </v-card-title>
         <v-card-text>
           <v-form ref="form" v-model="valid">
-            <v-text-field v-model="newItem" :label="$t('UserTestTable.inputs.variableName')" variant="outlined"
+            <v-text-field
+v-model="newItem" :label="$t('UserTestTable.inputs.variableName')" variant="outlined"
               density="comfortable" :rules="[v => !!v.trim() || $t('errors.fieldRequired')]" color="primary"
               @update:model-value="markDirty" />
           </v-form>
@@ -111,7 +123,8 @@
             </v-icon>
             {{ $t('buttons.close') }}
           </v-btn>
-          <v-btn color="success" variant="flat" class="px-6" :disabled="!valid || isSaving" :loading="isSaving"
+          <v-btn
+color="success" variant="flat" class="px-6" :disabled="!valid || isSaving" :loading="isSaving"
             @click="saveNewItem">
             <v-icon start>
               mdi-content-save

--- a/src/shared/components/buttons/ButtonSave.vue
+++ b/src/shared/components/buttons/ButtonSave.vue
@@ -5,7 +5,8 @@
 
     <v-tooltip v-if="visible" location="left">
       <template #activator="{ props }">
-        <v-btn size="large" icon fixed color="#F9A826" :disabled="disabled" class="save-btn" v-bind="props"
+        <v-btn
+size="large" icon fixed color="#F9A826" :disabled="disabled" class="save-btn" v-bind="props"
           @click="$emit('click')">
           <v-icon size="large">
             mdi-content-save

--- a/src/shared/components/buttons/ButtonSend.vue
+++ b/src/shared/components/buttons/ButtonSend.vue
@@ -1,7 +1,8 @@
 <template>
   <v-tooltip location="left">
     <template #activator="{ props }">
-      <v-btn :disabled="disabled" size="large" icon class="mr-5 mb-5" position="fixed" location="bottom right"
+      <v-btn
+:disabled="disabled" size="large" icon class="mr-5 mb-5" position="fixed" location="bottom right"
         color="#F9A826" v-bind="props" @click="emit('click')">
         <v-icon size="large">
           mdi-email

--- a/src/shared/components/dialogs/InviteDialog.vue
+++ b/src/shared/components/dialogs/InviteDialog.vue
@@ -1,8 +1,8 @@
 <template>
   <v-dialog
     :model-value="show"
-    @update:model-value="$emit('update:show', $event)"
     max-width="500"
+    @update:model-value="$emit('update:show', $event)"
   >
     <v-card class="rounded-lg">
       <v-card-title style="color: white" class="bg-primary rounded-top-lg">
@@ -35,8 +35,8 @@
             v-for="(coop, i) in selectedCoops"
             :key="i"
             closable
-            @click:close="removeSelectedCoop(i)"
             class="ml-2 mt-2"
+            @click:close="removeSelectedCoop(i)"
           >
             {{ typeof coop == 'object' ? coop.email : coop }}
           </v-chip>

--- a/src/shared/components/dialogs/MessageDialog.vue
+++ b/src/shared/components/dialogs/MessageDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-dialog :model-value="show" @update:model-value="$emit('update:show', $event)" max-width="500">
+    <v-dialog :model-value="show" max-width="500" @update:model-value="$emit('update:show', $event)">
         <v-card class="rounded-lg">
             <v-card-title style="color: white;" class="bg-primary rounded-top-lg">
                 <v-icon color="white" class="mr-2">
@@ -8,9 +8,11 @@
                 {{ title || 'Send a Message' }}
             </v-card-title>
             <v-card-text>
-                <v-text-field v-model="messageTitle" required :label="titleLabel || 'Title'"
+                <v-text-field
+v-model="messageTitle" required :label="titleLabel || 'Title'"
                     :hint="titleHint || 'Type a title for your message'" variant="outlined" class="rounded-lg mt-4" />
-                <v-textarea v-model="messageContent" required :label="contentLabel || 'Content'"
+                <v-textarea
+v-model="messageContent" required :label="contentLabel || 'Content'"
                     :hint="contentHint || 'Type the content of your message'" variant="outlined" class="rounded-lg" />
             </v-card-text>
             <v-divider />
@@ -19,7 +21,8 @@
                 <v-btn color="red" variant="outlined" class="rounded-lg" @click="onCancel">
                     {{ cancelText || 'Cancel' }}
                 </v-btn>
-                <v-btn color="orange" class="rounded-lg" :disabled="!messageTitle.trim() || !messageContent.trim()"
+                <v-btn
+color="orange" class="rounded-lg" :disabled="!messageTitle.trim() || !messageContent.trim()"
                     @click="onSend">
                     {{ sendText || 'Send' }}
                 </v-btn>

--- a/src/shared/components/tables/ListComponent.vue
+++ b/src/shared/components/tables/ListComponent.vue
@@ -8,8 +8,8 @@
     class="rounded-lg"
     elevation="2"
     hover
-    @click:row="emitClick"
     :loading="loadingStudy"
+    @click:row="emitClick"
   >
     <!-- Type Column -->
     <template #item.type="{ item }">

--- a/src/shared/views/ReportView.vue
+++ b/src/shared/views/ReportView.vue
@@ -37,7 +37,7 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
-    <template #subtitle v-if="showIntroView">
+    <template v-if="showIntroView" #subtitle>
       <div class="d-flex align-center">
         <v-icon
           icon="mdi-update"
@@ -50,7 +50,7 @@
       </div>
     </template>
 
-    <template #filters v-if="showIntroView">
+    <template v-if="showIntroView" #filters>
       <div class="d-flex align-center justify-space-between mb-6">
         <div class="d-flex align-center gap-4">
           <v-text-field

--- a/src/shared/views/SettingsView.vue
+++ b/src/shared/views/SettingsView.vue
@@ -250,7 +250,7 @@
                     max-width="290px"
                     min-width="auto"
                   >
-                    <template v-slot:activator="{ props }">
+                    <template #activator="{ props }">
                       <v-text-field
                         :model-value="formattedEndDate"
                         :label="$t('pages.settings.select_end_date')"

--- a/src/ux/CardSorting/components/CardSortingCard.vue
+++ b/src/ux/CardSorting/components/CardSortingCard.vue
@@ -9,9 +9,9 @@
         {{ props.element.title }}
       </div>
 
-      <div class="d-flex ml-auto align-center" v-if="props.options.card_tooltip && props.element.tooltip">
+      <div v-if="props.options.card_tooltip && props.element.tooltip" class="d-flex ml-auto align-center">
         <v-tooltip :text="element.tooltip">
-          <template v-slot:activator="{ props }">
+          <template #activator="{ props }">
             <v-icon v-bind="props">
               mdi-information-slab-circle-outline
             </v-icon>

--- a/src/ux/CardSorting/components/CardSortingTask.vue
+++ b/src/ux/CardSorting/components/CardSortingTask.vue
@@ -12,7 +12,8 @@
                 <VCardTitle class="d-flex justify-center align-center">
                   <VCol class="text-center">
                     <p>{{ pendingAllocationCount }} of {{ props.test.testStructure.cardSorting.cards.length }} cards</p>
-                    <v-progress-linear v-model="pendingAllocationCount" color="primary" height="12"
+                    <v-progress-linear
+v-model="pendingAllocationCount" color="primary" height="12"
                       :max="props.test.testStructure.cardSorting.cards.length" />
                   </VCol>
                 </VCardTitle>
@@ -26,8 +27,9 @@
             </VCol>
 
             <!-- Categories -->
-            <VCol :cols="12 / (categories.length + 1)" class="mb-0 pb-0" v-for="(category, index) in categories"
-              :key="index">
+            <VCol
+v-for="(category, index) in categories" :key="index" :cols="12 / (categories.length + 1)"
+              class="mb-0 pb-0">
               <VCard class="card-category category">
                 <VCardTitle class="d-flex justify-center align-center">
                   <VCol class="text-center">
@@ -38,7 +40,8 @@
                   </VCol>
                 </VCardTitle>
 
-                <Draggable :list="localTestAnswer.tasks[category.title]" item-key="title" class="list-group"
+                <Draggable
+:list="localTestAnswer.tasks[category.title]" item-key="title" class="list-group"
                   group="cards">
                   <template #item="{ element }">
                     <CardSortingCard :element="element" :options="props.test.testStructure.cardSorting.options" />

--- a/src/ux/CardSorting/components/CardSortingTest.vue
+++ b/src/ux/CardSorting/components/CardSortingTest.vue
@@ -11,7 +11,8 @@
                 <text-clamp class="titleText" :text="test.testTitle" :max-lines="2" />
               </v-col>
               <v-col>
-                <v-progress-circular rotate="-90" :model-value="calculateProgress()" color="#fca326" :size="50"
+                <v-progress-circular
+rotate="-90" :model-value="calculateProgress()" color="#fca326" :size="50"
                   class="mt-2">
                   {{ calculateProgress() }}%
                 </v-progress-circular>
@@ -21,7 +22,8 @@
         </div>
 
         <!-- Navigation Body -->
-        <v-list class="nav-list" density="compact" max-height="85%"
+        <v-list
+class="nav-list" density="compact" max-height="85%"
           style="overflow-y: auto; overflow-x: hidden; padding-bottom: 100px">
           <div v-for="item in items" :key="item.id">
             <!-- Pre Test -->

--- a/src/ux/CardSorting/components/CardsEditCardSorting.vue
+++ b/src/ux/CardSorting/components/CardsEditCardSorting.vue
@@ -80,7 +80,7 @@
         </v-card>
       </v-col>
     </v-row>
-    <CardSortingForm :value="card" v-model:dialog="dialog" @save="save" :options="options" />
+    <CardSortingForm v-model:dialog="dialog" :value="card" :options="options" @save="save" />
   </v-container>
 </template>
 

--- a/src/ux/CardSorting/components/dialogs/CardSortingForm.vue
+++ b/src/ux/CardSorting/components/dialogs/CardSortingForm.vue
@@ -9,7 +9,8 @@
         <VForm ref="form">
           <VRow justify="space-around">
             <VCol class="mt-4" cols="5">
-              <v-text-field v-model="localTask.title" :label="$t('common.name')" :rules="requiredRule"
+              <v-text-field
+v-model="localTask.title" :label="$t('common.name')" :rules="requiredRule"
                 variant="outlined" density="compact" />
               <quill-editor v-if="options.category_description || options.card_description" v-model:value="localTask.description" class="mb-5" style="height: 40%;" />
             </VCol>

--- a/src/ux/CardSorting/views/TestView.vue
+++ b/src/ux/CardSorting/views/TestView.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Loading />
-    <StartScreenTest v-if="!isTestStarted && test" @start="isTestStarted = true" :test="test" />
+    <StartScreenTest v-if="!isTestStarted && test" :test="test" @start="isTestStarted = true" />
     <!-- <CardSortingTest v-if="isTestStarted" :test="test" /> -->
   </div>
 </template>

--- a/src/ux/Heuristic/components/AddCommentBtn.vue
+++ b/src/ux/Heuristic/components/AddCommentBtn.vue
@@ -67,16 +67,16 @@
           clearable
           clear-icon="mdi-close"
           :label="$t('common.comment')"
-          @update:model-value="updateComment"
           :disabled="disable"
+          @update:model-value="updateComment"
         />
         <ImageImport
           v-if="show"
           :heuristic-id="test.testStructure[heurisIndex]"
           :question-id="answerHeu.heuristicId"
           :test-id="store.getters.test.id"
-          @image-uploaded="handleImageUploaded"
           :disable="disable"
+          @image-uploaded="handleImageUploaded"
         />
       </v-col>
     </v-row>

--- a/src/ux/Heuristic/components/HeuristicsAnalytics.vue
+++ b/src/ux/Heuristic/components/HeuristicsAnalytics.vue
@@ -169,7 +169,7 @@
                         :items="itemsHeuristic"
                         :search="search"
                         height="375px"
-                        dense
+                        density="compact"
                       >
                         <template
                           v-for="header in headersHeuristic"

--- a/src/ux/Heuristic/components/HeuristicsTable.vue
+++ b/src/ux/Heuristic/components/HeuristicsTable.vue
@@ -79,8 +79,8 @@
                     size="small"
                     color="accent"
                     :disabled="index === 0 || testAnswerDocLength > 0"
-                    @click="moveItemUp(index)"
                     class="action-btn"
+                    @click="moveItemUp(index)"
                   >
                     <v-icon>mdi-arrow-up</v-icon>
                     <v-tooltip
@@ -96,8 +96,8 @@
                     size="small"
                     color="accent"
                     :disabled="index === filteredHeuristics.length - 1 || testAnswerDocLength > 0"
-                    @click="moveItemDown(index)"
                     class="action-btn"
+                    @click="moveItemDown(index)"
                   >
                     <v-icon>mdi-arrow-down</v-icon>
                     <v-tooltip
@@ -113,8 +113,8 @@
                     size="small"
                     color="accent"
                     :disabled="testAnswerDocLength > 0"
-                    @click="setupQuestion(index)"
                     class="action-btn"
+                    @click="setupQuestion(index)"
                   >
                     <v-icon>mdi-plus</v-icon>
                     <v-tooltip
@@ -131,8 +131,8 @@
                     size="small"
                     color="primary"
                     :disabled="testAnswerDocLength > 0"
-                    @click="editHeuris(heuristic)"
                     class="action-btn"
+                    @click="editHeuris(heuristic)"
                   >
                     <v-icon>mdi-pencil</v-icon>
                   </v-btn>
@@ -155,8 +155,8 @@
                     size="small"
                     color="error"
                     :disabled="testAnswerDocLength > 0"
-                    @click="deleteHeuristic(index)"
                     class="action-btn"
+                    @click="deleteHeuristic(index)"
                   >
                     <v-icon>mdi-delete</v-icon>
                         </v-btn>
@@ -240,8 +240,8 @@
                               variant="text"
                               size="small"
                               color="primary"
-                              @click.stop="editQuestions(question)"
                               class="action-btn"
+                              @click.stop="editQuestions(question)"
                             />
                             <v-btn
                               icon="mdi-delete"
@@ -249,8 +249,8 @@
                               size="small"
                               color="error"
                               :disabled="testAnswerDocLength > 0"
-                              @click.stop="deleteQuestion(qIndex)"
                               class="action-btn"
+                              @click.stop="deleteQuestion(qIndex)"
                             />
                           </div>
                         </div>
@@ -273,8 +273,8 @@
                                     :ref="el => descBtn[index] = el"
                                     :question-index="questionSelect"
                                     :heuristic-index="itemSelect"
-                                    @update-description="updateDescription"
                                     class="add-desc-btn"
+                                    @update-description="updateDescription"
                                   />
                                 </div>
                                 
@@ -301,8 +301,8 @@
                                           size="small"
                                           variant="text"
                                           color="primary"
-                                          @click="editDescription(item)"
                                           class="table-action-btn"
+                                          @click="editDescription(item)"
                                         >
                                           <v-icon size="small">
                                             mdi-pencil
@@ -313,8 +313,8 @@
                                           size="small"
                                           variant="text"
                                           color="error"
-                                          @click="deleteItem(item)"
                                           class="table-action-btn"
+                                          @click="deleteItem(item)"
                                         >
                                           <v-icon size="small">
                                             mdi-delete
@@ -581,16 +581,16 @@
               <v-spacer />
               <v-btn
                 variant="text"
-                @click="closeDialog('dialogEdit')"
                 :disabled="isProcessing"
+                @click="closeDialog('dialogEdit')"
               >
                 {{ $t('HeuristicsTable.titles.cancel') }}
               </v-btn>
               <v-btn
                 color="primary"
                 variant="elevated"
-                @click="validateEdit"
                 :disabled="isProcessing || !itemEdit || isDialogClosing"
+                @click="validateEdit"
               >
                 {{ $t('HeuristicsTable.titles.ok') }}
               </v-btn>

--- a/src/ux/Heuristic/components/HeuristicsTestAnswer.vue
+++ b/src/ux/Heuristic/components/HeuristicsTestAnswer.vue
@@ -169,7 +169,7 @@
                   cols="10"
                 >
                   <v-data-table
-                    dense
+                    density="compact"
                     :headers="evaluatorStatistics.header"
                     :items="evaluatorStatistics.items"
                     :items-per-page="15"
@@ -302,7 +302,7 @@
                           :items="heuristicsEvaluator.items"
                           :items-per-page="15"
                           class="elevation-0 cardStyle mx-2 mt-3 mb-6"
-                          dense
+                          density="compact"
                         >
                           <template
                             v-for="header in heuristicsEvaluator.header"
@@ -336,7 +336,7 @@
                           :items="heuristicsStatistics.items"
                           :items-per-page="15"
                           class="elevation-0 cardStyle mx-2 mt-3 mb-6"
-                          dense
+                          density="compact"
                         >
                           <template #item.percentage="{ item }">
                             <div style="padding-top: 2px; padding-bottom: 2px">

--- a/src/ux/Heuristic/components/ImportImage.vue
+++ b/src/ux/Heuristic/components/ImportImage.vue
@@ -9,8 +9,8 @@
         ? $t('common.inputImage')
         : url
       "
-      @change="uploadFile"
       :disabled="disable"
+      @change="uploadFile"
     />
     <!-- Add the image field to display the inputted image -->
     <v-row justify="center">

--- a/src/ux/Heuristic/components/OptionsTable.vue
+++ b/src/ux/Heuristic/components/OptionsTable.vue
@@ -9,7 +9,8 @@
         </h1>
       </div>
 
-      <v-btn color="primary" prepend-icon="mdi-plus" variant="elevated" size="large" :disabled="testAnswerDocLength > 0"
+      <v-btn
+color="primary" prepend-icon="mdi-plus" variant="elevated" size="large" :disabled="testAnswerDocLength > 0"
         class="text-none add-option-btn" @click="dialog = true">
         {{ $t('HeuristicsTable.titles.addOption') }}
       </v-btn>
@@ -20,12 +21,14 @@
     <div class="options-table-container">
       <!-- Desktop Table View (only show when there are items) -->
       <v-card v-if="optionsWithFormattedValue.length > 0" class="options-table-card desktop-table">
-        <v-data-table :headers="headers" :items="optionsWithFormattedValue" :items-per-page="-1"
+        <v-data-table
+:headers="headers" :items="optionsWithFormattedValue" :items-per-page="-1"
           class="elevation-0 options-data-table" hide-default-footer>
           <!-- Custom header styling -->
           <template #headers="{ columns }">
             <tr class="table-header">
-              <th v-for="column in columns" :key="column.key" class="text-left font-weight-medium text-ternary pa-4"
+              <th
+v-for="column in columns" :key="column.key" class="text-left font-weight-medium text-ternary pa-4"
                 :style="{ width: column.width }">
                 {{ column.title }}
               </th>
@@ -52,10 +55,12 @@
               </td>
               <td class="pa-4 actions-cell">
                 <div class="d-flex gap-2 option-actions">
-                  <v-btn icon="mdi-pencil" variant="text" size="small" color="primary"
-                    :disabled="testAnswerDocLength > 0" @click="editItem(item)" class="table-action-btn" />
-                  <v-btn icon="mdi-delete" variant="text" size="small" color="error" :disabled="testAnswerDocLength > 0"
-                    @click="deleteItem(item)" class="table-action-btn" />
+                  <v-btn
+icon="mdi-pencil" variant="text" size="small" color="primary"
+                    :disabled="testAnswerDocLength > 0" class="table-action-btn" @click="editItem(item)" />
+                  <v-btn
+icon="mdi-delete" variant="text" size="small" color="error" :disabled="testAnswerDocLength > 0"
+                    class="table-action-btn" @click="deleteItem(item)" />
                 </div>
               </td>
             </tr>
@@ -90,7 +95,8 @@
                   <h5 class="text-subtitle-1 font-weight-medium text-on-surface option-title-mobile mb-0">
                     {{ item.text }}
                   </h5>
-                  <p v-if="item.description && item.description !== '-'"
+                  <p
+v-if="item.description && item.description !== '-'"
                     class="text-body-2 text-ternary ma-0 mt-1 option-desc-mobile">
                     {{ item.description }}
                   </p>
@@ -98,10 +104,12 @@
               </div>
 
               <div class="d-flex gap-1 option-actions-mobile">
-                <v-btn icon="mdi-pencil" variant="text" size="small" color="primary" :disabled="testAnswerDocLength > 0"
-                  @click.stop="editItem(item)" class="action-btn-mobile" />
-                <v-btn icon="mdi-delete" variant="text" size="small" color="error" :disabled="testAnswerDocLength > 0"
-                  @click.stop="deleteItem(item)" class="action-btn-mobile" />
+                <v-btn
+icon="mdi-pencil" variant="text" size="small" color="primary" :disabled="testAnswerDocLength > 0"
+                  class="action-btn-mobile" @click.stop="editItem(item)" />
+                <v-btn
+icon="mdi-delete" variant="text" size="small" color="error" :disabled="testAnswerDocLength > 0"
+                  class="action-btn-mobile" @click.stop="deleteItem(item)" />
               </div>
             </div>
           </v-card>
@@ -130,8 +138,9 @@
             </span>
           </div>
           <div class="d-flex align-center gap-2">
-            <v-btn v-if="testAnswerDocLength === 0" color="primary" variant="outlined" size="small"
-              prepend-icon="mdi-plus" @click="dialog = true" class="mobile-add-btn">
+            <v-btn
+v-if="testAnswerDocLength === 0" color="primary" variant="outlined" size="small"
+              prepend-icon="mdi-plus" class="mobile-add-btn" @click="dialog = true">
               Add Option
             </v-btn>
           </div>
@@ -140,7 +149,8 @@
     </div>
 
     <!-- AddOptionBtn Component -->
-    <AddOptionBtn v-model:dialog="dialog" :option="option" :has-value="hasValue" @change-has-value="updateHasValue"
+    <AddOptionBtn
+v-model:dialog="dialog" :option="option" :has-value="hasValue" @change-has-value="updateHasValue"
       @add-option="updateOptions" @change="emitChange" />
   </v-card>
 </template>

--- a/src/ux/Heuristic/components/manager/ParticipantsList.vue
+++ b/src/ux/Heuristic/components/manager/ParticipantsList.vue
@@ -115,7 +115,7 @@
             {{ $t('manager.sendReminder') }}
           </v-list-item-title>
         </v-list-item>
-        <v-list-item @click="removeParticipant" class="text-error">
+        <v-list-item class="text-error" @click="removeParticipant">
           <v-list-item-title>
             <v-icon size="small" class="mr-2">mdi-account-remove</v-icon>
             {{ $t('manager.removeParticipant') }}

--- a/src/ux/Heuristic/views/EditTest.vue
+++ b/src/ux/Heuristic/views/EditTest.vue
@@ -19,10 +19,10 @@
         <!-- Desktop Tabs -->
         <v-tabs
           v-if="!isMobile"
+          v-model="index"
           bg-color="transparent"
           color="#FCA326"
           class="pb-0 mb-0"
-          v-model="index"
         >
           <v-tab>{{ $t('HeuristicsEditTest.titles.heuristics') }}</v-tab>
           <v-tab>{{ $t('HeuristicsEditTest.titles.options') }}</v-tab>

--- a/src/ux/Heuristic/views/FinalReportView.vue
+++ b/src/ux/Heuristic/views/FinalReportView.vue
@@ -1,5 +1,6 @@
 <template>
-  <PageWrapper :title="answers.length > 0 ? $t('Final Report') : ''" :loading="loading"
+  <PageWrapper
+:title="answers.length > 0 ? $t('Final Report') : ''" :loading="loading"
     :loading-text="$t('HeuristicsReport.messages.reports_loading')" :side-gap="true">
 
     <!-- Subtitle Slot - only show when answers exist -->
@@ -16,7 +17,8 @@
     <div v-else class="finalReportView">
       <v-container>
 
-        <v-stepper :model-value="step" style="background-color:#F5F7FF" class="final-report-box rounded pt-0 mb-4"
+        <v-stepper
+:model-value="step" style="background-color:#F5F7FF" class="final-report-box rounded pt-0 mb-4"
           elevation="0">
           <v-stepper-header style="background-color: #F5F7FF;" class="pt-2">
             <v-stepper-item :complete="step > 1" :value="1" color="orange">

--- a/src/ux/Heuristic/views/HeuristicAnswerView.vue
+++ b/src/ux/Heuristic/views/HeuristicAnswerView.vue
@@ -4,7 +4,7 @@
     :side-gap="true"
   >
     <!-- Subtitle Slot -->
-    <template #subtitle v-if="hasTestAnswerDocument">
+    <template v-if="hasTestAnswerDocument" #subtitle>
       <p class="text-body-1 text-grey-darken-1">
         {{ $t('analytics.overallAnalyticsDescription') }}
       </p>

--- a/src/ux/Heuristic/views/HeuristicTestView.vue
+++ b/src/ux/Heuristic/views/HeuristicTestView.vue
@@ -389,10 +389,10 @@
                         currentUserTestAnswer.heuristicQuestions[heurisIndex]
                           ?.heuristicQuestions[i] || {}
                       "
+                      :disable="currentUserTestAnswer?.submitted"
                       @update-comment="
                         (comment) => updateComment(comment, heurisIndex, i)
                       "
-                      :disable="currentUserTestAnswer?.submitted"
                     >
                       <template #answer>
                         <v-select
@@ -405,8 +405,8 @@
                           item-value="value"
                           variant="outlined"
                           density="compact"
-                          @update:model-value="calculateProgress()"
                           :disabled="currentUserTestAnswer?.submitted"
+                          @update:model-value="calculateProgress()"
                         />
                         <v-alert v-else type="error" class="mt-4">
                           {{ $t('HeuristicsTestView.errors.questionNotLoaded') }}
@@ -471,8 +471,8 @@
                           <v-btn
                             color="testPrimary"
                             variant="flat"
-                            @click="dialog = true"
                             :disabled="currentUserTestAnswer?.submitted"
+                            @click="dialog = true"
                           >
                             <v-icon start>
                               mdi-send

--- a/src/ux/UserTest/calibration/GeneralConfigCard.vue
+++ b/src/ux/UserTest/calibration/GeneralConfigCard.vue
@@ -2,7 +2,8 @@
     <v-container>
         <v-col>
             <v-card flat>
-                <v-card-title class="text-h5 font-weight-bold mb-4"
+                <v-card-title
+class="text-h5 font-weight-bold mb-4"
                     :style="{ color: $vuetify.theme.current.colors['on-surface'] }">
                     General Configuration
                 </v-card-title>
@@ -11,7 +12,8 @@
                     <!-- Point Number -->
                     <v-tooltip text="Number of calibration points shown on the screen (more points = higher accuracy).">
                         <template #activator="{ props }">
-                            <v-slider v-bind="props" v-model="pointNumber" :min="2" :max="9" step="1"
+                            <v-slider
+v-bind="props" v-model="pointNumber" :min="2" :max="9" step="1"
                                 label="Point Number" thumb-label />
                         </template>
                     </v-tooltip>
@@ -20,7 +22,8 @@
                     <v-tooltip
                         text="How many gaze samples are collected per calibration point. Higher values improve precision but increase duration.">
                         <template #activator="{ props }">
-                            <v-slider v-bind="props" v-model="samplePerPoint" :min="10" :max="200" step="1"
+                            <v-slider
+v-bind="props" v-model="samplePerPoint" :min="10" :max="200" step="1"
                                 label="Samples Per Point" thumb-label />
                         </template>
                     </v-tooltip>
@@ -29,7 +32,8 @@
                     <v-tooltip
                         text="Duration (in milliseconds) to capture data per point. Defines how long the user must look at each target.">
                         <template #activator="{ props }">
-                            <v-slider v-bind="props" v-model="msPerCapture" :min="20" :max="100" step="5"
+                            <v-slider
+v-bind="props" v-model="msPerCapture" :min="20" :max="100" step="5"
                                 label="Milliseconds Per Point Capture" thumb-label />
                         </template>
                     </v-tooltip>
@@ -38,7 +42,8 @@
                     <v-tooltip
                         text="Maximum distance (in pixels) allowed between calibration samples before they are discarded. Controls spatial tolerance.">
                         <template #activator="{ props }">
-                            <v-slider v-bind="props" v-model="threshold" :min="0" :max="1000" step="5"
+                            <v-slider
+v-bind="props" v-model="threshold" :min="0" :max="1000" step="5"
                                 label="Points Distance Threshold" thumb-label />
                         </template>
                     </v-tooltip>

--- a/src/ux/UserTest/calibration/MiscConfigCard.vue
+++ b/src/ux/UserTest/calibration/MiscConfigCard.vue
@@ -2,7 +2,8 @@
     <v-container>
         <v-col>
             <v-card flat>
-                <v-card-title class="text-h5 font-weight-bold mb-4"
+                <v-card-title
+class="text-h5 font-weight-bold mb-4"
                     :style="{ color: $vuetify.theme.current.colors['on-surface'] }">
                     Miscelaneous configuration
                 </v-card-title>
@@ -22,7 +23,8 @@
                 </div>
                 <div class="custom-outline">
                     Model Selection:
-                    <v-select v-model="selectedModel" :items="availableModels" outlined
+                    <v-select
+v-model="selectedModel" :items="availableModels" variant="outlined"
                         placeholder="Select Model"></v-select>
                 </div>
                 <div class="custom-outline">

--- a/src/ux/UserTest/calibration/OffsetCalibration.vue
+++ b/src/ux/UserTest/calibration/OffsetCalibration.vue
@@ -3,7 +3,8 @@
         <v-col cols="8">
             <v-tooltip text="Offset (in pixels) to adjust the calibration area position." location="bottom">
                 <template #activator="{ props }">
-                    <v-slider v-bind="props" v-model="offset" :min="100" :max="300" step="5" label="Offset"
+                    <v-slider
+v-bind="props" v-model="offset" :min="100" :max="300" step="5" label="Offset"
                         thumb-label />
                 </template>
             </v-tooltip>

--- a/src/ux/UserTest/calibration/RadiusCalibration.vue
+++ b/src/ux/UserTest/calibration/RadiusCalibration.vue
@@ -1,7 +1,8 @@
 <template>
     <v-row class="d-flex align-center" no-gutters>
         <v-col cols="10">
-            <v-tooltip text="Adjust the radius of the calibration point. Larger values make the point bigger."
+            <v-tooltip
+text="Adjust the radius of the calibration point. Larger values make the point bigger."
                 location="bottom">
                 <template #activator="{ props }">
                     <v-slider v-bind="props" v-model="radius" :min="10" :max="35" step="1" label="Radius" thumb-label />

--- a/src/ux/UserTest/components/CalibrationInProgressModal.vue
+++ b/src/ux/UserTest/components/CalibrationInProgressModal.vue
@@ -6,7 +6,7 @@
             </v-card-title>
 
             <v-card-text class="mt-14 d-flex flex-column align-center justify-center">
-                <div class="mb-4 text-h6" v-if="!isCompleted">
+                <div v-if="!isCompleted" class="mb-4 text-h6">
                     Calibrating, please wait...
                 </div>
 
@@ -16,11 +16,11 @@
                         mdi-check
                     </v-icon>
                 </div>
-                <div class="text-subtitle-1 mt-auto" v-if="!isCompleted">
-                    The calibration didn't open? <a @click="$emit('openCalibration')" class="openCalib">Click here</a>
+                <div v-if="!isCompleted" class="text-subtitle-1 mt-auto">
+                    The calibration didn't open? <a class="openCalib" @click="$emit('openCalibration')">Click here</a>
                 </div>
 
-                <div class="text-subtitle-1 mt-auto" v-else>
+                <div v-else class="text-subtitle-1 mt-auto">
                     The calibration was successful!
                     <br>
                     <v-btn class="mt-4" color="primary" @click="$emit('close')">

--- a/src/ux/UserTest/components/ModeratedTestAnalytics/TranscriptionTool.vue
+++ b/src/ux/UserTest/components/ModeratedTestAnalytics/TranscriptionTool.vue
@@ -107,7 +107,7 @@
                   :answers-doc-id="testDocument?.answersDocId"
                   :user-doc-id="selectedUserID"
                   :task-id="selectedTaskId"
-                  :latestTranscriptionId="
+                  :latest-transcription-id="
                     selectedTask?.latestTranscriptionDocId
                   "
                 />
@@ -168,15 +168,6 @@
     </div> -->
   </div>
 </template>
-
-<style scoped>
-.panel-shell {
-  background: #e8eaf2;
-  width: 100%; /* ✅ full width */
-  padding: 0;
-  border-radius: 0;
-}
-</style>
 
 <script setup>
 import { computed, ref, watch } from 'vue'
@@ -304,3 +295,12 @@ function getCooperatorEmail(userDocId) {
   return cooperatorEmail
 }
 </script>
+
+<style scoped>
+.panel-shell {
+  background: #e8eaf2;
+  width: 100%; /* ✅ full width */
+  padding: 0;
+  border-radius: 0;
+}
+</style>

--- a/src/ux/UserTest/components/SessionAnalytics.vue
+++ b/src/ux/UserTest/components/SessionAnalytics.vue
@@ -17,7 +17,7 @@
                     <v-list density="compact" class="list-scroll">
                         <v-list-subheader>Evaluators</v-list-subheader>
                         <v-divider />
-                        <v-list dense nav>
+                        <v-list density="compact" nav>
                             <v-list-item v-for="i in 2" :key="i" class="rounded" @click="selectedUserId = i">
                                 <v-list-item-title>
                                     <v-skeleton-loader type="text" width="80%" />
@@ -99,6 +99,14 @@ export default {
             _timelineInterval: null
         };
     },
+    mounted() {
+        this._timelineInterval = setInterval(() => {
+            this.updateTimeline();
+        }, 200);
+    },
+    beforeUnmount() {
+        clearInterval(this._timelineInterval);
+    },
     methods: {
         emitTimelineUpdate() {
             const v1 = this.$refs.mainVideo1;
@@ -156,14 +164,6 @@ export default {
                 this.emitTimelineUpdate();
             }
         }
-    },
-    mounted() {
-        this._timelineInterval = setInterval(() => {
-            this.updateTimeline();
-        }, 200);
-    },
-    beforeUnmount() {
-        clearInterval(this._timelineInterval);
     }
 }
 

--- a/src/ux/UserTest/components/StartCalibrationButton.vue
+++ b/src/ux/UserTest/components/StartCalibrationButton.vue
@@ -1,6 +1,7 @@
 <template>
     <v-col cols="12" class="text-center">
-        <v-btn v-if="!calibrationInProgress" color="primary" variant="flat" size="large"
+        <v-btn
+v-if="!calibrationInProgress" color="primary" variant="flat" size="large"
             @click="$emit('openCalibration')">
             {{ $t('UserTestView.CalibrationStep.startButton') }}
         </v-btn>

--- a/src/ux/UserTest/components/StepSelector.vue
+++ b/src/ux/UserTest/components/StepSelector.vue
@@ -25,8 +25,8 @@
           icon 
           size="small" 
           variant="text" 
-          @click="toggleStepPanel"
           class="close-btn"
+          @click="toggleStepPanel"
         >
           <v-icon>mdi-close</v-icon>
         </v-btn>
@@ -40,7 +40,7 @@
             size="large" 
             class="mb-3"
           >
-            <v-icon left>mdi-play-circle</v-icon>
+            <v-icon start>mdi-play-circle</v-icon>
             Step {{ currentStep }} of {{ totalSteps }}
           </v-chip>
           <p class="step-description">{{ getCurrentStepDescription() }}</p>
@@ -93,7 +93,7 @@
                 </div>
               </div>
               
-              <div class="step-item-action" v-if="index + 1 !== currentStep">
+              <div v-if="index + 1 !== currentStep" class="step-item-action">
                 <v-btn
                   size="small"
                   variant="text"
@@ -113,22 +113,22 @@
             size="large"
             block
             class="mb-2"
-            @click="proceedToNextStep"
             :disabled="currentStep >= totalSteps"
+            @click="proceedToNextStep"
           >
-            <v-icon left>mdi-arrow-right</v-icon>
+            <v-icon start>mdi-arrow-right</v-icon>
             {{ currentStep >= totalSteps ? 'Test Complete' : `Proceed to Step ${currentStep + 1}` }}
           </v-btn>
           
           <v-btn
+            v-if="currentStep > 1"
             color="primary"
             size="large"
             block
             variant="outlined"
             @click="resetToFirstStep"
-            v-if="currentStep > 1"
           >
-            <v-icon left>mdi-restart</v-icon>
+            <v-icon start>mdi-restart</v-icon>
             Restart Test
           </v-btn>
         </div>

--- a/src/ux/UserTest/components/UnmoderatedTestAnalytics/SartAnalytics.vue
+++ b/src/ux/UserTest/components/UnmoderatedTestAnalytics/SartAnalytics.vue
@@ -169,7 +169,8 @@
                                 </div>
                                 <div class="flex-grow-1 mx-4">
                                   <div class="progress-container">
-                                    <div class="progress-bar" :style="{
+                                    <div
+class="progress-bar" :style="{
                                       width: `${(analytics.dimensionAverages[dimension.key] / 7) * 100}%`,
                                       backgroundColor: getGroupColor('demand'),
                                       borderRadius: '20px',
@@ -177,7 +178,8 @@
                                       position: 'relative',
                                       minWidth: '40px'
                                     }">
-                                      <span class="progress-text" style="
+                                      <span
+class="progress-text" style="
                                           position: absolute;
                                           left: 50%;
                                           top: 50%;
@@ -193,7 +195,8 @@
                                     </div>
                                   </div>
                                 </div>
-                                <div class="score-display text-body-1 font-weight-bold text-right"
+                                <div
+class="score-display text-body-1 font-weight-bold text-right"
                                   style="min-width: 50px;">
                                   {{ analytics.dimensionAverages[dimension.key].toFixed(1) }}
                                 </div>
@@ -235,7 +238,8 @@
                                 </div>
                                 <div class="flex-grow-1 mx-4">
                                   <div class="progress-container">
-                                    <div class="progress-bar" :style="{
+                                    <div
+class="progress-bar" :style="{
                                       width: `${(analytics.dimensionAverages[dimension.key] / 7) * 100}%`,
                                       backgroundColor: getGroupColor('supply'),
                                       borderRadius: '20px',
@@ -243,7 +247,8 @@
                                       position: 'relative',
                                       minWidth: '40px'
                                     }">
-                                      <span class="progress-text" style="
+                                      <span
+class="progress-text" style="
                                           position: absolute;
                                           left: 50%;
                                           top: 50%;
@@ -259,7 +264,8 @@
                                     </div>
                                   </div>
                                 </div>
-                                <div class="score-display text-body-1 font-weight-bold text-right"
+                                <div
+class="score-display text-body-1 font-weight-bold text-right"
                                   style="min-width: 50px;">
                                   {{ analytics.dimensionAverages[dimension.key].toFixed(1) }}
                                 </div>
@@ -289,7 +295,8 @@
                         </v-expansion-panel-title>
                         <v-expansion-panel-text>
                           <div class="dimension-bars pt-3">
-                            <div v-for="dimension in understandingDimensions" :key="dimension.key"
+                            <div
+v-for="dimension in understandingDimensions" :key="dimension.key"
                               class="dimension-row mb-3">
                               <div class="d-flex align-center">
                                 <div class="dimension-label" style="min-width: 180px; max-width: 180px;">
@@ -302,7 +309,8 @@
                                 </div>
                                 <div class="flex-grow-1 mx-4">
                                   <div class="progress-container">
-                                    <div class="progress-bar" :style="{
+                                    <div
+class="progress-bar" :style="{
                                       width: `${(analytics.dimensionAverages[dimension.key] / 7) * 100}%`,
                                       backgroundColor: getGroupColor('understanding'),
                                       borderRadius: '20px',
@@ -310,7 +318,8 @@
                                       position: 'relative',
                                       minWidth: '40px'
                                     }">
-                                      <span class="progress-text" style="
+                                      <span
+class="progress-text" style="
                                           position: absolute;
                                           left: 50%;
                                           top: 50%;
@@ -326,7 +335,8 @@
                                     </div>
                                   </div>
                                 </div>
-                                <div class="score-display text-body-1 font-weight-bold text-right"
+                                <div
+class="score-display text-body-1 font-weight-bold text-right"
                                   style="min-width: 50px;">
                                   {{ analytics.dimensionAverages[dimension.key].toFixed(1) }}
                                 </div>
@@ -491,7 +501,8 @@
               </h3>
               <v-row>
                 <v-col v-for="dimension in sartDimensions" :key="dimension.key" cols="12" md="6">
-                  <div class="dimension-detail pa-4"
+                  <div
+class="dimension-detail pa-4"
                     style="border: 1px solid #e0e0e0; border-radius: 8px; background: #fafafa;">
                     <div class="d-flex justify-space-between align-center mb-2">
                       <div class="font-weight-medium">
@@ -504,7 +515,8 @@
                     <div class="text-caption text-grey mb-2">
                       {{ dimension.description }}
                     </div>
-                    <v-progress-linear :model-value="(selectedResponse.sartAnswers[dimension.key] / 7) * 100"
+                    <v-progress-linear
+:model-value="(selectedResponse.sartAnswers[dimension.key] / 7) * 100"
                       :color="getGroupColor(getDimensionCategory(dimension.key))" height="8" rounded />
                   </div>
                 </v-col>

--- a/src/ux/UserTest/components/UnmoderatedTestAnalytics/UserAnalytics.vue
+++ b/src/ux/UserTest/components/UnmoderatedTestAnalytics/UserAnalytics.vue
@@ -68,8 +68,8 @@
               <!-- Categórico (multi-select) -->
               <v-select
                 v-if="def.isCategorical && def.items.length"
-                :items="def.items"
                 v-model="selectedFilters[def.index]"
+                :items="def.items"
                 multiple
                 chips
                 clearable
@@ -134,7 +134,7 @@
         <template
           v-for="(t, i) in taskColumns"
           :key="'col-task-' + i"
-          v-slot:[`item.task_${i}`]="{ item }"
+          #[`item.task_${i}`]="{ item }"
         >
           <div class="d-flex flex-column align-center py-2">
             <v-chip
@@ -224,12 +224,12 @@
               </v-btn>
             </template>
             <v-list density="compact" class="py-0">
-              <v-list-item @click="viewAnswers(item)" prepend-icon="mdi-eye">
+              <v-list-item prepend-icon="mdi-eye" @click="viewAnswers(item)">
                 <v-list-item-title>Test detail</v-list-item-title>
               </v-list-item>
               <v-list-item
-                @click="showTaskDetails(item)"
                 prepend-icon="mdi-clipboard-list"
+                @click="showTaskDetails(item)"
               >
                 <v-list-item-title>Task Details</v-list-item-title>
               </v-list-item>
@@ -283,9 +283,9 @@
 
               <!-- Pre-Test Answers -->
               <v-col
+                v-if="dialogItem?.preTestAnswer?.length"
                 cols="12"
                 md="6"
-                v-if="dialogItem?.preTestAnswer?.length"
                 class="section-col"
               >
                 <div class="section-card">
@@ -319,9 +319,9 @@
 
               <!-- Post-Test Answers -->
               <v-col
+                v-if="dialogItem?.postTestAnswer?.length"
                 cols="12"
                 md="6"
-                v-if="dialogItem?.postTestAnswer?.length"
                 class="section-col"
               >
                 <div class="section-card">
@@ -355,8 +355,8 @@
 
               <!-- Task Selector -->
               <v-col
-                cols="12"
                 v-if="testStructure?.userTasks?.length"
+                cols="12"
                 class="section-col"
               >
                 <div class="section-card">
@@ -387,28 +387,28 @@
                   >
                     <div class="mb-2 d-flex flex-wrap gap-2">
                       <v-chip
+                        v-if="dialogItem.tasks[taskSelect].completed"
                         size="x-small"
                         color="success"
                         variant="tonal"
-                        v-if="dialogItem.tasks[taskSelect].completed"
                       >
                         <v-icon size="14" start>mdi-check-circle</v-icon>
                         Completed
                       </v-chip>
                       <v-chip
+                        v-else
                         size="x-small"
                         color="error"
                         variant="tonal"
-                        v-else
                       >
                         <v-icon size="14" start>mdi-close-circle</v-icon> Not
                         Completed
                       </v-chip>
                       <v-chip
+                        v-if="dialogItem.tasks[taskSelect].taskTime"
                         size="x-small"
                         color="info"
                         variant="tonal"
-                        v-if="dialogItem.tasks[taskSelect].taskTime"
                       >
                         <v-icon size="14" start>mdi-timer-outline</v-icon>
                         {{
@@ -435,14 +435,14 @@
                     <!-- Media -->
                     <v-expansion-panels multiple class="media-panels">
                       <v-expansion-panel
-                        readonly
-                        hide-actions
-                        @click.stop="openSessionAnalyticsDialog"
                         v-if="
                           dialogItem.tasks[taskSelect].webcamRecordURL ||
                           dialogItem.tasks[taskSelect].irisTrackingData > 0
                         "
+                        readonly
+                        hide-actions
                         class="cursor-pointer"
+                        @click.stop="openSessionAnalyticsDialog"
                       >
                         <v-expansion-panel-title>
                           Task Analytics
@@ -463,12 +463,12 @@
                             aria-label="Webcam recording"
                           >
                             <track
-                              kind="captions"
-                              srclang="en"
-                              label="English"
                               v-if="
                                 dialogItem.tasks[taskSelect].webcamCaptionsURL
                               "
+                              kind="captions"
+                              srclang="en"
+                              label="English"
                               :src="
                                 dialogItem.tasks[taskSelect].webcamCaptionsURL
                               "
@@ -490,12 +490,12 @@
                             aria-label="Screen recording"
                           >
                             <track
-                              kind="captions"
-                              srclang="en"
-                              label="English"
                               v-if="
                                 dialogItem.tasks[taskSelect].screenCaptionsURL
                               "
+                              kind="captions"
+                              srclang="en"
+                              label="English"
                               :src="
                                 dialogItem.tasks[taskSelect].screenCaptionsURL
                               "
@@ -522,17 +522,17 @@
                     <v-dialog v-model="showSessionAnalytics" fullscreen>
                       <SessionAnalytics
                         :tasks="dialogItem.tasks"
-                        :taskSelect="taskSelect"
+                        :task-select="taskSelect"
                         @close="showSessionAnalytics = false"
                       />
                     </v-dialog>
                     <SessionAnalyticsDialog
                       v-model="showSessionAnalyticsDialog"
-                      :userId="dialogItem.userDocId"
+                      :user-id="dialogItem.userDocId"
                       :task-answer="dialogItem.tasks[taskSelect]"
-                      :selectedTask="taskSelect"
+                      :selected-task="taskSelect"
                       :test-answer="answers[dialogItem.userDocId]"
-                      :fromEyeTracking="true"
+                      :from-eye-tracking="true"
                     />
                   </div>
                 </div>

--- a/src/ux/UserTest/components/UserVariables.vue
+++ b/src/ux/UserTest/components/UserVariables.vue
@@ -4,7 +4,8 @@
       <v-card class="elevation-2 rounded-lg pa-md-6" width="100%">
         <v-row class="pa-4">
           <v-col>
-            <v-card-title class="text-h5 font-weight-bold mb-0 pa-0"
+            <v-card-title
+class="text-h5 font-weight-bold mb-0 pa-0"
               :style="{ color: $vuetify.theme.current.colors['on-surface'] }">
               {{ type === 'pre-test' ? $t('ModeratedTest.preTestVariables') : $t('ModeratedTest.postTestVariables') }}
             </v-card-title>
@@ -14,12 +15,14 @@
           </v-col>
         </v-row>
         <v-card-text>
-          <v-expansion-panels v-if="items.length > 0" variant="accordion" class="elevation-0"
+          <v-expansion-panels
+v-if="items.length > 0" variant="accordion" class="elevation-0"
             style="border: 1px solid #E5E7EB; border-radius: 12px;">
             <v-expansion-panel v-for="(item, i) in items" :key="i" class="rounded-lg mb-2" :disabled="isSaving">
               <v-expansion-panel-title class="py-3 px-4">
                 <div class="d-flex align-center">
-                  <span class="text-body-1 font-weight-medium"
+                  <span
+class="text-body-1 font-weight-medium"
                     :class="{ 'text-error': !item.title || !item.title.trim() }">
                     {{ item.title || $t('UserTestTable.fallbacks.untitledVariable') }}
                   </span>
@@ -30,15 +33,18 @@
               </v-expansion-panel-title>
               <v-expansion-panel-text class="pa-md-4">
                 <v-form @submit.prevent>
-                  <v-text-field v-model="item.title" :label="$t('UserTestTable.inputs.variableName')" variant="outlined"
+                  <v-text-field
+v-model="item.title" :label="$t('UserTestTable.inputs.variableName')" variant="outlined"
                     density="comfortable" :rules="[v => !!v || $t('errors.fieldRequired')]" color="primary"
                     class="mb-md-4" @update:model-value="markDirty" />
-                  <v-textarea v-model="item.description" :label="$t('UserTestTable.inputs.description')"
+                  <v-textarea
+v-model="item.description" :label="$t('UserTestTable.inputs.description')"
                     variant="outlined" density="comfortable" color="primary" rows="3" class="mb-4"
                     @update:model-value="markDirty" />
                   <div v-if="item.selectionField">
                     <div v-for="(field, index) in item.selectionFields" :key="index" class="d-flex align-center mb-2">
-                      <v-text-field v-model="item.selectionFields[index]"
+                      <v-text-field
+v-model="item.selectionFields[index]"
                         :label="$t('UserTestTable.inputs.selection') + ` ${index + 1}`" variant="outlined"
                         density="comfortable" :rules="[v => !!v || $t('errors.fieldRequired')]" color="primary"
                         class="mr-md-2" @update:model-value="markDirty">
@@ -46,7 +52,8 @@
                           <v-icon color="accent" class="mr-2" @click="newSelection(i)">
                             mdi-plus-circle
                           </v-icon>
-                          <v-icon v-if="item.selectionFields.length > 1" color="error"
+                          <v-icon
+v-if="item.selectionFields.length > 1" color="error"
                             @click="deleteSelection(i, index)">
                             mdi-trash-can-outline
                           </v-icon>
@@ -65,11 +72,13 @@
                   </div>
                   <v-row align="center" class="mt-2">
                     <v-col cols="12" sm="6">
-                      <v-checkbox v-model="item.selectionField" :label="$t('UserTestTable.checkboxes.selectionField')"
+                      <v-checkbox
+v-model="item.selectionField" :label="$t('UserTestTable.checkboxes.selectionField')"
                         color="primary" @update:model-value="selectField(i); markDirty()" />
                     </v-col>
                     <v-col cols="12" sm="5">
-                      <v-checkbox v-model="item.textField" :label="$t('UserTestTable.checkboxes.textField')"
+                      <v-checkbox
+v-model="item.textField" :label="$t('UserTestTable.checkboxes.textField')"
                         color="primary" @update:model-value="selectText(i); markDirty()" />
                     </v-col>
                     <v-col cols="12" sm="1" class="text-right">
@@ -82,11 +91,13 @@
               </v-expansion-panel-text>
             </v-expansion-panel>
           </v-expansion-panels>
-          <v-alert v-else type="info" icon="mdi-information-outline" class="mt-4 rounded-lg"
+          <v-alert
+v-else type="info" icon="mdi-information-outline" class="mt-4 rounded-lg"
             :text="$t('UserTestTable.messages.noVariables')" />
         </v-card-text>
         <v-card-actions>
-          <v-card class="border-dashed text-center py-6" width="100%" variant="outlined"
+          <v-card
+class="border-dashed text-center py-6" width="100%" variant="outlined"
             style="cursor: pointer; border-style: dashed !important; border-color: #D1D5DB;" @click="showModal">
             <v-card-text>
               <v-icon icon="mdi-plus-circle" size="24" class="mb-2" />
@@ -103,13 +114,15 @@
   <!-- New Variable Dialog -->
   <v-dialog v-model="show" max-width="600" persistent transition="dialog-bottom-transition">
     <v-card class="rounded-lg pa-6">
-      <v-card-title class="text-h6 font-weight-bold mb-4"
+      <v-card-title
+class="text-h6 font-weight-bold mb-4"
         :style="{ color: $vuetify.theme.current.colors['on-surface'] }">
         {{ $t('ModeratedTest.createNewVariableTitle') }}
       </v-card-title>
       <v-card-text>
         <v-form ref="form" v-model="valid">
-          <v-text-field v-model="newItem" :label="$t('UserTestTable.inputs.dialogVariableName')" variant="outlined"
+          <v-text-field
+v-model="newItem" :label="$t('UserTestTable.inputs.dialogVariableName')" variant="outlined"
             density="comfortable" :rules="[v => !!v.trim() || $t('errors.fieldRequired')]" color="primary"
             @update:model-value="markDirty" />
         </v-form>
@@ -122,7 +135,8 @@
           </v-icon>
           {{ $t('buttons.close') }}
         </v-btn>
-        <v-btn color="success" variant="flat" class="px-6" :disabled="!valid || isSaving" :loading="isSaving"
+        <v-btn
+color="success" variant="flat" class="px-6" :disabled="!valid || isSaving" :loading="isSaving"
           @click="saveNewItem">
           <v-icon start>
             mdi-content-save

--- a/src/ux/UserTest/components/VideoCall.vue
+++ b/src/ux/UserTest/components/VideoCall.vue
@@ -3,8 +3,8 @@
 
     <!-- Videos Row -->
     <v-row class="video-row justify-center" no-gutters>
-      <v-col cols="12" class="d-flex justify-center align-center" v-show="isSharingScreen">
-        <div class="video-container" v-show="isSharingScreen">
+      <v-col v-show="isSharingScreen" cols="12" class="d-flex justify-center align-center">
+        <div v-show="isSharingScreen" class="video-container">
           <video ref="screenVideo" autoplay playsinline class="video-element"></video>
           <div class="video-label">Compartilhando tela</div>
         </div>
@@ -55,9 +55,9 @@
             :color="roomExists ? 'primary' : 'warning'" 
             size="x-large" 
             class="join-room-btn"
-            @click="answerCall"
             :disabled="!roomExists"
             :variant="roomExists ? 'flat' : 'outlined'"
+            @click="answerCall"
           >
             <template v-if="!roomExists">
               <v-progress-circular
@@ -66,11 +66,11 @@
                 width="2"
                 class="me-2"
               ></v-progress-circular>
-              <v-icon left size="24">mdi-clock-outline</v-icon>
+              <v-icon start size="24">mdi-clock-outline</v-icon>
               Waiting for moderator...
             </template>
             <template v-else>
-              <v-icon left size="24">mdi-video</v-icon>
+              <v-icon start size="24">mdi-video</v-icon>
               Join Room
             </template>
           </v-btn>
@@ -151,7 +151,7 @@
                 size="large"
                 @click="startCall"
               >
-                <v-icon left size="20">mdi-video-plus</v-icon>
+                <v-icon start size="20">mdi-video-plus</v-icon>
                 Open Room
               </v-btn>
             </template>
@@ -168,7 +168,7 @@
                 size="large"
                 @click="endCall"
               >
-                <v-icon left size="20">mdi-phone-hangup</v-icon>
+                <v-icon start size="20">mdi-phone-hangup</v-icon>
                 End Call
               </v-btn>
             </template>
@@ -185,7 +185,7 @@
                 size="large"
                 @click="endCall"
               >
-                <v-icon left size="20">mdi-phone-hangup</v-icon>
+                <v-icon start size="20">mdi-phone-hangup</v-icon>
                 Leave Call
               </v-btn>
             </template>
@@ -237,8 +237,8 @@
           icon 
           size="small" 
           variant="text" 
-          @click="toggleSidePanel"
           class="close-btn"
+          @click="toggleSidePanel"
         >
           <v-icon>mdi-close</v-icon>
         </v-btn>
@@ -254,7 +254,7 @@
             <!-- Note: Join Room controls moved to main interface for better visibility -->
             <div v-if="!caller" class="participant-info">
               <p class="text-body-2 mb-0">
-                <v-icon left size="16">mdi-information</v-icon>
+                <v-icon start size="16">mdi-information</v-icon>
                 Join room controls are now in the main interface above
               </p>
             </div>
@@ -271,7 +271,7 @@
               class="mb-3"
               @click="proceedToNextStep"
             >
-              <v-icon left>mdi-arrow-right</v-icon>
+              <v-icon start>mdi-arrow-right</v-icon>
               Proceed to Next Step
             </v-btn>
 
@@ -283,14 +283,14 @@
               variant="outlined"
               @click="endCall"
             >
-              <v-icon left>mdi-phone-hangup</v-icon>
+              <v-icon start>mdi-phone-hangup</v-icon>
               End Call
             </v-btn>
 
             <!-- Call status -->
             <div class="status-message">
               <v-chip color="green" size="small" class="mb-2">
-                <v-icon left size="16">mdi-phone</v-icon>
+                <v-icon start size="16">mdi-phone</v-icon>
                 Llamada activa
               </v-chip>
             </div>
@@ -306,14 +306,14 @@
             <div class="participant-info">
               <span class="participant-name">{{ caller ? 'Moderador (Tú)' : 'Participante (Tú)' }}</span>
               <div class="participant-status">
-                <v-chip size="x-small" color="green" v-if="isCameraEnabled">Cámara</v-chip>
-                <v-chip size="x-small" color="red" v-else>Sin cámara</v-chip>
-                <v-chip size="x-small" color="green" v-if="isMicrophoneEnabled" class="ml-1">Micrófono</v-chip>
-                <v-chip size="x-small" color="red" v-else class="ml-1">Sin micrófono</v-chip>
+                <v-chip v-if="isCameraEnabled" size="x-small" color="green">Cámara</v-chip>
+                <v-chip v-else size="x-small" color="red">Sin cámara</v-chip>
+                <v-chip v-if="isMicrophoneEnabled" size="x-small" color="green" class="ml-1">Micrófono</v-chip>
+                <v-chip v-else size="x-small" color="red" class="ml-1">Sin micrófono</v-chip>
               </div>
             </div>
           </div>
-          <div class="participant-item" v-if="callStarted">
+          <div v-if="callStarted" class="participant-item">
             <v-avatar size="32" :color="caller ? 'green' : 'blue'">
               <v-icon color="white">{{ caller ? 'mdi-account' : 'mdi-account-star' }}</v-icon>
             </v-avatar>
@@ -372,8 +372,8 @@
           icon 
           size="small" 
           variant="text" 
-          @click="toggleStepperPanel"
           class="close-btn"
+          @click="toggleStepperPanel"
         >
           <v-icon>mdi-close</v-icon>
         </v-btn>
@@ -383,7 +383,7 @@
         <!-- Moderator indicator -->
         <div v-if="!caller" class="moderator-notice">
           <v-chip size="small" color="orange" class="mb-4">
-            <v-icon left size="16">mdi-information</v-icon>
+            <v-icon start size="16">mdi-information</v-icon>
             Solo el moderador puede cambiar los pasos
           </v-chip>
         </div>
@@ -405,7 +405,7 @@
                 <v-icon v-if="currentStepperValue >= 1" color="white" size="16">mdi-check</v-icon>
                 <span v-else>1</span>
               </div>
-              <div class="step-line" v-if="currentStepperValue >= 1"></div>
+              <div v-if="currentStepperValue >= 1" class="step-line"></div>
             </div>
             <div class="step-content">
               <h4 class="step-title">Consent</h4>
@@ -428,7 +428,7 @@
                 <v-icon v-if="currentStepperValue >= 2" color="white" size="16">mdi-check</v-icon>
                 <span v-else>2</span>
               </div>
-              <div class="step-line" v-if="currentStepperValue >= 2"></div>
+              <div v-if="currentStepperValue >= 2" class="step-line"></div>
             </div>
             <div class="step-content">
               <h4 class="step-title">Pre-test</h4>
@@ -451,7 +451,7 @@
                 <v-icon v-if="currentStepperValue >= 3" color="white" size="16">mdi-check</v-icon>
                 <span v-else>3</span>
               </div>
-              <div class="step-line" v-if="currentStepperValue >= 3"></div>
+              <div v-if="currentStepperValue >= 3" class="step-line"></div>
             </div>
             <div class="step-content">
               <h4 class="step-title">Tasks</h4>
@@ -462,7 +462,6 @@
                 <v-select
                   :items="taskDropdownItems"
                   :model-value="currentTaskIndex"
-                  @update:model-value="goToSpecificTask"
                   item-title="title"
                   item-value="index"
                   variant="outlined"
@@ -471,6 +470,7 @@
                   class="task-selector"
                   placeholder="Select a task"
                   prepend-inner-icon="mdi-format-list-bulleted"
+                  @update:model-value="goToSpecificTask"
                 >
                   <template #item="{ props, item }">
                     <v-list-item v-bind="props" :title="item.raw.title">
@@ -501,7 +501,7 @@
                 <v-icon v-if="currentStepperValue >= 4" color="white" size="16">mdi-check</v-icon>
                 <span v-else>4</span>
               </div>
-              <div class="step-line" v-if="currentStepperValue >= 4"></div>
+              <div v-if="currentStepperValue >= 4" class="step-line"></div>
             </div>
             <div class="step-content">
               <h4 class="step-title">Post-test</h4>
@@ -573,7 +573,7 @@
             class="mb-2"
             @click="joinRoomFromDialog"
           >
-            <v-icon left>mdi-video</v-icon>
+            <v-icon start>mdi-video</v-icon>
             Join Video Call
           </v-btn>
           

--- a/src/ux/UserTest/components/dialogs/CreateInviteDialog.vue
+++ b/src/ux/UserTest/components/dialogs/CreateInviteDialog.vue
@@ -206,7 +206,7 @@
                   <h3 class="text-h6 font-weight-bold">Invitation Preview</h3>
                 </div>
                 
-                <v-card class="invitation-preview elevation-2" outlined>
+                <v-card class="invitation-preview elevation-2" border>
                   <v-card-title class="bg-grey-lighten-4 py-3">
                     <v-icon class="mr-2" color="primary">mdi-email-outline</v-icon>
                     <span class="text-subtitle-1">Evaluation Invitation</span>

--- a/src/ux/UserTest/components/dialogs/SessionAnalyticsDialog.vue
+++ b/src/ux/UserTest/components/dialogs/SessionAnalyticsDialog.vue
@@ -19,8 +19,8 @@
         <v-row class="mb-4">
           <v-col cols="12" md="6" class="mt-16">
             <div
-              class="video-box mb-2 video-rect-box"
               v-if="rightTab !== 'eye'"
+              class="video-box mb-2 video-rect-box"
             >
               <video
                 ref="mainVideo1"
@@ -34,9 +34,9 @@
             </div>
 
             <div
+              v-if="rightTab !== 'sentimental'"
               class="video-box screen-video-box video-rect-box"
               style="position: relative"
-              v-if="rightTab !== 'sentimental'"
             >
               <video
                 ref="mainVideo2"
@@ -50,7 +50,7 @@
               <EyeTrackingOverlay
                 v-show="rightTab === 'eye' && predictedData"
                 :video-ref="mainVideo2"
-                :predictedData="predictedData"
+                :predicted-data="predictedData"
                 :current-time="videoCurrentTime"
                 :is-playing="isPlaying"
                 :view-mode="selectedView"
@@ -59,12 +59,12 @@
           </v-col>
 
           <v-col cols="12" md="6">
-            <v-tabs v-model="rightTab" background-color="grey-lighten-4" grow>
+            <v-tabs v-model="rightTab" bg-color="grey-lighten-4" grow>
               <!-- <v-tab value="general">General</v-tab> -->
-              <v-tab value="eye" v-if="taskAnswer?.irisTrackingData.length > 0"
+              <v-tab v-if="taskAnswer?.irisTrackingData.length > 0" value="eye"
                 >Eye Tracker</v-tab
               >
-              <v-tab value="sentimental" v-if="taskAnswer?.webcamRecordURL"
+              <v-tab v-if="taskAnswer?.webcamRecordURL" value="sentimental"
                 >Sentimental</v-tab
               >
               <!-- <v-tab value="transcript">Transcripción</v-tab>
@@ -80,12 +80,12 @@
                             </v-window-item> -->
 
               <v-window-item
-                value="eye"
                 v-if="taskAnswer?.irisTrackingData.length > 0"
+                value="eye"
               >
                 <EyeTrackingStats
                   :iris-data="taskAnswer?.irisTrackingData"
-                  :userId="userId"
+                  :user-id="userId"
                   :accuracy="
                     taskAnswer?.eyeTracking?.accuracy ??
                     mockEyeTracking.accuracy
@@ -94,15 +94,15 @@
                     taskAnswer?.eyeTracking?.fixations ??
                     mockEyeTracking.fixations
                   "
+                  class="mb-4"
                   @predictions-ready="predictedData = $event"
                   @view-changed="selectedView = $event"
-                  class="mb-4"
                 />
               </v-window-item>
 
               <v-window-item
-                value="sentimental"
                 v-if="taskAnswer?.webcamRecordURL"
+                value="sentimental"
               >
                 <FacialSentimentPanel
                   :video-element="mainVideo1"
@@ -131,10 +131,10 @@
 
         <SessionTimeline
           :duration="videoDuration"
-          :currentTime="videoCurrentTime"
-          :isPlaying="isPlaying"
+          :current-time="videoCurrentTime"
+          :is-playing="isPlaying"
           @seek="onSeek"
-          @togglePlay="togglePlay"
+          @toggle-play="togglePlay"
         />
       </v-card-text>
     </v-card>

--- a/src/ux/UserTest/components/editTest/EditUserTest.vue
+++ b/src/ux/UserTest/components/editTest/EditUserTest.vue
@@ -10,14 +10,16 @@
   <v-col cols="12">
     <!-- TEST -->
     <div v-if="index === 0">
-      <TestConfigForm :welcome="welcomeMessage" :final-message="finalMessage"
+      <TestConfigForm
+:welcome="welcomeMessage" :final-message="finalMessage"
         @update:welcome-message="saveState('welcomeMessage', $event)"
         @update:final-message="saveState('finalMessage', $event)" />
     </div>
 
     <!-- COSENT FORM -->
     <v-card v-if="index === 1" rounded="xxl">
-      <TextareaForm v-model="consent" :title="$t('ModeratedTest.consentForm')"
+      <TextareaForm
+v-model="consent" :title="$t('ModeratedTest.consentForm')"
         :subtitle="$t('ModeratedTest.consentFormSubtitle')" @update:value="saveState('consent', $event)" />
     </v-card>
 

--- a/src/ux/UserTest/components/manager/StorageInfo.vue
+++ b/src/ux/UserTest/components/manager/StorageInfo.vue
@@ -106,8 +106,8 @@
         variant="text" 
         size="small" 
         color="primary"
-        @click="manageStorage"
         disabled
+        @click="manageStorage"
       >
         Manage Storage
       </v-btn>

--- a/src/ux/UserTest/components/sentimentAnalysis/AudioWave.vue
+++ b/src/ux/UserTest/components/sentimentAnalysis/AudioWave.vue
@@ -21,7 +21,8 @@
 
       <v-col cols="auto" class="volume-col">
         <v-icon>mdi-volume-high</v-icon>
-        <v-slider v-model="volume" min="0" max="1" step="0.01" hide-details class="volume-slider"
+        <v-slider
+v-model="volume" min="0" max="1" step="0.01" hide-details class="volume-slider"
           @update:model-value="setVolume" />
       </v-col>
     </v-row>

--- a/src/ux/UserTest/components/sentimentAnalysis/UserModeratedSentiment.vue
+++ b/src/ux/UserTest/components/sentimentAnalysis/UserModeratedSentiment.vue
@@ -12,7 +12,8 @@
               <v-divider />
 
               <v-list v-model:selected="selectedUserID" selection-mode="single">
-                <v-list-item v-for="(item, i) in usersID" :key="i" :value="item" :active="selectedUserID === item"
+                <v-list-item
+v-for="(item, i) in usersID" :key="i" :value="item" :active="selectedUserID === item"
                   @click="selectedUserID = item">
                   <v-list-item-title>
                     {{ getCooperatorEmail(item) }}
@@ -34,15 +35,17 @@
           <!------------------------------------------------------------------------------------------------------------------------->
           <v-col v-if="selectedAnswerDocument" class="ma-0 pa-1 answer-list" cols="9">
             <!-- Co-operators -->
-            <ModeratedTestCard :moderator="{ name: testDocument ? testDocument.testAdmin.email : '<Error>' }"
+            <ModeratedTestCard
+:moderator="{ name: testDocument ? testDocument.testAdmin.email : '<Error>' }"
               :evaluator="{ name: selectedAnswerDocument ? getCooperatorEmail(selectedAnswerDocument.userDocId) : '<Error>' }" />
 
             <h2>Tasks</h2>
-            <div class="mt-6" v-for="(task, index) in selectedAnswerDocument.tasks" :key="index">
+            <div v-for="(task, index) in selectedAnswerDocument.tasks" :key="index" class="mt-6">
               <h3>Task {{ Number(index + 1) }}</h3>
 
               <!-- Audio Wave -->
-              <AudioWave :ref="i => audioWaveRefs[index] = i" v-model:active-region="activeRegion"
+              <AudioWave
+:ref="i => audioWaveRefs[index] = i" v-model:active-region="activeRegion"
                 :file="task.audioRecordURL"
                 :regions="selectedAnswerSentiment ? selectedAnswerSentiment.regions || [] : []" />
 
@@ -66,7 +69,8 @@
             </div>
 
             <!-- Segments Transcripts Sentiment -->
-            <SentimentTranscriptsList :play-segment="(start, end) => playSegmentInAudioWave(index, start, end)"
+            <SentimentTranscriptsList
+:play-segment="(start, end) => playSegmentInAudioWave(index, start, end)"
               :regions="selectedAnswerSentiment ? selectedAnswerSentiment.regions || [] : []"
               :delete-region="deleteRegion" />
           </v-col>

--- a/src/ux/UserTest/components/sessions/EyeTrackingStats.vue
+++ b/src/ux/UserTest/components/sessions/EyeTrackingStats.vue
@@ -9,7 +9,8 @@
                 </div>
             </v-col>
             <v-col cols="auto">
-                <v-chip :color="isAnalyzing ? 'grey' : hasError ? 'red-darken-2' : 'primary'" variant="flat"
+                <v-chip
+:color="isAnalyzing ? 'grey' : hasError ? 'red-darken-2' : 'primary'" variant="flat"
                     prepend-icon="mdi-eye">
                     {{ isAnalyzing ? 'Analyzing...' : hasError ? 'Analysis Failed' : 'Analysis Completed' }}
                 </v-chip>
@@ -46,7 +47,8 @@
                         <v-icon :color="metric.color">{{ metric.icon }}</v-icon>
                     </div>
                     <div class="text-h6 font-weight-bold">{{ metric.value }}</div>
-                    <v-progress-linear :model-value="metric.progress" :color="metric.color" height="6" class="mt-2"
+                    <v-progress-linear
+:model-value="metric.progress" :color="metric.color" height="6" class="mt-2"
                         rounded />
                 </v-card>
             </v-col>
@@ -57,7 +59,8 @@
                     <h4 class="text-subtitle-1 font-weight-medium mb-3">Prediction Overview</h4>
 
                     <v-btn-toggle v-model="selectedView" class="mb-2 d-flex justify-space-between" divided mandatory>
-                        <v-btn value="precision" variant="outlined"
+                        <v-btn
+value="precision" variant="outlined"
                             :color="selectedView === 'precision' ? 'blue-darken-2' : 'blue-lighten-3'"
                             class="px-8 py-3 rounded-lg font-weight-medium">
                             <v-icon start :color="selectedView === 'precision' ? 'blue-darken-2' : 'blue-lighten-3'">
@@ -66,7 +69,8 @@
                             Prediction Points
                         </v-btn>
 
-                        <v-btn value="heatmap" variant="outlined"
+                        <v-btn
+value="heatmap" variant="outlined"
                             :color="selectedView === 'heatmap' ? 'orange-darken-2' : 'orange-lighten-3'"
                             class="px-8 py-3 rounded-lg font-weight-medium">
                             <v-icon start :color="selectedView === 'heatmap' ? 'orange-darken-2' : 'orange-lighten-3'">
@@ -75,7 +79,8 @@
                             Heatmap
                         </v-btn>
 
-                        <v-btn value="free" variant="outlined"
+                        <v-btn
+value="free" variant="outlined"
                             :color="selectedView === 'free' ? 'red-darken-2' : 'red-lighten-3'"
                             class="px-8 py-3 rounded-lg font-weight-medium">
                             <v-icon start :color="selectedView === 'free' ? 'red-darken-2' : 'red-lighten-3'">
@@ -94,7 +99,8 @@
                     <h4 class="text-subtitle-1 font-weight-medium mb-3">Key Insights</h4>
                     <v-row>
                         <v-col v-for="(insight, index) in insights" :key="index" cols="12">
-                            <v-alert :type="insight.type" variant="tonal" class="rounded-xl" border="start"
+                            <v-alert
+:type="insight.type" variant="tonal" class="rounded-xl" border="start"
                                 :border-color="insight.color">
                                 <v-icon class="mr-2" :color="insight.color">{{ insight.icon }}</v-icon>
                                 <span class="font-weight-medium">{{ insight.text }}</span>

--- a/src/ux/UserTest/components/sessions/SessionTimeline.vue
+++ b/src/ux/UserTest/components/sessions/SessionTimeline.vue
@@ -6,7 +6,7 @@
         </v-btn>
 
         <!-- Linha de progresso -->
-        <div class="timeline-bar" @click="seek($event)" @mousedown="startDrag" ref="bar">
+        <div ref="bar" class="timeline-bar" @click="seek($event)" @mousedown="startDrag">
             <div class="timeline-track" :style="{ width: progress + '%' }"></div>
             <div class="timeline-thumb" :style="{ left: progress + '%' }"></div>
         </div>

--- a/src/ux/UserTest/components/steps/ConsentStep.vue
+++ b/src/ux/UserTest/components/steps/ConsentStep.vue
@@ -5,7 +5,8 @@
         <div class="rich-text mb-6 pa-md-4" v-html="consentText" />
         <v-row justify="center">
           <v-col cols="12" md="6">
-            <v-text-field :model-value="localFullName" label="Full Name" variant="outlined" density="comfortable"
+            <v-text-field
+:model-value="localFullName" label="Full Name" variant="outlined" density="comfortable"
               :rules="[v => !!v || 'Name is required']" @update:model-value="onFullNameInput" />
           </v-col>
         </v-row>
@@ -19,7 +20,8 @@
         </v-row>
         <v-row justify="center" class="mt-4">
           <v-col cols="12" md="6" class="text-center">
-            <v-btn color="primary" variant="flat" block :disabled="localConsentCompleted === null || !localFullName"
+            <v-btn
+color="primary" variant="flat" block :disabled="localConsentCompleted === null || !localFullName"
               @click="handleContinue">
               Continue
             </v-btn>

--- a/src/ux/UserTest/components/steps/ModeratorWelcomeStep.vue
+++ b/src/ux/UserTest/components/steps/ModeratorWelcomeStep.vue
@@ -4,7 +4,7 @@
       <div class="moderator-content pa-6 rounded-xl text-center fade-in">
         <div class="moderator-badge mb-4">
           <v-chip color="primary" size="large" class="px-4 py-2">
-            <v-icon left size="20">mdi-account-star</v-icon>
+            <v-icon start size="20">mdi-account-star</v-icon>
             Moderator View
           </v-chip>
         </div>
@@ -21,7 +21,7 @@
           <v-col cols="12" md="10" lg="8">
             <v-card class="moderator-instructions elevation-3" color="blue-grey-lighten-5">
               <v-card-title class="text-h6 text-center pb-2">
-                <v-icon left color="primary">mdi-clipboard-list</v-icon>
+                <v-icon start color="primary">mdi-clipboard-list</v-icon>
                 Moderator Instructions
               </v-card-title>
               <v-card-text>
@@ -62,7 +62,7 @@
             class="px-8"
             @click="$emit('start')"
           >
-            <v-icon left>mdi-play</v-icon>
+            <v-icon start>mdi-play</v-icon>
             Start Moderated Session
           </v-btn>
         </div>

--- a/src/ux/UserTest/components/steps/WelcomeStep.vue
+++ b/src/ux/UserTest/components/steps/WelcomeStep.vue
@@ -5,7 +5,7 @@
         <h2 class="text-h5 font-weight-bold mb-4 text-primary">
           {{ $t('UserTestView.WelcomeStep.welcome') }}
         </h2>
-        <div v-if="welcomeMessage" v-html="welcomeMessage" class="text-body-1 mb-4 text-grey-darken-3"></div>
+        <div v-if="welcomeMessage" class="text-body-1 mb-4 text-grey-darken-3" v-html="welcomeMessage"></div>
         <p v-else class="text-body-1 mb-4 text-grey-darken-3">
           {{ $t('UserTestView.WelcomeStep.description') }}
         </p>
@@ -32,7 +32,7 @@
             <v-divider />
             <v-stepper-item
               value="2"
-              class="red"
+              class="bg-red"
               :title="$t('UserTestView.WelcomeStep.steps.preQuestions')"
             />
             <v-divider />

--- a/src/ux/UserTest/components/task-steps/SartStep.vue
+++ b/src/ux/UserTest/components/task-steps/SartStep.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="sart-container pa-4">
+    <h3 class="text-h5 mb-2">{{ $t('sartLong') }}</h3>
+    <p class="text-caption mb-6">{{ $t('sartCalculationExplanation') }}</p>
+
+    <v-divider class="mb-6"></v-divider>
+
+    <div class="mb-4">
+      <div class="d-flex justify-space-between mb-1">
+        <span class="font-weight-medium">{{ $t('sartDemand') }}</span>
+        <span class="text-primary font-weight-bold">{{ answers.demand }}</span>
+      </div>
+      <v-slider v-model="answers.demand" min="1" max="7" step="1" ticks="always" thumb-label></v-slider>
+    </div>
+
+    <div class="mb-4">
+      <div class="d-flex justify-space-between mb-1">
+        <span class="font-weight-medium">{{ $t('sartSupply') }}</span>
+        <span class="text-primary font-weight-bold">{{ answers.supply }}</span>
+      </div>
+      <v-slider v-model="answers.supply" min="1" max="7" step="1" ticks="always" thumb-label></v-slider>
+    </div>
+
+    <div class="mb-6">
+      <div class="d-flex justify-space-between mb-1">
+        <span class="font-weight-medium">{{ $t('sartUnderstanding') }}</span>
+        <span class="text-primary font-weight-bold">{{ answers.understanding }}</span>
+      </div>
+      <v-slider v-model="answers.understanding" min="1" max="7" step="1" ticks="always" thumb-label></v-slider>
+    </div>
+
+    <v-btn color="primary" block size="large" @click="submit">
+      {{ $t('common.submit') || 'Submit' }}
+    </v-btn>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'SartStep',
+  // FIX: This declaration is required to resolve the 'require-explicit-emits' error
+  emits: ['submit'],
+  data: () => ({
+    answers: {
+      demand: 4,
+      supply: 4,
+      understanding: 4
+    }
+  }),
+  methods: {
+    submit() {
+      // SA = Understanding - (Demand - Supply)
+      const saScore = this.answers.understanding - (this.answers.demand - this.answers.supply);
+      this.$emit('submit', {
+        instrument: 'sart',
+        data: this.answers,
+        score: saScore
+      });
+    }
+  }
+}
+</script>

--- a/src/ux/UserTest/components/task-steps/TaskAdvancedOptions.vue
+++ b/src/ux/UserTest/components/task-steps/TaskAdvancedOptions.vue
@@ -34,7 +34,7 @@
               </v-row>
             </v-col>
             <v-col cols="12" md="auto" class="py-sm-0">
-              <v-switch v-model="localTask.hasEye" color="primary" hide-details @change="validateStep" />
+              <v-switch v-model="localTask.hasEye" color="primary" hide-details @update:model-value="validateStep" />
             </v-col>
           </v-row>
         </v-card-text>
@@ -66,7 +66,7 @@
               </v-row>
             </v-col>
             <v-col cols="12" md="auto" class="py-0">
-              <v-switch v-model="localTask.hasScreenRecord" color="primary" hide-details @change="validateStep" />
+              <v-switch v-model="localTask.hasScreenRecord" color="primary" hide-details @update:model-value="validateStep" />
             </v-col>
           </v-row>
         </v-card-text>
@@ -98,7 +98,7 @@
               </v-row>
             </v-col>
             <v-col cols="12" md="auto" class="py-0">
-              <v-switch v-model="localTask.hasCamRecord" color="primary" hide-details @change="validateStep" />
+              <v-switch v-model="localTask.hasCamRecord" color="primary" hide-details @update:model-value="validateStep" />
             </v-col>
           </v-row>
         </v-card-text>
@@ -129,7 +129,7 @@
               </v-row>
             </v-col>
             <v-col cols="12" md="auto" class="py-0">
-              <v-switch v-model="localTask.hasAudioRecord" color="primary" hide-details @change="validateStep" />
+              <v-switch v-model="localTask.hasAudioRecord" color="primary" hide-details @update:model-value="validateStep" />
             </v-col>
           </v-row>
         </v-card-text>

--- a/src/ux/UserTest/components/task-steps/TaskBasicInfo.vue
+++ b/src/ux/UserTest/components/task-steps/TaskBasicInfo.vue
@@ -18,9 +18,10 @@
             <v-icon size="14" class="mr-1">mdi-information-outline</v-icon>
             Give your task a clear, concise name that describes what participants need to accomplish
           </p>
-          <v-text-field v-model="localTask.taskName" :rules="validationRules" variant="outlined" density="comfortable"
+          <v-text-field
+v-model="localTask.taskName" :rules="validationRules" variant="outlined" density="comfortable"
             prepend-inner-icon="mdi-format-title"
-            placeholder="e.g., 'Find product information', 'Complete checkout process'" @input="validateStep" />
+            placeholder="e.g., 'Find product information', 'Complete checkout process'" @update:model-value="validateStep" />
         </v-col>
 
         <v-col cols="12">
@@ -32,9 +33,11 @@
             Provide detailed instructions for participants. Include the goal, context, and any specific steps they
             should follow.
           </p>
-          <div class="description-editor"
+          <div
+class="description-editor"
             :class="{ 'editor-error': showDescriptionError && !localTask.taskDescription?.trim() }">
-            <quill-editor v-model:value="localTask.taskDescription" :options="editorOptions" class="custom-editor"
+            <quill-editor
+v-model:value="localTask.taskDescription" :options="editorOptions" class="custom-editor"
               @change="onChangeEditor" @blur="checkDescriptionValidation" />
           </div>
           <span v-if="showDescriptionError && !localTask.taskDescription?.trim()" class="error-text ml-4">
@@ -50,9 +53,10 @@
             <v-icon size="14" class="mr-1">mdi-information-outline</v-icon>
             Optional guidance or hints to help participants during the task
           </p>
-          <v-text-field v-model="localTask.taskTip" variant="outlined" density="comfortable"
+          <v-text-field
+v-model="localTask.taskTip" variant="outlined" density="comfortable"
             prepend-inner-icon="mdi-lightbulb-outline"
-            placeholder="e.g., 'Focus on the main navigation', 'Take your time to explore'" @input="validateStep" />
+            placeholder="e.g., 'Focus on the main navigation', 'Take your time to explore'" @update:model-value="validateStep" />
         </v-col>
       </v-row>
     </v-form>

--- a/src/ux/UserTest/components/transcription/ExportPanel.vue
+++ b/src/ux/UserTest/components/transcription/ExportPanel.vue
@@ -77,10 +77,10 @@
     <v-row class="mb-4" dense>
       <v-col cols="12" md="6">
         <!-- Scope -->
-        <span class="sr-only" id="scopeLabel">Scope</span>
+        <span id="scopeLabel" class="sr-only">Scope</span>
         <v-btn-toggle
-          aria-labelledby="scopeLabel"
           v-model="scope"
+          aria-labelledby="scopeLabel"
           mandatory
           density="comfortable"
           class="toggle--responsive seg"
@@ -98,10 +98,10 @@
 
       <v-col cols="12" md="6">
         <!-- Format -->
-        <span class="sr-only" id="formatLabel">Format</span>
+        <span id="formatLabel" class="sr-only">Format</span>
         <v-btn-toggle
-          aria-labelledby="formatLabel"
           v-model="format"
+          aria-labelledby="formatLabel"
           mandatory
           density="comfortable"
           class="toggle--responsive seg"
@@ -205,7 +205,7 @@
             </div>
             <QuillEditor
               v-model:content="pdfSummaryHtml"
-              contentType="html"
+              content-type="html"
               theme="snow"
               style="height: 220px"
             />
@@ -255,98 +255,6 @@
     </v-card>
   </v-dialog>
 </template>
-
-<style scoped>
-.export-surface {
-  display: flex;
-  flex-direction: column;
-}
-.export-actions {
-  justify-content:flex-end;
-  gap: 8px;
-}
-@media (max-width: 960px) {
-  .export-actions {
-    flex-wrap: wrap;
-    justify-content: space-between;
-  }
-  .export-actions .v-btn {
-    width: 100%;
-  }
-}
-
-.toggle--responsive {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-.toggle--responsive .v-btn {
-  flex: 1 1 220px;
-  min-width: 0;
-}
-
-.actions .v-btn {
-  min-width: 140px;
-}
-@media (max-width: 960px) {
-  .actions {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-  .actions .v-btn {
-    width: 100%;
-  }
-}
-
-/* PDF dialog: prevent overflow on small screens */
-.scroll-panel {
-  max-height: 60vh;
-  overflow: auto;
-}
-
-/* Tables: allow horizontal scroll on mobile */
-.scroll-x {
-  display: block;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-.scroll-x table {
-  width: 100%;
-}
-
-.pdf-preview {
-  background: #fff;
-  border: 1px solid #eee;
-  border-radius: 8px;
-  padding: 20px 30px;
-}
-.seg-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 12px;
-}
-.seg-table th,
-.seg-table td {
-  border: 1px solid #e6e6e6;
-  padding: 6px 8px;
-  vertical-align: top;
-}
-.seg-table thead th {
-  background: #fff7ea;
-}
-.sr-only {
-  position: absolute !important;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-</style>
 
 <script setup>
 import { ref, watch, computed } from 'vue'
@@ -920,3 +828,95 @@ function getImageSize(dataUrl) {
   })
 }
 </script>
+
+<style scoped>
+.export-surface {
+  display: flex;
+  flex-direction: column;
+}
+.export-actions {
+  justify-content:flex-end;
+  gap: 8px;
+}
+@media (max-width: 960px) {
+  .export-actions {
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+  .export-actions .v-btn {
+    width: 100%;
+  }
+}
+
+.toggle--responsive {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.toggle--responsive .v-btn {
+  flex: 1 1 220px;
+  min-width: 0;
+}
+
+.actions .v-btn {
+  min-width: 140px;
+}
+@media (max-width: 960px) {
+  .actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .actions .v-btn {
+    width: 100%;
+  }
+}
+
+/* PDF dialog: prevent overflow on small screens */
+.scroll-panel {
+  max-height: 60vh;
+  overflow: auto;
+}
+
+/* Tables: allow horizontal scroll on mobile */
+.scroll-x {
+  display: block;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.scroll-x table {
+  width: 100%;
+}
+
+.pdf-preview {
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 20px 30px;
+}
+.seg-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.seg-table th,
+.seg-table td {
+  border: 1px solid #e6e6e6;
+  padding: 6px 8px;
+  vertical-align: top;
+}
+.seg-table thead th {
+  background: #fff7ea;
+}
+.sr-only {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>

--- a/src/ux/UserTest/components/transcription/TimeLinePanel.vue
+++ b/src/ux/UserTest/components/transcription/TimeLinePanel.vue
@@ -41,17 +41,17 @@
         <!-- Provider -->
         <v-col cols="12" md="4" lg="4">
           <v-select
+            v-model="selectedProvider"
             label="Provider"
             :items="providers"
             item-title="label"
             item-value="value"
-            v-model="selectedProvider"
             variant="outlined"
             density="comfortable"
             prepend-inner-icon="mdi-robot-outline"
             hide-details
             :menu-props="{ maxHeight: 260 }"
-            @update:modelValue="
+            @update:model-value="
               (val) => {
                 selectedProvider = val
                 selectedModel = modelsByProvider[val]?.[0] || ''
@@ -63,11 +63,11 @@
         <!-- Model -->
         <v-col cols="12" md="4" lg="4">
           <v-select
+            v-model="selectedModel"
             label="Model"
             :items="modelOptions"
             item-title="label"
             item-value="value"
-            v-model="selectedModel"
             variant="outlined"
             density="comfortable"
             prepend-inner-icon="mdi-cube-outline"
@@ -100,7 +100,7 @@
     <!-- Runs list -->
     <TranscriptionList
       v-if="transcriptSegments.length"
-      :transcriptSegments="transcriptSegments"
+      :transcript-segments="transcriptSegments"
     />
 
     <!-- Empty state -->

--- a/src/ux/UserTest/components/transcription/TranscriptionsPanel.vue
+++ b/src/ux/UserTest/components/transcription/TranscriptionsPanel.vue
@@ -74,7 +74,7 @@
           <!-- full transcription list for this run -->
           <TranscriptionList
             v-if="segmentsFor(run).length"
-            :transcriptSegments="segmentsFor(run)"
+            :transcript-segments="segmentsFor(run)"
           />
           <div v-else class="text-medium-emphasis text-caption">
             No segments in this run.

--- a/src/ux/UserTest/views/EditTestView.vue
+++ b/src/ux/UserTest/views/EditTestView.vue
@@ -34,14 +34,16 @@
         <v-col cols="12">
           <!-- TEST -->
           <div v-if="index === 0">
-            <TestConfigForm :welcome="welcomeMessage" :final-message="finalMessage"
+            <TestConfigForm
+:welcome="welcomeMessage" :final-message="finalMessage"
               @update:welcome-message="welcomeMessage = $event; change = true"
               @update:final-message="finalMessage = $event; change = true" />
           </div>
 
           <!-- CONSENT FORM -->
           <div v-if="index === 1" rounded="xxl">
-            <TextareaForm v-model="consent" :title="$t('ModeratedTest.consentForm')"
+            <TextareaForm
+v-model="consent" :title="$t('ModeratedTest.consentForm')"
               :subtitle="$t('ModeratedTest.consentFormSubtitle')" @update:value="consent = $event" />
           </div>
 

--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -24,9 +24,9 @@
             color="white"
             variant="outlined"
             rounded
-            x-large
-            @click="startTest"
+            size="x-large"
             :disabled="isStartTestDisabled"
+            @click="startTest"
           >
             Start Test
           </v-btn>
@@ -298,7 +298,7 @@
           <!-- Video Call Component -->
           <div v-show="displayVideoCallComponent">
             <VideoCall
-              :roomId="roomId"
+              :room-id="roomId"
               :caller="isUserTestAdmin"
               :current-global-index="globalIndex"
               :current-task-index="taskIndex"
@@ -343,12 +343,12 @@
               :consent-text="test.testStructure.consent"
               :full-name-model="fullName"
               :consent-completed-model="localTestAnswer.consentCompleted"
-              @update:fullNameModel="(val) => (fullName = val)"
-              @update:consentCompletedModel="
+              @update:full-name-model="(val) => (fullName = val)"
+              @update:consent-completed-model="
                 (val) => (localTestAnswer.consentCompleted = val)
               "
               @continue="completeStep(taskIndex, 'consent')"
-              @declineConsent="handleConsentDecline"
+              @decline-consent="handleConsentDecline"
             />
 
             <!--Step 2: Pre-test -->
@@ -366,7 +366,7 @@
             <PreTasksStep
               v-if="globalIndex === 3 && taskIndex === 0"
               :num-tasks="test?.testStructure?.userTasks?.length || 0"
-              @startTasks="
+              @start-tasks="
                 () => {
                   taskIndex = 0
                   globalIndex = 4
@@ -378,23 +378,23 @@
             <TaskStep
               v-if="globalIndex === 4 && test.testType === STUDY_TYPES.USER"
               ref="taskStepComponent"
-              :task="test.testStructure.userTasks[taskIndex]"
-              :task-index="taskIndex"
-              :test-id="testId"
               v-model:post-answer="localTestAnswer.tasks[taskIndex].postAnswer"
               v-model:task-answer="localTestAnswer.tasks[taskIndex].taskAnswer"
               v-model:task-observations="
                 localTestAnswer.tasks[taskIndex].taskObservations
               "
+              :task="test.testStructure.userTasks[taskIndex]"
+              :task-index="taskIndex"
+              :test-id="testId"
               :sus-answers="localTestAnswer.tasks[taskIndex].susAnswers"
               :nasa-tlx-answers="
                 localTestAnswer.tasks[taskIndex].nasaTlxAnswers
               "
               :submitted="localTestAnswer.submitted"
               :done-task-disabled="doneTaskDisabled"
-              :remoteStream="remoteStream"
-              :shouldRecordModerator="!isUserTestAdmin"
-              @update:susAnswers="
+              :remote-stream="remoteStream"
+              :should-record-moderator="!isUserTestAdmin"
+              @update:sus-answers="
                 (val) => {
                   localTestAnswer.tasks[taskIndex].susAnswers = Array.isArray(
                     val,
@@ -403,13 +403,13 @@
                     : []
                 }
               "
-              @update:nasaTlxAnswers="
+              @update:nasa-tlx-answers="
                 (val) => {
                   localTestAnswer.tasks[taskIndex].nasaTlxAnswers = { ...val }
                 }
               "
               @done="() => handleTaskFinish(true)"
-              @couldNotFinish="() => handleTaskFinish(false)"
+              @could-not-finish="() => handleTaskFinish(false)"
               @show-loading="isLoading = true"
               @stop-show-loading="isLoading = false"
               @recording-started="isVisualizerVisible = $event"

--- a/src/ux/UserTest/views/Moderators/CooperatorsModeratedView.vue
+++ b/src/ux/UserTest/views/Moderators/CooperatorsModeratedView.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <CooperatorsView :hasRoleColumn="false" :showDateColumns="true" :showSessionColumn="true">
+    <CooperatorsView :has-role-column="false" :show-date-columns="true" :show-session-column="true">
       <template #dialog="{ isDrawerOpen, setDrawerOpen }">
         <CreateInviteDialog 
           :dialog="isDrawerOpen" 

--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -6,9 +6,9 @@
         :is-running="isTracking"
         :ms-per-capture="300"
         :record-screen="isRecording"
-        @faceData="handleIrisData"
         :test-id="testId"
         :task-index="taskIndex"
+        @face-data="handleIrisData"
       />
     </div>
 
@@ -96,9 +96,9 @@
             color="white"
             variant="outlined"
             rounded
-            @click="startTest"
             class="mt-4"
             :disabled="isStartTestDisabled"
+            @click="startTest"
           >
             Start Test
           </v-btn>
@@ -313,12 +313,12 @@
             :consent-text="test.testStructure.consent"
             :full-name-model="fullName"
             :consent-completed-model="localTestAnswer.consentCompleted"
-            @update:fullNameModel="(val) => (fullName = val)"
-            @update:consentCompletedModel="
+            @update:full-name-model="(val) => (fullName = val)"
+            @update:consent-completed-model="
               (val) => (localTestAnswer.consentCompleted = val)
             "
             @continue="completeStep(taskIndex, 'consent')"
-            @declineConsent="handleConsentDecline"
+            @decline-consent="handleConsentDecline"
           />
 
           <PreTestStep
@@ -332,17 +332,17 @@
 
           <EyeTrackingCalibrationStep
             v-if="globalIndex === 3 && hasEyeTracking"
+            :calibration-in-progress="calibrationInProgress"
+            :calibration-completed="calibrationCompleted"
             @done="globalIndex = 4"
-            @closeCalibration="closeCalibration()"
-            @openCalibration="openCalibration()"
-            :calibrationInProgress="calibrationInProgress"
-            :calibrationCompleted="calibrationCompleted"
+            @close-calibration="closeCalibration()"
+            @open-calibration="openCalibration()"
           />
 
           <PreTasksStep
             v-if="globalIndex === (hasEyeTracking ? 4 : 3) && taskIndex === 0"
             :num-tasks="test?.testStructure?.userTasks?.length || 0"
-            @startTasks="
+            @start-tasks="
               () => {
                 taskIndex = 0
                 globalIndex = hasEyeTracking ? 5 : 4
@@ -357,33 +357,33 @@
               test.testType === STUDY_TYPES.USER
             "
             ref="taskStepComponent"
-            :task="test.testStructure.userTasks[taskIndex]"
-            :task-index="taskIndex"
-            :test-id="testId"
-            :user-doc-id="user?.id || anonymousUserDocId"
             v-model:post-answer="localTestAnswer.tasks[taskIndex].postAnswer"
             v-model:task-answer="localTestAnswer.tasks[taskIndex].taskAnswer"
             v-model:task-observations="
               localTestAnswer.tasks[taskIndex].taskObservations
             "
+            :task="test.testStructure.userTasks[taskIndex]"
+            :task-index="taskIndex"
+            :test-id="testId"
+            :user-doc-id="user?.id || anonymousUserDocId"
             :sus-answers="localTestAnswer.tasks[taskIndex].susAnswers"
             :nasa-tlx-answers="localTestAnswer.tasks[taskIndex].nasaTlxAnswers"
             :submitted="localTestAnswer.submitted"
             :done-task-disabled="doneTaskDisabled"
-            @update:susAnswers="
+            @update:sus-answers="
               (val) => {
                 localTestAnswer.tasks[taskIndex].susAnswers = Array.isArray(val)
                   ? [...val]
                   : []
               }
             "
-            @update:nasaTlxAnswers="
+            @update:nasa-tlx-answers="
               (val) => {
                 localTestAnswer.tasks[taskIndex].nasaTlxAnswers = { ...val }
               }
             "
             @done="() => handleTaskFinish(true)"
-            @couldNotFinish="() => handleTaskFinish(false)"
+            @could-not-finish="() => handleTaskFinish(false)"
             @show-loading="isLoading = true"
             @stop-show-loading="isLoading = false"
             @recording-started="isVisualizerVisible = $event"

--- a/src/ux/accessibility/components/atoms/EyeTrackingPredictionCanvas.vue
+++ b/src/ux/accessibility/components/atoms/EyeTrackingPredictionCanvas.vue
@@ -1,32 +1,35 @@
 <template>
     <div class="eye-tracking-container" style="position: relative;">
         <!-- Config Toggle Button -->
-        <v-btn icon color="primary" class="config-btn" elevation="4" rounded @click="configOpen = !configOpen"
-            :aria-label="configOpen ? 'Close settings' : 'Open settings'">
+        <v-btn
+icon color="primary" class="config-btn" elevation="4" rounded :aria-label="configOpen ? 'Close settings' : 'Open settings'"
+            @click="configOpen = !configOpen">
             <v-icon>{{ configOpen ? 'mdi-cog-off-outline' : 'mdi-cog-outline' }}</v-icon>
         </v-btn>
 
         <!-- Config Panel with Transition -->
         <v-slide-x-transition>
-            <v-card v-if="configOpen" class="config-panel" elevation="6" rounded outlined>
+            <v-card v-if="configOpen" class="config-panel" elevation="6" rounded border>
                 <v-card-text>
                     <v-row align="center" justify="space-around" class="g-4">
                         <v-col cols="12" sm="4" class="text-center">
                             <label>
                                 Color:
-                                <input type="color" v-model="circleColor" />
+                                <input v-model="circleColor" type="color" />
                             </label>
                         </v-col>
 
                         <v-col cols="12" sm="4" class="text-center">
                             <v-label class="mb-1">Radius</v-label>
-                            <v-slider v-model="circleRadius" min="5" max="100" step="1" ticks tick-size="3"
+                            <v-slider
+v-model="circleRadius" min="5" max="100" step="1" show-ticks tick-size="3"
                                 class="mx-auto" style="max-width: 180px;" />
                         </v-col>
 
                         <v-col cols="12" sm="4" class="text-center">
                             <v-label class="mb-1">Opacity</v-label>
-                            <v-slider v-model="circleOpacity" min="0.01" max="1" step="0.01" ticks tick-size="3"
+                            <v-slider
+v-model="circleOpacity" min="0.01" max="1" step="0.01" show-ticks tick-size="3"
                                 class="mx-auto" style="max-width: 180px;" />
                         </v-col>
                     </v-row>
@@ -35,7 +38,8 @@
         </v-slide-x-transition>
 
         <!-- Canvas -->
-        <canvas ref="canvas" :width="screenWidth" :height="screenHeight"
+        <canvas
+ref="canvas" :width="screenWidth" :height="screenHeight"
             style="border: 1px solid #ccc; display: block; margin: 1rem auto;"></canvas>
     </div>
 </template>

--- a/src/ux/accessibility/view/automatic/EditTest.vue
+++ b/src/ux/accessibility/view/automatic/EditTest.vue
@@ -29,11 +29,13 @@
         <v-card class="form-card mb-6" elevation="8" rounded="xl">
           <v-card-text class="pa-8">
             <v-form @submit.prevent="runTest">
-              <v-text-field v-model="url" label="Website URL" placeholder="https://example.com" type="url" required
+              <v-text-field
+v-model="url" label="Website URL" placeholder="https://example.com" type="url" required
                 :disabled="isLoading" prepend-inner-icon="mdi-web" append-inner-icon="mdi-link" variant="outlined"
                 color="primary" class="mb-4" :rules="[rules.required, rules.url]" />
 
-              <v-btn type="submit" :disabled="isLoading || !url.trim()" :loading="isLoading" color="primary"
+              <v-btn
+type="submit" :disabled="isLoading || !url.trim()" :loading="isLoading" color="primary"
                 size="large" block rounded="lg" class="text-none">
                 <template #prepend>
                   <v-icon v-if="!isLoading">
@@ -60,10 +62,12 @@
 
             <div class="loading-steps">
               <v-list class="bg-transparent">
-                <v-list-item v-for="(step, index) in steps" :key="index"
+                <v-list-item
+v-for="(step, index) in steps" :key="index"
                   :class="{ 'step-active': currentStep >= index + 1 }" class="step-item">
                   <template #prepend>
-                    <v-icon :color="currentStep >= index + 1 ? 'success' : 'grey-lighten-1'
+                    <v-icon
+:color="currentStep >= index + 1 ? 'success' : 'grey-lighten-1'
                       " size="20">
                       mdi-check-circle
                     </v-icon>
@@ -159,10 +163,10 @@ import axios from 'axios'
 import PageWrapper from '@/shared/views/template/PageWrapper.vue'
 
 export default {
+  name: 'Home',
   components: {
     PageWrapper
   },
-  name: 'Home',
   data() {
     return {
       url: '',

--- a/src/ux/accessibility/view/automatic/Report.vue
+++ b/src/ux/accessibility/view/automatic/Report.vue
@@ -275,7 +275,7 @@
               </h2>
 
               <!-- Issue Summary Cards -->
-              <v-row class="mb-3" dense v-if="currentRuleIssueCounts.total > 0">
+              <v-row v-if="currentRuleIssueCounts.total > 0" class="mb-3" dense>
                 <v-col cols="4" class="py-1">
                   <v-card
                     :color="currentRuleIssueCounts.errors > 0 ? 'error' : 'grey-lighten-3'"
@@ -530,8 +530,8 @@
                   variant="outlined"
                   size="small"
                   prepend-icon="mdi-chevron-left"
-                  @click="prevRule"
                   :disabled="!hasPrevRule"
+                  @click="prevRule"
                 >
                   Previous
                 </v-btn>
@@ -542,8 +542,8 @@
                   variant="outlined"
                   size="small"
                   append-icon="mdi-chevron-right"
-                  @click="nextRule"
                   :disabled="!hasNextRule"
+                  @click="nextRule"
                 >
                   Next
                 </v-btn>

--- a/src/ux/accessibility/view/manual/AccessibilityAnswer.vue
+++ b/src/ux/accessibility/view/manual/AccessibilityAnswer.vue
@@ -1,5 +1,6 @@
 <template>
-  <PageWrapper :title="currentPage === 'userSelection' ? 'Select User' : 'Accessibility Assessment Results'"
+  <PageWrapper
+:title="currentPage === 'userSelection' ? 'Select User' : 'Accessibility Assessment Results'"
     :loading="isLoading"
     :loading-text="currentPage === 'userSelection' ? 'Loading users...' : 'Loading assessment data...'">
     <template #subtitle>
@@ -39,7 +40,8 @@
 
             <!-- User table (only show when not loading) -->
             <v-card v-if="!isLoadingUsers" elevation="2">
-              <v-data-table :headers="userHeaders" :items="userDetails" :items-per-page="10" :loading="isLoadingUsers"
+              <v-data-table
+:headers="userHeaders" :items="userDetails" :items-per-page="10" :loading="isLoadingUsers"
                 loading-text="Fetching users..." class="user-table elevation-0" height="50vh" density="compact"
                 @click:row="(event, { item }) => selectUser(item)">
                 <!-- Email/User Info Column -->
@@ -77,7 +79,8 @@
                     <v-btn color="primary" variant="flat" size="small" prepend-icon="mdi-eye" @click="selectUser(item)">
                       View Results
                     </v-btn>
-                    <v-btn color="secondary" variant="outlined" size="small" prepend-icon="mdi-test-tube"
+                    <v-btn
+color="secondary" variant="outlined" size="small" prepend-icon="mdi-test-tube"
                       @click="viewUserInPreview(item)">
                       View in Preview
                     </v-btn>
@@ -101,7 +104,8 @@
         <v-card class="mb-4">
           <v-card-text class="d-flex align-center justify-space-between pa-4">
             <div class="d-flex align-center">
-              <v-btn color="primary" variant="outlined" prepend-icon="mdi-arrow-left" class="mr-4"
+              <v-btn
+color="primary" variant="outlined" prepend-icon="mdi-arrow-left" class="mr-4"
                 @click="goBackToUserSelection">
                 Back to User Selection
               </v-btn>
@@ -115,7 +119,8 @@
               </div>
             </div>
             <div class="d-flex ga-2 align-center">
-              <v-btn color="secondary" variant="outlined" prepend-icon="mdi-test-tube"
+              <v-btn
+color="secondary" variant="outlined" prepend-icon="mdi-test-tube"
                 @click="viewUserInPreview(selectedUser)">
                 View in Preview Mode
               </v-btn>
@@ -140,7 +145,8 @@
                 <span class="text-subtitle-2 font-weight-medium">WCAG Level Filter:</span>
               </v-col>
               <v-col cols="auto" class="pa-0 ml-3">
-                <v-btn-toggle v-model="selectedLevel" mandatory color="primary" variant="outlined" divided
+                <v-btn-toggle
+v-model="selectedLevel" mandatory color="primary" variant="outlined" divided
                   density="compact">
                   <v-btn value="A" size="small" :class="{ 'level-a': selectedLevel === 'A' }">
                     A
@@ -163,7 +169,8 @@
 
           <!-- Tabs for Principles -->
           <v-tabs v-model="activeTab" grow show-arrows class="principle-tabs">
-            <v-tab v-for="(principle, index) in principles" :key="index" :value="index"
+            <v-tab
+v-for="(principle, index) in principles" :key="index" :value="index"
               :class="`principle-tab principle-${index}`">
               <v-icon start>
                 {{ getPrincipleIcon(index) }}
@@ -178,7 +185,8 @@
           <v-card-text class="pa-0">
             <v-window v-model="activeTab">
               <v-window-item v-for="(principle, pIndex) in principles" :key="pIndex" :value="pIndex">
-                <v-data-table :headers="headers" :items="getRulesForPrinciple(pIndex)" :items-per-page="10"
+                <v-data-table
+:headers="headers" :items="getRulesForPrinciple(pIndex)" :items-per-page="10"
                   :loading="isLoading" class="elevation-1" height="65vh">
                   <template #item.status="{ item }">
                     <v-chip :color="getStatusColor(item.status)" class="text-uppercase" size="small">
@@ -187,7 +195,8 @@
                   </template>
 
                   <template #item.severity="{ item }">
-                    <v-chip :color="getSeverityColor(item.severity)" class="text-uppercase" size="small"
+                    <v-chip
+:color="getSeverityColor(item.severity)" class="text-uppercase" size="small"
                       variant="outlined">
                       {{ item.severity || 'Not Set' }}
                     </v-chip>
@@ -239,7 +248,8 @@
               <v-list-item-subtitle class="text-body-1 mb-2">
                 {{ note.text }}
               </v-list-item-subtitle>
-              <v-img v-if="note.imagePreview" :src="note.imagePreview" max-height="300" cover
+              <v-img
+v-if="note.imagePreview" :src="note.imagePreview" max-height="300" cover
                 class="mt-2 mb-2 rounded" />
               <v-chip v-if="note.imageName" size="small" color="grey-lighten-2" class="mt-2">
                 <v-icon size="small" class="mr-1">

--- a/src/ux/accessibility/view/manual/AccessibilityConfig.vue
+++ b/src/ux/accessibility/view/manual/AccessibilityConfig.vue
@@ -50,7 +50,8 @@
               <v-radio-group v-model="selectedCompliance" class="mb-4">
                 <v-row dense>
                   <v-col v-for="level in complianceLevels" :key="level.value" cols="12" sm="6" md="4" class="pa-1">
-                    <v-card :class="[
+                    <v-card
+:class="[
                       'compliance-card cursor-pointer',
                       selectedCompliance === level.value ? 'selected-compliance' : ''
                     ]" :variant="selectedCompliance === level.value ? 'flat' : 'outlined'" elevation="1" hover
@@ -58,7 +59,8 @@
                       <v-card-text class="pa-3">
                         <div class="d-flex align-center mb-2">
                           <v-radio :value="level.value" :color="level.color" hide-details class="mr-2" readonly />
-                          <v-chip :color="level.color"
+                          <v-chip
+:color="level.color"
                             :variant="selectedCompliance === level.value ? 'flat' : 'outlined'" size="small"
                             class="font-weight-bold">
                             {{ level.value }}
@@ -104,12 +106,14 @@
             </v-card-text>
 
             <v-card-actions class="pa-4 pt-2">
-              <v-btn variant="outlined" :disabled="isLoading" prepend-icon="mdi-refresh" size="small"
+              <v-btn
+variant="outlined" :disabled="isLoading" prepend-icon="mdi-refresh" size="small"
                 @click="resetToDefaults">
                 Reset
               </v-btn>
               <v-spacer />
-              <v-btn color="primary" :loading="isLoading" :disabled="!selectedCompliance" append-icon="mdi-arrow-right"
+              <v-btn
+color="primary" :loading="isLoading" :disabled="!selectedCompliance" append-icon="mdi-arrow-right"
                 @click="saveComplianceAndContinue">
                 Continue
               </v-btn>
@@ -138,7 +142,8 @@
               </v-alert>
 
               <!-- Validation Error Alert -->
-              <v-alert v-if="showValidationErrors && validationErrors.length > 0" color="error" variant="tonal"
+              <v-alert
+v-if="showValidationErrors && validationErrors.length > 0" color="error" variant="tonal"
                 class="mb-4" density="compact">
                 <template #prepend>
                   <v-icon size="18">
@@ -156,9 +161,11 @@
               </v-alert>
 
               <!-- Compact Principle Tabs -->
-              <v-tabs v-model="selectedPrincipleTab" class="mb-3" color="primary" slider-color="primary" show-arrows
+              <v-tabs
+v-model="selectedPrincipleTab" class="mb-3" color="primary" slider-color="primary" show-arrows
                 density="compact">
-                <v-tab v-for="(principle, idx) in filteredPrinciples" :key="principle.id || idx" class="text-capitalize"
+                <v-tab
+v-for="(principle, idx) in filteredPrinciples" :key="principle.id || idx" class="text-capitalize"
                   size="small">
                   <v-icon :color="getPrincipleIcon(idx).color" class="mr-1" size="16">
                     {{ getPrincipleIcon(idx).icon }}
@@ -173,10 +180,12 @@
                   <v-window-item v-for="(principle, pIdx) in filteredPrinciples" :key="principle.id || pIdx">
                     <v-card variant="outlined" class="mb-3">
                       <v-list density="compact">
-                        <v-list-item v-for="(guideline) in principle.Guidelines || []" :key="guideline.id" class="pa-2"
+                        <v-list-item
+v-for="(guideline) in principle.Guidelines || []" :key="guideline.id" class="pa-2"
                           :class="{ 'guideline-error': isGuidelineInvalid(guideline.id) }">
                           <template #prepend>
-                            <v-checkbox v-model="selectedGuidelines" :value="guideline.id" hide-details
+                            <v-checkbox
+v-model="selectedGuidelines" :value="guideline.id" hide-details
                               density="compact" color="primary" @update:model-value="onGuidelineCheck(guideline.id)" />
                           </template>
 
@@ -193,7 +202,8 @@
                           <div
                             v-if="selectedGuidelines.includes(guideline.id) && guideline.rules && guideline.rules.length > 0"
                             class="mt-2">
-                            <v-select v-model="selectedRulesByGuideline[guideline.id]"
+                            <v-select
+v-model="selectedRulesByGuideline[guideline.id]"
                               :items="guideline.rules.map(r => ({ title: r.title, value: r.id }))" item-title="title"
                               item-value="value" label="Select specific rules (required)" multiple chips clearable
                               density="compact" variant="outlined" hide-details class="rules-select"
@@ -236,7 +246,8 @@
                 Back
               </v-btn>
               <v-spacer />
-              <v-btn color="primary" :loading="isLoading" :disabled="!isValidConfiguration"
+              <v-btn
+color="primary" :loading="isLoading" :disabled="!isValidConfiguration"
                 append-icon="mdi-content-save" @click="saveConfiguration">
                 Save Config
               </v-btn>


### PR DESCRIPTION
I worked on adding the SART (Situational Awareness Rating Technique) to the platform. It is now fully ready to use in the task creator, and I’ve added a section in the analytics dashboard so researchers can actually see the calculated scores.

**What I did:**

* **Added SART to the task selection:** You can now pick "SART" when creating a task.
* **Built the participant form:** Created the `SartStep.vue` component with the 1-7 sliders for Demand, Supply, and Understanding.
* **Added Analytics:** Created a card in the results view that automatically calculates the SA score using the Understanding - (Demand - Supply) formula.
* **Cleaned up the code:** Fixed the linting errors and updated the components to use Vuetify 3 standards (like `text-primary` and `size="large"`).

I've tested this locally and the math works perfectly (for example, a score of 7, 2, and 5 results in a 10.00). All my modified files pass `npm run lint` with 0 errors

Please let me know if you’d like any changes or refinements. Happy to iterate.

**Fixes: #1211**