### PR TITLE
Fix(#1318) : notification bell  fix

### DIFF
--- a/src/features/navigation/components/NotificationButton.vue
+++ b/src/features/navigation/components/NotificationButton.vue
@@ -42,7 +42,7 @@
       <v-card class="notification-dropdown" elevation="6">
         <!-- Header -->
         <div class="dropdown-header">
-          <span class="title">{{ $t('common.notifications') }}</span>
+          <span class="text-h6">{{ $t('common.notifications') }}</span>
 
           <div class="actions">
             <v-btn
@@ -214,20 +214,22 @@ watch(menuOpen, (open) => {
 /* Pulse animation */
 .notification-bell.pulse {
   position: relative;
+  z-index: 1;
 }
 
 .notification-bell.pulse::after {
   content: '';
   position: absolute;
-  inset: -6px;
+  inset: 0;
   border-radius: 50%;
   border: 2px solid rgba(255, 0, 0, 0.5);
   animation: pulse 1.5s infinite;
+  pointer-events: none;
 }
 
 @keyframes pulse {
-  0% { transform: scale(0.9); opacity: 1; }
-  100% { transform: scale(1.4); opacity: 0; }
+  0% { transform: scale(1.0); opacity: 1; }
+  100% { transform: scale(1.8); opacity: 0; }
 }
 
 /* Dropdown */


### PR DESCRIPTION
## Summary
The notification bell badge was not perfectly aligned with the bell icon. This PR fixes the alignment issue to ensure the badge is centered correctly.

## Fix
- Corrected the positioning of the notification badge so it aligns properly with the bell icon
- Improves visual consistency in the header UI

## Reference
Fixes: #1318

## Before
<img width="483" height="291" alt="Before screenshot" src="https://github.com/user-attachments/assets/1f26bb3e-a650-4e4e-8c97-f61326c2e2e2" />

## After
<img width="326" height="125" alt="After screenshot" src="https://github.com/user-attachments/assets/36465763-853a-4161-9271-f1db5800db1e" />

## Additional Info
- Updated `title` to `text-h6` since `title` is no longer supported
