### PR TITLE
Export pre-test as latex language

### DIFF
--- a/src/ux/UserTest/components/answers/SelectionPieChart.vue
+++ b/src/ux/UserTest/components/answers/SelectionPieChart.vue
@@ -20,6 +20,12 @@
             </template>
             <v-list-item-title>Download as PNG</v-list-item-title>
           </v-list-item>
+          <v-list-item @click="openLatexModal">
+            <template #prepend>
+              <v-icon>mdi-code-braces</v-icon>
+            </template>
+            <v-list-item-title>Copy LaTeX</v-list-item-title>
+          </v-list-item>
         </v-list>
       </v-menu>
     </div>
@@ -44,11 +50,19 @@
         <span>{{ option }} ({{ counts[option] || 0 }})</span>
       </div>
     </div>
+    <LaTeXExportModal 
+      v-model="showLatexModal" 
+      :question-title="questionTitle" 
+      :options="options" 
+      :counts="counts" 
+      :colors="chartColors" 
+    />
   </v-card>
 </template>
 
 <script setup>
 import { onMounted, watch, nextTick, ref } from 'vue'
+import LaTeXExportModal from '../modals/LaTeXExportModal.vue'
 
 const props = defineProps({
   questionTitle: String,
@@ -69,6 +83,12 @@ const props = defineProps({
     ],
   },
 })
+
+const showLatexModal = ref(false)
+
+const openLatexModal = () => {
+  showLatexModal.value = true
+}
 
 const drawChart = () => {
   nextTick(() => {

--- a/src/ux/UserTest/components/modals/LaTeXExportModal.vue
+++ b/src/ux/UserTest/components/modals/LaTeXExportModal.vue
@@ -1,0 +1,104 @@
+<template>
+  <v-dialog v-model="isOpen" max-width="800px">
+    <v-card>
+      <v-card-title class="text-h6 font-weight-bold">
+        LaTeX Code Export
+      </v-card-title>
+
+      <v-card-text>
+        <div class="code-display">
+          <pre><code>{{ tikzCode }}</code></pre>
+        </div>
+      </v-card-text>
+
+      <v-card-actions class="justify-space-between">
+        <v-btn @click="closeDialog">Close</v-btn>
+        <div class="d-flex align-center gap-2">
+          <v-btn color="primary" @click="copyToClipboard">
+            Copy Code
+          </v-btn>
+          <v-slide-x-transition>
+            <span v-if="copySuccess" class="text-success font-weight-bold">
+              ✓ Copied successfully!
+            </span>
+          </v-slide-x-transition>
+        </div>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { generatePieChartLatex } from '../../utils/latexPieChartGenerator.js'
+
+const props = defineProps({
+  modelValue: Boolean,
+  questionTitle: String,
+  options: Array,
+  counts: Object,
+  colors: Array,
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const copySuccess = ref(false)
+
+const isOpen = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+})
+
+const tikzCode = computed(() =>
+  generatePieChartLatex(props.questionTitle, props.options, props.counts, props.colors)
+)
+
+const copyToClipboard = async () => {
+  try {
+    await navigator.clipboard.writeText(tikzCode.value)
+    copySuccess.value = true
+    // Hide message after 3 seconds
+    setTimeout(() => {
+      copySuccess.value = false
+    }, 3000)
+  } catch (err) {
+    console.error('Failed to copy:', err)
+  }
+}
+
+const closeDialog = () => {
+  isOpen.value = false
+}
+</script>
+
+<style scoped>
+.code-display {
+  background-color: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 12px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.code-display pre {
+  margin: 0;
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.code-display code {
+  color: #333;
+}
+
+.gap-2 {
+  gap: 8px;
+}
+
+.text-success {
+  color: #4caf50;
+}
+</style>

--- a/src/ux/UserTest/components/modals/LaTeXExportModal.vue
+++ b/src/ux/UserTest/components/modals/LaTeXExportModal.vue
@@ -6,8 +6,22 @@
       </v-card-title>
 
       <v-card-text>
-        <div class="code-display">
-          <pre><code>{{ tikzCode }}</code></pre>
+        <div class="mb-4">
+          <div class="text-subtitle-2 font-weight-bold mb-2">
+            Required Packages (add to preamble):
+          </div>
+          <div class="code-display">
+            <pre><code>{{ latexCode.packages }}</code></pre>
+          </div>
+        </div>
+
+        <div>
+          <div class="text-subtitle-2 font-weight-bold mb-2">
+            Graphic Code (add to document body):
+          </div>
+          <div class="code-display">
+            <pre><code>{{ latexCode.content }}</code></pre>
+          </div>
         </div>
       </v-card-text>
 
@@ -15,7 +29,7 @@
         <v-btn @click="closeDialog">Close</v-btn>
         <div class="d-flex align-center gap-2">
           <v-btn color="primary" @click="copyToClipboard">
-            Copy Code
+            Copy All Code
           </v-btn>
           <v-slide-x-transition>
             <span v-if="copySuccess" class="text-success font-weight-bold">
@@ -49,13 +63,14 @@ const isOpen = computed({
   set: (value) => emit('update:modelValue', value),
 })
 
-const tikzCode = computed(() =>
+const latexCode = computed(() =>
   generatePieChartLatex(props.questionTitle, props.options, props.counts, props.colors)
 )
 
 const copyToClipboard = async () => {
   try {
-    await navigator.clipboard.writeText(tikzCode.value)
+    const fullCode = `${latexCode.value.packages}\n\n${latexCode.value.content}`
+    await navigator.clipboard.writeText(fullCode)
     copySuccess.value = true
     // Hide message after 3 seconds
     setTimeout(() => {

--- a/src/ux/UserTest/utils/latexPieChartGenerator.js
+++ b/src/ux/UserTest/utils/latexPieChartGenerator.js
@@ -1,0 +1,173 @@
+
+/**
+ * Escape special LaTeX characters
+ * @param {string} text - Text to escape
+ * @returns {string} Escaped text
+ */
+const escapeLatex = (text) => {
+  if (!text) return ''
+  return String(text)
+    .replace(/\\/g, '\\textbackslash{}')
+    .replace(/([&%$#_{}~^])/g, '\\$1')
+    .replace(/\^/g, '\\textasciicircum{}')
+    .replace(/~/g, '\\textasciitilde{}')
+}
+
+/**
+ * Generate LaTeX TikZ code for a pie chart
+ * @param {string} title - Chart title
+ * @param {Array} options - Array of option labels
+ * @param {Object} counts - Object with counts for each option
+ * @param {Array} colors - Array of hex color codes
+ * @returns {string} LaTeX code
+ */
+export const generatePieChartLatex = (title, options, counts, colors = []) => {
+  // Default colors if not provided
+  const defaultColors = ['blue!40', 'green!40', 'orange!40', 'purple!40', 'red!40', 'teal!40', 'yellow!40', 'brown!40']
+  const chartColors = colors && colors.length > 0 ? colors : defaultColors
+
+  // Convert hex colors to TikZ format if needed
+  const tikzColors = chartColors.map((color, idx) => {
+    if (color && color.startsWith('#')) {
+      return `color${idx}`
+    }
+    return color
+  })
+
+  // Calculate totals and percentages
+  const total = Object.values(counts || {}).reduce((a, b) => a + b, 0)
+  const data = (options || []).map((option) => ({
+    label: option,
+    count: counts[option] || 0,
+    percentage: total > 0 ? (((counts[option] || 0) / total) * 100).toFixed(1) : 0
+  }))
+
+  // Build LaTeX document
+  let latex = '\\documentclass{standalone}\n'
+  latex += '\\usepackage{tikz}\n'
+  latex += '\\begin{document}\n\n'
+
+  // Define custom colors if hex colors were provided
+  if (colors && colors.length > 0 && colors[0] && colors[0].startsWith('#')) {
+    latex += '\\definecolor{color0}{HTML}{' + colors[0].replace('#', '').toUpperCase() + '}\n'
+    for (let i = 1; i < colors.length; i++) {
+      if (colors[i] && colors[i].startsWith('#')) {
+        latex += `\\definecolor{color${i}}{HTML}{${colors[i].replace('#', '').toUpperCase()}}\n`
+      }
+    }
+    latex += '\n'
+  }
+
+  latex += '\\begin{tikzpicture}\n'
+
+  // Draw pie chart with labels on slices
+  let startAngle = 0
+  data.forEach((item, idx) => {
+    const endAngle = startAngle + (item.count / total) * 360
+    const color = tikzColors[idx % tikzColors.length]
+    const midAngle = (startAngle + endAngle) / 2
+
+    // Draw pie slice
+    if (item.count > 0) {
+      latex += `\\filldraw[fill=${color}, draw=white, line width=2pt]\n`
+      latex += `  (0, 0) -- (${Math.cos((startAngle * Math.PI) / 180) * 1.5}, ${Math.sin((startAngle * Math.PI) / 180) * 1.5})\n`
+      latex += `  arc[radius=1.5, start angle=${startAngle}, end angle=${endAngle}]\n`
+      latex += `  -- (0, 0);\n\n`
+
+      // Add percentage label on the slice (white text)
+      const labelRadius = 0.9
+      const labelX = Math.cos((midAngle * Math.PI) / 180) * labelRadius
+      const labelY = Math.sin((midAngle * Math.PI) / 180) * labelRadius
+      latex += `\\node at (${labelX}, ${labelY}) [font=\\bfseries, text=white] {${item.percentage}\\%};\n\n`
+    }
+
+    startAngle = endAngle
+  })
+
+  // Draw legend below the pie chart
+  latex += '% Legend\n'
+  let legendY = -1.8
+  data.forEach((item, idx) => {
+    const color = tikzColors[idx % tikzColors.length]
+    
+    // Draw colored circle
+    latex += `\\filldraw[fill=${color}] (-2.2, ${legendY}) circle (0.1);\n`
+    
+    // Draw label text
+    latex += `\\node at (-2.0, ${legendY}) [anchor=west, font=\\small] {${escapeLatex(item.label)} (${item.count})};\n`
+    
+    legendY -= 0.35
+  })
+
+  latex += '\n\\end{tikzpicture}\n\n'
+  latex += '\\end{document}\n'
+
+  return latex
+}
+
+/**
+ * Generate simplified LaTeX code (without TikZ, just raw data representation)
+ * @param {string} title - Chart title
+ * @param {Array} options - Array of option labels
+ * @param {Object} counts - Object with counts for each option
+ * @returns {string} Simplified LaTeX code
+ */
+export const generateSimplifiedPieChartLatex = (title, options, counts) => {
+  let latex = '% Pie Chart Data\n'
+  latex += `% Title: ${escapeLatex(title)}\n\n`
+
+  const total = Object.values(counts || {}).reduce((a, b) => a + b, 0)
+
+  latex += '\\begin{tabular}{|c|c|c|}\n'
+  latex += '\\hline\n'
+  latex += '\\textbf{Option} & \\textbf{Count} & \\textbf{Percentage} \\\\\n'
+  latex += '\\hline\n'
+
+  ;(options || []).forEach((option) => {
+    const count = counts[option] || 0
+    const percentage = total > 0 ? ((count / total) * 100).toFixed(1) : 0
+    latex += `${escapeLatex(option)} & ${count} & ${percentage}\\% \\\\\n`
+  })
+
+  latex += '\\hline\n'
+  latex += `\\textbf{Total} & ${total} & 100\\% \\\\\n`
+  latex += '\\hline\n'
+  latex += '\\end{tabular}\n'
+
+  return latex
+}
+
+/**
+ * Generate PGFPlots LaTeX code (more compact and modern)
+ * @param {string} title - Chart title
+ * @param {Array} options - Array of option labels
+ * @param {Object} counts - Object with counts for each option
+ * @returns {string} PGFPlots LaTeX code
+ */
+export const generatePgfplotsPieChartLatex = (title, options, counts) => {
+  const total = Object.values(counts || {}).reduce((a, b) => a + b, 0)
+
+  let latex = '\\documentclass{standalone}\n'
+  latex += '\\usepackage{pgfplots}\n'
+  latex += '\\begin{document}\n\n'
+
+  latex += '\\begin{tikzpicture}\n'
+  latex += '\\begin{axis}[\n'
+  latex += '  title={' + escapeLatex(title) + '},\n'
+  latex += '  legend pos=outer north east,\n'
+  latex += '  legend columns=1,\n'
+  latex += ']\n'
+  latex += '\\addplot[pie chart] table[meta index=0] {\n'
+  ;(options || []).forEach((option) => {
+    const count = counts[option] || 0
+    latex += `${count}\n`
+  })
+
+  latex += '};\n'
+  latex += '\\legend{' + (options || []).map(escapeLatex).join(',') + '}\n'
+  latex += '\\end{axis}\n'
+  latex += '\\end{tikzpicture}\n\n'
+  latex += '\\end{document}\n'
+
+  return latex
+}

--- a/src/ux/UserTest/utils/latexPieChartGenerator.js
+++ b/src/ux/UserTest/utils/latexPieChartGenerator.js
@@ -19,7 +19,7 @@ const escapeLatex = (text) => {
  * @param {Array} options - Array of option labels
  * @param {Object} counts - Object with counts for each option
  * @param {Array} colors - Array of hex color codes
- * @returns {string} LaTeX code
+ * @returns {Object} Object with packages and content properties
  */
 export const generatePieChartLatex = (title, options, counts, colors = []) => {
   // Default colors if not provided
@@ -42,23 +42,24 @@ export const generatePieChartLatex = (title, options, counts, colors = []) => {
     percentage: total > 0 ? (((counts[option] || 0) / total) * 100).toFixed(1) : 0
   }))
 
-  // Build LaTeX document
-  let latex = '\\documentclass{standalone}\n'
-  latex += '\\usepackage{tikz}\n'
-  latex += '\\begin{document}\n\n'
+  // Build packages section
+  let packages = '\\usepackage{tikz}\n'
+
+  // Build content section
+  let content = ''
 
   // Define custom colors if hex colors were provided
   if (colors && colors.length > 0 && colors[0] && colors[0].startsWith('#')) {
-    latex += '\\definecolor{color0}{HTML}{' + colors[0].replace('#', '').toUpperCase() + '}\n'
+    content += '\\definecolor{color0}{HTML}{' + colors[0].replace('#', '').toUpperCase() + '}\n'
     for (let i = 1; i < colors.length; i++) {
       if (colors[i] && colors[i].startsWith('#')) {
-        latex += `\\definecolor{color${i}}{HTML}{${colors[i].replace('#', '').toUpperCase()}}\n`
+        content += `\\definecolor{color${i}}{HTML}{${colors[i].replace('#', '').toUpperCase()}}\n`
       }
     }
-    latex += '\n'
+    content += '\n'
   }
 
-  latex += '\\begin{tikzpicture}\n'
+  content += '\\begin{tikzpicture}\n'
 
   // Draw pie chart with labels on slices
   let startAngle = 0
@@ -69,40 +70,39 @@ export const generatePieChartLatex = (title, options, counts, colors = []) => {
 
     // Draw pie slice
     if (item.count > 0) {
-      latex += `\\filldraw[fill=${color}, draw=white, line width=2pt]\n`
-      latex += `  (0, 0) -- (${Math.cos((startAngle * Math.PI) / 180) * 1.5}, ${Math.sin((startAngle * Math.PI) / 180) * 1.5})\n`
-      latex += `  arc[radius=1.5, start angle=${startAngle}, end angle=${endAngle}]\n`
-      latex += `  -- (0, 0);\n\n`
+      content += `\\filldraw[fill=${color}, draw=white, line width=2pt]\n`
+      content += `  (0, 0) -- (${Math.cos((startAngle * Math.PI) / 180) * 1.5}, ${Math.sin((startAngle * Math.PI) / 180) * 1.5})\n`
+      content += `  arc[radius=1.5, start angle=${startAngle}, end angle=${endAngle}]\n`
+      content += `  -- (0, 0);\n\n`
 
       // Add percentage label on the slice (white text)
       const labelRadius = 0.9
       const labelX = Math.cos((midAngle * Math.PI) / 180) * labelRadius
       const labelY = Math.sin((midAngle * Math.PI) / 180) * labelRadius
-      latex += `\\node at (${labelX}, ${labelY}) [font=\\bfseries, text=white] {${item.percentage}\\%};\n\n`
+      content += `\\node at (${labelX}, ${labelY}) [font=\\bfseries, text=white] {${item.percentage}\\%};\n\n`
     }
 
     startAngle = endAngle
   })
 
   // Draw legend below the pie chart
-  latex += '% Legend\n'
+  content += '% Legend\n'
   let legendY = -1.8
   data.forEach((item, idx) => {
     const color = tikzColors[idx % tikzColors.length]
     
     // Draw colored circle
-    latex += `\\filldraw[fill=${color}] (-2.2, ${legendY}) circle (0.1);\n`
+    content += `\\filldraw[fill=${color}] (-2.2, ${legendY}) circle (0.1);\n`
     
     // Draw label text
-    latex += `\\node at (-2.0, ${legendY}) [anchor=west, font=\\small] {${escapeLatex(item.label)} (${item.count})};\n`
+    content += `\\node at (-2.0, ${legendY}) [anchor=west, font=\\small] {${escapeLatex(item.label)} (${item.count})};\n`
     
     legendY -= 0.35
   })
 
-  latex += '\n\\end{tikzpicture}\n\n'
-  latex += '\\end{document}\n'
+  content += '\\end{tikzpicture}\n'
 
-  return latex
+  return { packages, content }
 }
 
 /**
@@ -142,32 +142,29 @@ export const generateSimplifiedPieChartLatex = (title, options, counts) => {
  * @param {string} title - Chart title
  * @param {Array} options - Array of option labels
  * @param {Object} counts - Object with counts for each option
- * @returns {string} PGFPlots LaTeX code
+ * @returns {Object} Object with packages and content properties
  */
 export const generatePgfplotsPieChartLatex = (title, options, counts) => {
   const total = Object.values(counts || {}).reduce((a, b) => a + b, 0)
 
-  let latex = '\\documentclass{standalone}\n'
-  latex += '\\usepackage{pgfplots}\n'
-  latex += '\\begin{document}\n\n'
+  let packages = '\\usepackage{pgfplots}\n'
 
-  latex += '\\begin{tikzpicture}\n'
-  latex += '\\begin{axis}[\n'
-  latex += '  title={' + escapeLatex(title) + '},\n'
-  latex += '  legend pos=outer north east,\n'
-  latex += '  legend columns=1,\n'
-  latex += ']\n'
-  latex += '\\addplot[pie chart] table[meta index=0] {\n'
+  let content = '\\begin{tikzpicture}\n'
+  content += '\\begin{axis}[\n'
+  content += '  title={' + escapeLatex(title) + '},\n'
+  content += '  legend pos=outer north east,\n'
+  content += '  legend columns=1,\n'
+  content += ']\n'
+  content += '\\addplot[pie chart] table[meta index=0] {\n'
   ;(options || []).forEach((option) => {
     const count = counts[option] || 0
-    latex += `${count}\n`
+    content += `${count}\n`
   })
 
-  latex += '};\n'
-  latex += '\\legend{' + (options || []).map(escapeLatex).join(',') + '}\n'
-  latex += '\\end{axis}\n'
-  latex += '\\end{tikzpicture}\n\n'
-  latex += '\\end{document}\n'
+  content += '};\n'
+  content += '\\legend{' + (options || []).map(escapeLatex).join(',') + '}\n'
+  content += '\\end{axis}\n'
+  content += '\\end{tikzpicture}\n'
 
-  return latex
+  return { packages, content }
 }


### PR DESCRIPTION
fixes #1205
## Overview
Adds a "Copy LaTeX" export feature for pie charts in the General Analytics section, allowing users to export pie chart data as compilable TikZ LaTeX code.

## Changes

### New Features
- **LaTeX Export Button**: Added a "Copy LaTeX" option in the pie chart menu (three dots)
- **Modal Dialog**: Displays formatted LaTeX code ready for copying
- **Success Feedback**: Shows " Copied successfully!" message in green after copying (auto-hides after 3 seconds)
- **TikZ Format**
### Files Added
- `src/ux/UserTest/components/modals/LaTeXExportModal.vue` - Modal dialog component for displaying LaTeX code
- `src/ux/UserTest/utils/latexPieChartGenerator.js` - LaTeX code generation utility

### Files Modified
- `src/ux/UserTest/components/answers/SelectionPieChart.vue` - Added LaTeX export button and modal integration

https://github.com/user-attachments/assets/4e7966df-9bd5-4d49-9b96-5c9c6dbfa773

