### PR TITLE
ci: add i18n translation validator for pull requests

### DIFF
--- a/.github/workflows/i18n-diff-guard.yml
+++ b/.github/workflows/i18n-diff-guard.yml
@@ -1,0 +1,99 @@
+name: i18n Diff Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  i18n:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run i18n diff guard
+        id: i18n_check
+        continue-on-error: true
+        run: node i18n-diff-guard.js
+
+      - name: Post PR comment on failure
+        if: steps.i18n_check.outcome == 'failure'
+        uses: actions/github-script@v7
+        env:
+          I18N_REPORT: ${{ steps.i18n_check.outputs.report }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const report = process.env.I18N_REPORT;
+            if (!report) return;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' &&
+              c.body.includes('i18n Translation Validation')
+            );
+
+            const body = `${report}\n\n---\n*Updated: ${new Date().toUTCString()}*`;
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }
+
+      - name: Remove comment on success
+        if: steps.i18n_check.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' &&
+              c.body.includes('i18n Translation Validation')
+            );
+
+            if (botComment) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id
+              });
+            }
+
+      - name: Fail build if validation failed
+        if: steps.i18n_check.outcome == 'failure'
+        run: exit 1

--- a/i18n-diff-guard.js
+++ b/i18n-diff-guard.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+/**
+ i18n Translation Validator - Diff-based (Multi-locale)
+  - Validates ONLY new/modified i18n usage in git diff
+  - Dynamically checks missing keys in all other locales
+**/
+
+import { execSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+const BASE_LOCALE = 'en'
+const ALL_LOCALES = ['en', 'es', 'pt_br', 'hi', 'de', 'fr', 'zh', 'ar', 'ru', 'ja']
+const LOCALES_DIR = 'src/app/plugins/locales'
+
+function getDiff() {
+  if (process.env.GITHUB_BASE_REF) {
+    try {
+      return execSync(
+        `git diff origin/${process.env.GITHUB_BASE_REF}...HEAD`,
+        { encoding: 'utf8' }
+      )
+    } catch {}
+  }
+
+  try {
+    return execSync(`git diff HEAD~1...HEAD`, { encoding: 'utf8' })
+  } catch {}
+
+  try {
+    return execSync(`git diff --cached`, { encoding: 'utf8' })
+  } catch {}
+
+  try {
+    return execSync(`git diff`, { encoding: 'utf8' })
+  } catch {}
+
+  return ''
+}
+
+const diff = getDiff()
+
+if (!diff.trim()) {
+  console.log('[INFO] No diff detected, skipping i18n validation')
+  process.exit(0)
+}
+
+const addedCodeLines = []
+let currentFile = null
+
+for (const line of diff.split('\n')) {
+  const fileMatch = line.match(/^\+\+\+ b\/(.+)/)
+  if (fileMatch) {
+    currentFile = fileMatch[1]
+    continue
+  }
+
+  if (!line.startsWith('+') || line.startsWith('+++')) continue
+
+  if (currentFile && /\.(js|ts|vue)$/.test(currentFile)) {
+    addedCodeLines.push(line.slice(1))
+  }
+}
+
+console.log(`[INFO] Analyzing ${addedCodeLines.length} added code lines`)
+
+const codeKeys = new Set()
+
+const patterns = [
+  /\$t\s*\(\s*['"`]([\w.-]+)['"`]\s*[,)]/g,
+  /\bt\s*\(\s*['"`]([\w.-]+)['"`]\s*[,)]/g,
+  /\$tc\s*\(\s*['"`]([\w.-]+)['"`]\s*[,)]/g,
+  /v-t\s*=\s*['"`]([\w.-]+)['"`]/g,
+  /keypath\s*=\s*['"`]([\w.-]+)['"`]/g,
+  /\.t\s*\(\s*['"`]([\w.-]+)['"`]\s*[,)]/g,
+  /:\w+\s*=\s*['"]\$t\(['"`]([\w.-]+)['"`]\)/g,
+  /{{\s*\$t\s*\(\s*['"`]([\w.-]+)['"`]/g,
+  /show(?:Toast|Success|Error|Info|Warning)\s*\(\s*['"`]([\w.-]+)['"`]\s*[,)]/g,
+  /toast\.(?:success|error|info|warning)\s*\(\s*['"`]([\w.-]+)['"`]\s*[,)]/g,
+  /\btoast\s*\(\s*['"`]([\w.-]+)['"`]\s*[,)]/g,
+]
+
+for (const line of addedCodeLines) {
+  for (const pattern of patterns) {
+    for (const match of line.matchAll(pattern)) {
+      const key = match[1].trim()
+      if (key.includes('.')) {
+        codeKeys.add(key)
+      }
+    }
+  }
+}
+
+console.log(`[INFO] Found ${codeKeys.size} i18n key(s) in added code`)
+
+function loadLocale(locale) {
+  const file = path.join(LOCALES_DIR, `${locale}.json`)
+  if (!fs.existsSync(file)) return null
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+function hasKey(obj, key) {
+  return key.split('.').every(p => {
+    if (obj && typeof obj === 'object' && p in obj) {
+      obj = obj[p]
+      return true
+    }
+    return false
+  })
+}
+
+const enJson = loadLocale(BASE_LOCALE)
+if (!enJson) {
+  console.error(`[ERROR] ${BASE_LOCALE}.json missing or invalid`)
+  process.exit(1)
+}
+
+const missingInEn = [...codeKeys].filter(k => !hasKey(enJson, k))
+
+const localeMissingMap = {}
+const otherLocales = ALL_LOCALES.filter(l => l !== BASE_LOCALE)
+
+console.log(`[INFO] Checking ${otherLocales.length} other locale(s): ${otherLocales.join(', ')}`)
+
+for (const locale of otherLocales) {
+  const json = loadLocale(locale)
+  const missing = json
+    ? [...codeKeys].filter(k => !hasKey(json, k))
+    : [...codeKeys]
+
+  localeMissingMap[locale] = missing
+  console.log(`[DEBUG] ${locale}.json missing ${missing.length} keys`)
+}
+
+const hasOtherLocaleMissing = Object.values(localeMissingMap).some(v => v.length)
+
+if (missingInEn.length || hasOtherLocaleMissing) {
+  console.error('\n' + '='.repeat(50))
+  console.error('i18n Translation Validation Failed')
+  console.error('='.repeat(50))
+
+  // CI CONSOLE OUTPUT
+
+  if (missingInEn.length) {
+    console.error(`\nError: ${missingInEn.length} NEW missing key(s) in en.json:\n`)
+    missingInEn.forEach(k => console.error(`  - ${k}`))
+  }
+
+  const localeFailures = Object.entries(localeMissingMap).filter(
+    ([, v]) => v.length
+  )
+
+  if (localeFailures.length) {
+    console.error('\nError: Missing keys in other locales:\n')
+    localeFailures.forEach(([locale, keys]) => {
+      console.error(`  ${locale}: ${keys.length} missing`)
+    })
+  }
+
+  console.error('\n')
+
+  // PR COMMENT REPORT
+
+  let report = '### i18n Translation Validation Failed\n\n'
+
+  if (missingInEn.length) {
+    report += '#### Missing keys in en.json\n\n'
+    missingInEn.forEach((k, i) => {
+      report += `${i + 1}. \`${k}\`\n`
+    })
+  }
+
+  if (localeFailures.length) {
+    report += '\n---\n\n#### Missing keys in other locales\n\n'
+    report += '| Locale | Missing | Locale | Missing | Locale | Missing |\n'
+    report += '|--------|---------|--------|---------|--------|---------|\n'
+
+    for (let i = 0; i < localeFailures.length; i += 3) {
+      const row = localeFailures.slice(i, i + 3)
+      const cells = row.map(([l, m]) => ` ${l} | ${m.length} `)
+      while (cells.length < 3) cells.push('  |  ')
+      report += `|${cells.join('|')}|\n`
+    }
+  }
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `report<<EOF\n${report}\nEOF\n`
+    )
+  }
+
+  process.exit(1)
+}
+
+console.log('[SUCCESS] i18n validation passed')
+process.exit(0)

--- a/i18n-diff-guard.js
+++ b/i18n-diff-guard.js
@@ -6,37 +6,37 @@
   - Dynamically checks missing keys in all other locales
 **/
 
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
 const BASE_LOCALE = 'en'
 const ALL_LOCALES = ['en', 'es', 'pt_br', 'hi', 'de', 'fr', 'zh', 'ar', 'ru', 'ja']
 const LOCALES_DIR = 'src/app/plugins/locales'
+const GIT_BIN = '/usr/bin/git'
+
+function gitDiff(args) {
+  try {
+    return execFileSync(GIT_BIN, args, { encoding: 'utf8' })
+  } catch {
+    return ''
+  }
+}
 
 function getDiff() {
   if (process.env.GITHUB_BASE_REF) {
-    try {
-      return execSync(
-        `git diff origin/${process.env.GITHUB_BASE_REF}...HEAD`,
-        { encoding: 'utf8' }
-      )
-    } catch {}
+    return gitDiff([
+      'diff',
+      `origin/${process.env.GITHUB_BASE_REF}...HEAD`
+    ])
   }
 
-  try {
-    return execSync(`git diff HEAD~1...HEAD`, { encoding: 'utf8' })
-  } catch {}
-
-  try {
-    return execSync(`git diff --cached`, { encoding: 'utf8' })
-  } catch {}
-
-  try {
-    return execSync(`git diff`, { encoding: 'utf8' })
-  } catch {}
-
-  return ''
+  return (
+    gitDiff(['diff', 'HEAD~1...HEAD']) ||
+    gitDiff(['diff', '--cached']) ||
+    gitDiff(['diff']) ||
+    ''
+  )
 }
 
 const diff = getDiff()


### PR DESCRIPTION
## Description

Introduces a **diff-based i18n Translation Validator** to automatically detect missing translations at PR time.

The validator scans only newly added or modified code, extracts newly introduced i18n keys, and verifies their presence across all locale files. This prevents translation regressions without scanning the entire codebase or blocking on existing issues.

The CI posts a compact, readable PR comment and fails the build when missing keys are detected.

---

## Related Issue

Fixes #1332

---

## Impact

* Early detection of missing translations
* Consistent i18n coverage across locales
* Faster, more focused PR reviews