### PR TITLE
fix: prevent comment textarea from clearing on image upload

### DIFF
--- a/src/ux/Heuristic/components/AddCommentBtn.vue
+++ b/src/ux/Heuristic/components/AddCommentBtn.vue
@@ -155,9 +155,8 @@ const updateComment = (input) => {
 }
 
 const handleImageUploaded = (imageUrl) => {
-  if (imageUrl) {
-    localComment.value = ''; 
-    emit('updateComment', '', props.heurisIndex, props.answerHeu.heuristicId)
+  if (imageUrl) { 
+    emit('updateComment', localComment.value, props.heurisIndex, props.answerHeu.heuristicId)
   }
 };
 </script>

--- a/src/ux/Heuristic/views/HeuristicTestView.vue
+++ b/src/ux/Heuristic/views/HeuristicTestView.vue
@@ -662,7 +662,9 @@ const updateComment = (comment, heurisIndex, answerIndex) => {
   const question = currentUserTestAnswer.value.heuristicQuestions[heurisIndex].heuristicQuestions[answerIndex];
   if (comment !== '' && comment !== undefined) {
     question.heuristicComment = comment;
-  } else if (store.state.Heuristic.currentImageUrl) {
+  }
+
+  if (store.state.Heuristic.currentImageUrl) {
     question.answerImageUrl = store.state.Heuristic.currentImageUrl;
   }
 };


### PR DESCRIPTION
### Problem
When adding a heuristic comment during a test, uploading an image caused the comment textarea to be cleared immediately.  
Although the comment and image were saved correctly and reappeared after navigating away and returning, the temporary clearing created a confusing user experience and gave the impression that the comment was lost.

### Fixes: #1327 

### Screen Recording

https://github.com/user-attachments/assets/c838b48e-5540-469b-887c-4a390039cfe8


### Solution
This PR keeps the local comment state intact when an image is uploaded and ensures the UI stays in sync with the underlying heuristic answer state.

- Prevents clearing the comment textarea on image upload
- Preserves existing comment text while allowing image updates
- Avoids unnecessary UI desynchronization

###  Files Changed
- `src/ux/Heuristic/components/AddCommentBtn.vue`
- `src/ux/Heuristic/views/HeuristicTestView.vue`

###  How to Test
1. Create a heuristic test
2. Start the test and navigate to a heuristic question
3. Type a comment in the comment textarea
4. Upload an image using the image upload button
5. Verify that:
   - The comment remains visible
   - The image is uploaded successfully
   - No temporary clearing of the comment occurs

###  Notes
This change only affects UI state handling.  
No backend logic or data structure was modified.
