### PR TITLE
chore(deps): replace invalid UTC with Etc/UTC in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: 'weekly'
       day: 'monday'
       time: '09:00'
-      timezone: 'UTC'
+      timezone: 'Etc/UTC'
     target-branch: 'develop'
     commit-message:
       prefix: 'chore(deps):'


### PR DESCRIPTION
Fix Dependabot config by using a valid IANA timezone (`Etc/UTC`) to resolve validation errors.
