### PR TITLE
ci: fix i18n diff guard checkout context in PR workflow

### DIFF
--- a/.github/workflows/i18n-diff-guard.yml
+++ b/.github/workflows/i18n-diff-guard.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Fetch base branch
         run: git fetch origin ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
Fixes CI failure where i18n-diff-guard.js was not found during PR runs.
Removes explicit checkout ref to rely on default PR checkout behavior.
No functional changes to the validator.
