### PR TITLE
Fix: SART answers not being persisted to Firestore

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -386,6 +386,11 @@
                 localTestAnswer.tasks[taskIndex].nasaTlxAnswers = { ...val }
               }
             "
+            @update:sartAnswers="
+              (val) => {
+                localTestAnswer.tasks[taskIndex].sartAnswers = { ...val }
+              }
+            "
             @done="() => handleTaskFinish(true)"
             @couldNotFinish="() => handleTaskFinish(false)"
             @show-loading="isLoading = true"


### PR DESCRIPTION
fixes #1357 
This happens because the component is missing the required update binding, so the local state is never synced with localTestAnswer.
	•	Added missing @update:sartAnswers handler
	•	Ensured emitted values correctly update localTestAnswer

https://github.com/user-attachments/assets/843775c5-d583-4d77-9424-f5f87865a8e6

