### PR TITLE
fix(i18n): localize Sessions page UI

### DIFF
--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -587,6 +587,27 @@
       "noTests": "لم يتم العثور على اختبارات",
       "noTemplates": "لم يتم العثور على قوالب"
     },
+    "sessions": {
+      "searchPlaceholder": "البحث في الجلسات...",
+      "reset": "إعادة تعيين",
+      "showFilters": "عرض الفلاتر",
+      "hideFilters": "إخفاء الفلاتر",
+      "sessionDate": "تاريخ الجلسة",
+      "selectRange": "اختر النطاق",
+      "statusLabel": "الحالة",
+      "ownership": "الملكية",
+      "evaluator": "المقيم",
+      "noActiveSessions": "ليس لديك جلسات نشطة",
+      "filters": {
+        "allStatuses": "جميع الحالات",
+        "today": "اليوم",
+        "upcoming": "القادمة",
+        "completed": "مكتمل",
+        "allStudies": "جميع الدراسات",
+        "myStudies": "دراساتي",
+        "whereICollaborate": "حيث أتعاون"
+      }
+    },
     "createTest": {
       "title": "إنشاء اختبار جديد",
       "blankTitle": "إنشاء اختبار فارغ",

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -587,6 +587,27 @@
       "noTests": "Keine Tests gefunden",
       "noTemplates": "Keine Vorlagen gefunden"
     },
+    "sessions": {
+      "searchPlaceholder": "Sitzungen suchen...",
+      "reset": "Zurücksetzen",
+      "showFilters": "Filter anzeigen",
+      "hideFilters": "Filter ausblenden",
+      "sessionDate": "Sitzungsdatum",
+      "selectRange": "Bereich auswählen",
+      "statusLabel": "Status",
+      "ownership": "Eigentum",
+      "evaluator": "Bewerter",
+      "noActiveSessions": "Sie haben keine aktiven Sitzungen",
+      "filters": {
+        "allStatuses": "Alle Status",
+        "today": "Heute",
+        "upcoming": "Bevorstehend",
+        "completed": "Abgeschlossen",
+        "allStudies": "Alle Studien",
+        "myStudies": "Meine Studien",
+        "whereICollaborate": "Wo ich mitarbeite"
+      }
+    },
     "createTest": {
       "title": "Neuen Test erstellen",
       "blankTitle": "Leeren Test erstellen",

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -687,6 +687,27 @@
       "noTests": "No tests found",
       "noTemplates": "No templates found"
     },
+    "sessions": {
+      "searchPlaceholder": "Search sessions...",
+      "reset": "Reset",
+      "showFilters": "Show filters",
+      "hideFilters": "Hide filters",
+      "sessionDate": "Session date",
+      "selectRange": "Select range",
+      "statusLabel": "Status",
+      "ownership": "Ownership",
+      "evaluator": "Evaluator",
+      "noActiveSessions": "You don't have active sessions",
+      "filters": {
+        "allStatuses": "All Statuses",
+        "today": "Today",
+        "upcoming": "Upcoming",
+        "completed": "Completed",
+        "allStudies": "All Studies",
+        "myStudies": "My Studies",
+        "whereICollaborate": "Where I Collaborate"
+      }
+    },
     "createTest": {
       "title": "Create a new test",
       "blankTitle": "Create a blank test",

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -660,6 +660,27 @@
       "noTests": "No se encontraron pruebas",
       "noTemplates": "No se encontraron plantillas"
     },
+    "sessions": {
+      "searchPlaceholder": "Buscar sesiones...",
+      "reset": "Restablecer",
+      "showFilters": "Mostrar filtros",
+      "hideFilters": "Ocultar filtros",
+      "sessionDate": "Fecha de sesión",
+      "selectRange": "Seleccionar rango",
+      "statusLabel": "Estado",
+      "ownership": "Propiedad",
+      "evaluator": "Evaluador",
+      "noActiveSessions": "No tienes sesiones activas",
+      "filters": {
+        "allStatuses": "Todos los estados",
+        "today": "Hoy",
+        "upcoming": "Próximas",
+        "completed": "Completado",
+        "allStudies": "Todos los estudios",
+        "myStudies": "Mis estudios",
+        "whereICollaborate": "Donde colaboro"
+      }
+    },
     "createTest": {
       "title": "Crear una nueva prueba",
       "blankTitle": "Crear una prueba en blanco",

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -587,6 +587,27 @@
       "noTests": "Aucun test trouvé",
       "noTemplates": "Aucun modèle trouvé"
     },
+    "sessions": {
+      "searchPlaceholder": "Rechercher des sessions...",
+      "reset": "Réinitialiser",
+      "showFilters": "Afficher les filtres",
+      "hideFilters": "Masquer les filtres",
+      "sessionDate": "Date de session",
+      "selectRange": "Sélectionner une plage",
+      "statusLabel": "Statut",
+      "ownership": "Propriété",
+      "evaluator": "Évaluateur",
+      "noActiveSessions": "Vous n'avez pas de sessions actives",
+      "filters": {
+        "allStatuses": "Tous les statuts",
+        "today": "Aujourd'hui",
+        "upcoming": "À venir",
+        "completed": "Terminé",
+        "allStudies": "Toutes les études",
+        "myStudies": "Mes études",
+        "whereICollaborate": "Où je collabore"
+      }
+    },
     "createTest": {
       "title": "Créer un nouveau test",
       "blankTitle": "Créer un test vierge",

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -574,6 +574,27 @@
       "noTests": "कोई परीक्षण नहीं मिला",
       "noTemplates": "कोई टेम्पलेट नहीं मिला"
     },
+    "sessions": {
+      "searchPlaceholder": "सत्र खोजें...",
+      "reset": "रीसेट",
+      "showFilters": "फ़िल्टर दिखाएं",
+      "hideFilters": "फ़िल्टर छिपाएं",
+      "sessionDate": "सत्र तिथि",
+      "selectRange": "सीमा चुनें",
+      "statusLabel": "स्थिति",
+      "ownership": "स्वामित्व",
+      "evaluator": "मूल्यांकनकर्ता",
+      "noActiveSessions": "आपके पास कोई सक्रिय सत्र नहीं है",
+      "filters": {
+        "allStatuses": "सभी स्थितियाँ",
+        "today": "आज",
+        "upcoming": "आगामी",
+        "completed": "पूर्ण",
+        "allStudies": "सभी अध्ययन",
+        "myStudies": "मेरे अध्ययन",
+        "whereICollaborate": "जहाँ मैं सहयोग करता हूँ"
+      }
+    },
     "createTest": {
       "title": "एक नया परीक्षण बनाएँ",
       "blankTitle": "खाली परीक्षण बनाएँ",

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -582,6 +582,27 @@
       "noTests": "テストが見つかりません",
       "noTemplates": "テンプレートが見つかりません"
     },
+    "sessions": {
+      "searchPlaceholder": "セッションを検索...",
+      "reset": "リセット",
+      "showFilters": "フィルターを表示",
+      "hideFilters": "フィルターを非表示",
+      "sessionDate": "セッション日",
+      "selectRange": "範囲を選択",
+      "statusLabel": "ステータス",
+      "ownership": "所有権",
+      "evaluator": "評価者",
+      "noActiveSessions": "アクティブなセッションがありません",
+      "filters": {
+        "allStatuses": "すべてのステータス",
+        "today": "今日",
+        "upcoming": "今後",
+        "completed": "完了",
+        "allStudies": "すべての研究",
+        "myStudies": "私の研究",
+        "whereICollaborate": "コラボレーション中"
+      }
+    },
     "createTest": {
       "title": "新しいテストを作成",
       "blankTitle": "空白のテストを作成",

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -593,6 +593,27 @@
       "noTests": "Nenhum teste encontrado",
       "noTemplates": "Nenhum modelo encontrado"
     },
+    "sessions": {
+      "searchPlaceholder": "Pesquisar sessões...",
+      "reset": "Redefinir",
+      "showFilters": "Mostrar filtros",
+      "hideFilters": "Ocultar filtros",
+      "sessionDate": "Data da sessão",
+      "selectRange": "Selecionar intervalo",
+      "statusLabel": "Status",
+      "ownership": "Propriedade",
+      "evaluator": "Avaliador",
+      "noActiveSessions": "Você não tem sessões ativas",
+      "filters": {
+        "allStatuses": "Todos os status",
+        "today": "Hoje",
+        "upcoming": "Próximas",
+        "completed": "Concluído",
+        "allStudies": "Todos os estudos",
+        "myStudies": "Meus estudos",
+        "whereICollaborate": "Onde eu colaboro"
+      }
+    },
     "createTest": {
       "title": "Criar um novo teste",
       "blankTitle": "Criar um teste em branco",

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -600,6 +600,27 @@
       "noTests": "Тесты не найдены",
       "noTemplates": "Шаблоны не найдены"
     },
+    "sessions": {
+      "searchPlaceholder": "Поиск сессий...",
+      "reset": "Сбросить",
+      "showFilters": "Показать фильтры",
+      "hideFilters": "Скрыть фильтры",
+      "sessionDate": "Дата сессии",
+      "selectRange": "Выбрать диапазон",
+      "statusLabel": "Статус",
+      "ownership": "Владение",
+      "evaluator": "Оценщик",
+      "noActiveSessions": "У вас нет активных сессий",
+      "filters": {
+        "allStatuses": "Все статусы",
+        "today": "Сегодня",
+        "upcoming": "Предстоящие",
+        "completed": "Завершенный",
+        "allStudies": "Все исследования",
+        "myStudies": "Мои исследования",
+        "whereICollaborate": "Где я сотрудничаю"
+      }
+    },
     "createTest": {
       "title": "Создать новый тест",
       "blankTitle": "Создать пустой тест",

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -600,6 +600,27 @@
       "noTests": "未找到测试",
       "noTemplates": "未找到模板"
     },
+    "sessions": {
+      "searchPlaceholder": "搜索会话...",
+      "reset": "重置",
+      "showFilters": "显示筛选",
+      "hideFilters": "隐藏筛选",
+      "sessionDate": "会话日期",
+      "selectRange": "选择范围",
+      "statusLabel": "状态",
+      "ownership": "所有权",
+      "evaluator": "评估者",
+      "noActiveSessions": "您没有活跃的会话",
+      "filters": {
+        "allStatuses": "所有状态",
+        "today": "今天",
+        "upcoming": "即将到来",
+        "completed": "已完成",
+        "allStudies": "所有研究",
+        "myStudies": "我的研究",
+        "whereICollaborate": "我参与协作的"
+      }
+    },
     "createTest": {
       "title": "创建新测试",
       "blankTitle": "创建空白测试",

--- a/src/features/navigation/components/navbarSections/SessionsSection.vue
+++ b/src/features/navigation/components/navbarSections/SessionsSection.vue
@@ -9,7 +9,7 @@
         density="compact"
         hide-details
         variant="outlined"
-        placeholder="Search sessions..."
+        :placeholder="t('pages.sessions.searchPlaceholder')"
         class="flex-grow-1"
       />
 
@@ -29,7 +29,7 @@
           }
         "
       >
-        Reset
+        {{ t('pages.sessions.reset') }}
       </v-btn>
 
       <!-- Toggle filters visibility -->
@@ -52,7 +52,7 @@
         <v-row dense>
           <!-- 👤 Ownership filter -->
           <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">Ownership</div>
+            <div class="filter-label">{{ t('pages.sessions.ownership') }}</div>
             <v-select
               v-model="selectedSessionOwnershipFilter"
               :items="ownershipOptions"
@@ -66,7 +66,7 @@
 
           <!-- 👥 Evaluator filter -->
           <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">Evaluator</div>
+            <div class="filter-label">{{ t('pages.sessions.evaluator') }}</div>
             <v-select
               v-model="selectedSessionEvaluatorFilter"
               :items="evaluatorOptions"
@@ -80,7 +80,7 @@
 
           <!-- 📅 Session date range filter -->
           <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">Session date</div>
+            <div class="filter-label">{{ t('pages.sessions.sessionDate') }}</div>
             <v-menu
               :close-on-content-click="false"
               transition="scale-transition"
@@ -103,7 +103,7 @@
                             selectedSessionDateRange.length - 1
                           ],
                         ).toLocaleDateString()}`
-                      : 'Select range'
+                      : t('pages.sessions.selectRange')
                   "
                   prepend-inner-icon="mdi-calendar"
                 />
@@ -118,7 +118,7 @@
 
           <!-- ⚙️ Status filter -->
           <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">Status</div>
+            <div class="filter-label">{{ t('pages.sessions.statusLabel') }}</div>
             <v-select
               v-model="selectedSessionStatusFilter"
               :items="sessionStatusOptions"
@@ -153,7 +153,7 @@
       color="grey-lighten-1"
       class="mb-2"
     />
-    <p class="text-h6">You don't have active sessions</p>
+    <p class="text-h6">{{ t('pages.sessions.noActiveSessions') }}</p>
   </div>
 </template>
 
@@ -162,12 +162,15 @@
 import { ref, computed } from 'vue'
 import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import List from '@/shared/components/tables/ListComponent.vue'
 import { STUDY_TYPES } from '@/shared/constants/methodDefinitions'
 import {
   getSessionStatus,
   SESSION_STATUSES,
 } from '@/shared/utils/sessionsUtils'
+
+const { t } = useI18n()
 
 const props = defineProps({
   sessions: {
@@ -184,11 +187,11 @@ const activeSection = ref('dashboard')
 // ===== Filter options =====
 
 // Ownership dropdown options
-const ownershipOptions = [
-  { value: 'all', text: 'All Studies' },
-  { value: 'mine', text: 'My Studies' },
-  { value: 'cooperator', text: 'Where I Collaborate' },
-]
+const ownershipOptions = computed(() => [
+  { value: 'all', text: t('pages.sessions.filters.allStudies') },
+  { value: 'mine', text: t('pages.sessions.filters.myStudies') },
+  { value: 'cooperator', text: t('pages.sessions.filters.whereICollaborate') },
+])
 
 // Filter visibility toggle
 const showFilters = ref(false)
@@ -206,18 +209,18 @@ const evaluatorOptions = computed(() => {
   const evaluatorsSet = new Set()
   props.sessions.forEach((s) => evaluatorsSet.add(s.evaluator))
   return [
-    { text: 'All', value: 'all' },
+    { text: t('common.all'), value: 'all' },
     ...Array.from(evaluatorsSet).map((ev) => ({ text: ev, value: ev })),
   ]
 })
 
 // Session status options
-const sessionStatusOptions = [
-  { value: 'all', text: 'All Statuses' },
-  { value: 'today', text: 'Today' },
-  { value: 'upcoming', text: 'Upcoming' },
-  { value: 'completed', text: 'Completed' },
-]
+const sessionStatusOptions = computed(() => [
+  { value: 'all', text: t('pages.sessions.filters.allStatuses') },
+  { value: 'today', text: t('pages.sessions.filters.today') },
+  { value: 'upcoming', text: t('pages.sessions.filters.upcoming') },
+  { value: 'completed', text: t('pages.sessions.filters.completed') },
+])
 
 // Whether filters are currently active (to enable/disable reset button)
 const hasActiveSessionFilters = computed(() => {


### PR DESCRIPTION
fixes #1294 
## Summary
This PR adds full i18n support to the **Sessions page**, replacing hardcoded UI strings with translation keys and updating locale files accordingly.

## Changes
- Localized all user-facing text in `SessionsSection.vue`
  - Search placeholder
  - Reset button text
  - Filter labels (Ownership, Evaluator, Session Date, Status)
- Updated table headers to use i18n keys via `useDataTableConfig`
- Added/updated translations across all supported locales:
  - `en`, `de`, `fr`, `es`, `pt_br`, `ar`, `hi`, `ja`, `ru`, `zh`

## Testing
- Verified Sessions page UI renders correctly after language switch
- Confirmed all labels, placeholders, and table headers update based on selected locale
- No functional or layout regressions observed

## Notes
- This PR continues the ongoing i18n effort and follows the same patterns used in previous navigation and Studies page localization PRs.

##Screenshots

BEFORE
<img width="3024" height="1660" alt="image" src="https://github.com/user-attachments/assets/bd567e4e-26a5-4cb0-9b60-498d166d105a" />

AFTER
<img width="3024" height="1660" alt="image" src="https://github.com/user-attachments/assets/62daa008-69aa-4146-819d-1feebe853976" />

