### PR TITLE
Fixes heuristic color when all option values are equal

### DIFF
--- a/src/ux/Heuristic/components/HeuristicsTestAnswer.vue
+++ b/src/ux/Heuristic/components/HeuristicsTestAnswer.vue
@@ -653,15 +653,20 @@ const checkIfNan = (value) => {
 const getColor = (value, max, min) => {
   max = Number(max) || 0;
   min = Number(min) || 0;
-  const h = max ? (max - min) / max : 0;
 
   if (value == null) return 'grey';
-  else if (value === 0) return 'red';
-  else if (value <= min + 1 * h) return 'amber';
+  if (value === 0) return 'red';
+
+  if (max === min) return 'green';
+
+  const h = (max - min) / max;
+  
+  if (value <= min + 1 * h) return 'amber';
   else if (value <= min + 2 * h) return 'orange lighten-1';
   else if (value <= min + 3 * h) return 'lime';
   else return 'green';
 };
+
 
 const getColorPorcentage = (value) => {
   value = Number(value) || 0;


### PR DESCRIPTION
### **Description :**
Fixes: #1377 
Fixes an edge case in heuristic color calculation where results were incorrectly shown as amber when all option values were equal. In this scenario, the value represents the maximum possible score and should be displayed as green.

### **Impact :**
- Prevents misleading visual feedback in Heuristic Evaluation results 
- Ensures correct color classification when option ranges collapse (max === min)

### **Root Cause :**

When max === min, the threshold calculation evaluates to zero, causing the first range check to always match and return amber.

`h = (max - min) / max; // evaluates to 0 when max === min`

### **What has been fixed :**

Explicitly handle the equal-range case before applying threshold logic:

`if (max === min) return 'green';`
