### PR TITLE
added username on signup

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -221,7 +221,8 @@
     "authenticationCancelled": "Sign-in was cancelled. Please try again.",
     "networkError": "Network error. Please check your internet connection and try again.",
     "popupBlocked": "Your browser blocked the sign-in popup. Please allow popups for this site and try again.",
-    "tooManyAttempts": "Too many attempts. Please try again later."
+    "tooManyAttempts": "Too many attempts. Please try again later.",
+    "usernameMinLength": "Username must be at least 3 characters"
   },
   "Introduction": {
     "title": "UX Remote LAB",
@@ -766,6 +767,7 @@
     "previous": "Previous",
     "seeCode": "See the code",
     "username": "Username",
+    "optional": "Optional",
     "goToConsole": "Go to Console",
     "signout": "Sign-out",
     "profile": "profile",

--- a/src/features/auth/store/Auth.js
+++ b/src/features/auth/store/Auth.js
@@ -67,7 +67,7 @@ export default {
           payload.email,
           payload.password,
         )
-        await userController.create({ id: user.uid, email: user.email })
+        await userController.create({ id: user.uid, email: user.email, username: payload.username })
         commit('SET_TOAST', {
           message: i18n.global.t('auth.signupSuccess'),
           type: 'success',

--- a/src/features/auth/views/SignUpView.vue
+++ b/src/features/auth/views/SignUpView.vue
@@ -29,6 +29,16 @@
           />
 
           <v-text-field
+            v-model="username"
+            :rules="usernameRules"
+            :label="$t('buttons.username') + ' (' + $t('buttons.optional') + ')'"
+            type="text"
+            placeholder="John Doe"
+            prepend-inner-icon="mdi-account-outline"
+            variant="outlined"
+          />
+
+          <v-text-field
             v-model="password"
             :rules="passwordRules"
             :label="$t('auth.SIGNIN.password')"
@@ -110,6 +120,7 @@ import GoogleSignInButton from '@/features/auth/components/GoogleSignInButton'
 import PasswordStrength from '@/features/auth/components/PasswordStrength.vue'
 
 const email = ref('')
+const username = ref('')
 const password = ref('')
 const confirmpassword = ref('')
 const showPassword = ref(false)
@@ -127,6 +138,10 @@ const { t } = useI18n()
 const emailRules = [
   (v) => !!v || t('errors.emailIsRequired'),
   (v) => /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(v) || t('errors.invalidEmail'),
+]
+
+const usernameRules = [
+  (v) => !v || v.length >= 3 || t('errors.usernameMinLength'),
 ]
 
 const passwordRules = [
@@ -150,6 +165,7 @@ const onSignUp = async () => {
       await store.dispatch('signup', {
         email: email.value,
         password: password.value,
+        username: username.value,
       })
       await router.push('/admin')
     } catch (error) {


### PR DESCRIPTION
This PR adds an optional Username field to the signup flow and stores it in the user profile document. If provided, the dashboard greeting uses the username; if left blank, the app continues to fall back to the default.

Newly created accounts currently show a generic dashboard greeting (e.g., “Welcome back, User!”). Asking for an optional username during signup improves personalization without blocking registration.

Changes
Added an optional username input on the signup form.
Added client-side validation: if username is entered, it must be ≥ 3 characters.
Passed the username through the signup action and persisted it in the Firestore user document.
Added/updated i18n strings for "Optional" label and the username min-length validation message.

https://github.com/user-attachments/assets/42297e40-c1c0-4e60-b785-ddc852a07c59

Fixes #1380 