### PR TITLE
Fix radar chart display in Evaluators tab

### DIFF
--- a/src/shared/components/charts/RadarChart.vue
+++ b/src/shared/components/charts/RadarChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Radar
-      :chart-data="chartData"
+      :data="chartData"
       :options="chartOptions"
     />
   </div>
@@ -10,6 +10,23 @@
 <script setup>
 import { Radar } from 'vue-chartjs'
 import { ref, computed, watch, onMounted } from 'vue'
+import {
+  Chart as ChartJS,
+  Title,
+  Tooltip,
+  Legend,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+} from 'chart.js'
+ChartJS.register(
+  Title,
+  Tooltip,
+  Legend,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+)
 
 const props = defineProps({
   labels: {

--- a/src/ux/Heuristic/components/HeuristicsAnalytics.vue
+++ b/src/ux/Heuristic/components/HeuristicsAnalytics.vue
@@ -296,6 +296,7 @@ import { useStore } from 'vuex';
 import { useRoute } from 'vue-router';
 import ShowInfo from '@/shared/components/ShowInfo.vue';
 import BarChart from '@/ux/Heuristic/components/charts/BarChart.vue';
+import IntroAnalytics from '@/shared/components/introduction_cards/IntroAnalytics.vue';
 
 const store = useStore();
 const route = useRoute();

--- a/src/ux/Heuristic/components/charts/BarChart.vue
+++ b/src/ux/Heuristic/components/charts/BarChart.vue
@@ -30,8 +30,8 @@ ChartJS.register(
 
 const props = defineProps({
   labels: {
-    type: String,
-    default: 'Data One'
+    type: Array,
+    default: () => []
   },
   data: {
     type: Array,


### PR DESCRIPTION
### Description
The Radar chart in **Answers → Evaluators → Graphic** was not rendering due to missing `Chart.js` component registration and improper data binding. This resulted in a runtime error:
> `TypeError: Cannot read properties of undefined (reading 'labels')`

### Screenshots / Recording 📸🎥
>**After fix:** Radar chart renders correctly in Evaluators → Graphic tab
<img width="1903" height="951" alt="Screenshot 2026-01-22 082435" src="https://github.com/user-attachments/assets/e30c36d9-2b2e-4d1c-b258-eae0c5c94977" />

https://github.com/user-attachments/assets/ac0a1b53-b698-4276-85d1-4bd03dab269b


### Changes Made

- Registered required `Chart.js` components (`RadialLinearScale`, `PointElement`, `LineElement`, `Title`, `Tooltip`, `Legend`) in `RadarChart.vue`.
- Corrected Radar chart prop binding to use `data` instead of `chart-data`.
- Ensured labels and dataset values are safely passed to the chart

### Impact

- Radar chart now renders correctly in the Graphic tab.
- Evaluators can view heuristic test results in graphical form without runtime errors.

### Checklist

- [x] Closes: #1389
- [x] Bug reproduced before fix
- [x] Fix applied and tested locally
- [x] Screenshots/logs attached for validation