### PR TITLE
fix: add issues:write permission to i18n workflow

### DIFF
--- a/.github/workflows/i18n-diff-guard.yml
+++ b/.github/workflows/i18n-diff-guard.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Adds `issues: write` permission to the i18n diff guard workflow to fix the 403 error when posting PR comments.

GitHub requires explicit `issues: write` permission to create/update PR comments, even with `pull-requests: write` already set, since PR comments use the issues API.