### PR TITLE
fix: console warning when template body is undefined

### DIFF
--- a/src/shared/components/dialogs/TemplateInfoDialog.vue
+++ b/src/shared/components/dialogs/TemplateInfoDialog.vue
@@ -239,10 +239,9 @@ const formRef = ref(null);
 const formValid = ref(false);
 
 const mountTest = computed(() => {
-  if (!props.template?.body) {
-    console.warn('Template body is undefined:', props.template);
-    return {};
-  }
+  // if no template or no body just return null
+  if(!props.template || !props.template.body) 
+    return null;
 
   const test = { ...props.template.body };
   if (!test.testType && props.template.body.testType) {
@@ -264,7 +263,11 @@ watch(
   (newTemplate) => {
     isMyTemplate.value =
       newTemplate?.header?.templateAuthor?.userDocId === user.value?.id;
-    localTest.value = mountTest.value ? { ...mountTest.value } : null;
+    if(mountTest.value){
+      localTest.value = { ...mountTest.value };
+    } else {
+      localTest.value = null;
+    }
   },
   { immediate: true, deep: true }
 );


### PR DESCRIPTION
### pr purpose

this pr fixes console warning that happens when navigating to templates page with no templates available

**Fixed issue**: #1401

### Fix added:

- added proper guards for empty template state and prevents mountTest and the watcher from running when no template body is present

> this removes unnecessary console warnings and correctly handles the empty templates state


**Before**
<img width="2529" height="1315" alt="image" src="https://github.com/user-attachments/assets/c97512a3-e68a-43e3-9a07-21b91a39354c" />


**After**
<img width="2534" height="1315" alt="image" src="https://github.com/user-attachments/assets/cb176dd0-bd76-4213-83d0-fff9a0ef6156" />
