### PR TITLE
fix: pass hideCol as boolean to ShowInfo component

### DIFF
--- a/src/ux/UserTest/components/UserTestAnswer.vue
+++ b/src/ux/UserTest/components/UserTestAnswer.vue
@@ -9,7 +9,7 @@
       justify="center"
       class="ma-0"
     >
-      <ShowInfo hide-col="true">
+      <ShowInfo :hide-col="true">
         <!-- Main Tabs -->
         <template #top>
           <v-tabs


### PR DESCRIPTION
**Fixed issue**: #1403 

**Before**
<img width="2530" height="1321" alt="image" src="https://github.com/user-attachments/assets/8a5cb395-5814-4017-ba70-fff99dba815b" />

**After**
<img width="2522" height="1320" alt="image" src="https://github.com/user-attachments/assets/9c3e7c31-fe3e-438c-9958-7e2d082692cf" />

### Fix added 

- used boolean binding instead of string:
```bash
<ShowInfo :hindCol="true">
```