### PR TITLE
fix: define dialogMaxWidth in SusAnalytics to remove Vue render warning

### DIFF
--- a/src/ux/Heuristic/components/HeuristicsTestAnswer.vue
+++ b/src/ux/Heuristic/components/HeuristicsTestAnswer.vue
@@ -15,7 +15,7 @@
       justify="center"
       class="ma-0 mt-4"
     >
-      <ShowInfo hide-col="true">
+      <ShowInfo :hide-col="true">
         <!-- Main Tabs -->
         <template #top>
           <v-tabs

--- a/src/ux/UserTest/components/UnmoderatedTestAnalytics/SusAnalytics.vue
+++ b/src/ux/UserTest/components/UnmoderatedTestAnalytics/SusAnalytics.vue
@@ -368,6 +368,7 @@ const detailsModal = ref(false)
 const selectedResponse = ref(null)
 const selectedRatingFilter = ref(null)
 const scoreRange = ref([0, 100])
+const dialogMaxWidth = 800
 
 const tableHeaders = [
   { title: 'User', key: 'user', sortable: true },

--- a/src/ux/UserTest/components/UserTestAnswer.vue
+++ b/src/ux/UserTest/components/UserTestAnswer.vue
@@ -9,7 +9,7 @@
       justify="center"
       class="ma-0"
     >
-      <ShowInfo hide-col="true">
+      <ShowInfo :hide-col="true">
         <!-- Main Tabs -->
         <template #top>
           <v-tabs


### PR DESCRIPTION
**Fixed issue**: #1406 

### Fix added

define dialogMaxWidth in script as 
```bash
const dialogMaxWidth = 800
```

**Before**
<img width="2504" height="1317" alt="image" src="https://github.com/user-attachments/assets/d749d35f-0e19-4c23-b63b-28025733f04e" />

**After**
<img width="2519" height="1307" alt="image" src="https://github.com/user-attachments/assets/20b65432-99ee-4f3b-81ee-e7041b781482" />
