### PR TITLE
fix: correct v-overlay prop type in PageWrapper

### DIFF
--- a/src/shared/views/template/PageWrapper.vue
+++ b/src/shared/views/template/PageWrapper.vue
@@ -4,7 +4,7 @@
       <Snackbar />
 
       <!-- Loading Overlay -->
-      <v-overlay v-if="loading" model-value="loading" class="text-center">
+      <v-overlay v-if="loading" :model-value="loading" class="text-center">
         <v-progress-circular indeterminate color="primary" size="50" />
         <div class="text-white mt-3">
           {{ loadingText || $t('common.loading') }}


### PR DESCRIPTION
**fixed issue**: #1408 

### fix added

before vue treating loading as string but now it will take loading as expected boolean 

**Before code**

```bash
<v-overlay v-if="loading" model-value="loading" class="text-center">
        <v-progress-circular indeterminate color="primary" size="50" />
        <div class="text-white mt-3">
          {{ loadingText || $t('common.loading') }}
        </div>
</v-overlay>
```

**After code** - ensures v-overlay receives a boolean as expected by vuetify

```bash
<v-overlay v-if="loading" :model-value="loading" class="text-center">
        <v-progress-circular indeterminate color="primary" size="50" />
        <div class="text-white mt-3">
          {{ loadingText || $t('common.loading') }}
        </div>
</v-overlay>
```

**Before**
<img width="2494" height="1078" alt="image" src="https://github.com/user-attachments/assets/8821e4aa-dd98-4b38-9be9-366edcdc2124" />

**After**
<img width="2509" height="1317" alt="image" src="https://github.com/user-attachments/assets/ca85b90f-a07c-4cf4-879c-48495d26d851" />
