### PR TITLE
fix(i18n): localize manager page UI

### DIFF
--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -1138,5 +1138,69 @@
         "upcoming": "قادم"
       }
     }
+  },
+  "manager": {
+    "dashboard": {
+      "defaultTitle": "دراسة اختبار المستخدم",
+      "unmoderatedStudy": "دراسة غير مُيسَّرة",
+      "moderatedStudy": "دراسة مُيسَّرة",
+      "active": "نشط",
+      "draft": "مسودة",
+      "completed": "مكتمل",
+      "archived": "مؤرشف"
+    },
+    "studyOverview": {
+      "totalParticipants": "إجمالي المشاركين",
+      "completed": "مكتمل",
+      "rate": "معدل {percentage}%",
+      "inProgress": "قيد التنفيذ",
+      "active": "نشط {percentage}%",
+      "averageTime": "متوسط الوقت",
+      "completionTime": "وقت الإكمال",
+      "minUnit": "{value} دقيقة"
+    },
+    "managementModules": {
+      "title": "وحدات الإدارة",
+      "description": "أدوات شاملة لإدارة المشاركين والمهام والإعدادات وتحليل بيانات دراستك",
+      "additionalModules": "مساحة للوحدات الإضافية"
+    },
+    "participants": {
+      "title": "المشاركون",
+      "subtitle": "نظرة عامة على المشاركة في الاختبار",
+      "beta": "تجريبي",
+      "completed": "مكتمل",
+      "notStarted": "لم يبدأ",
+      "pendingInvites": "دعوات معلقة",
+      "overallProgress": "التقدم العام",
+      "participantsCompleted": "أكمل {completed} من {total} مشاركين",
+      "details": "التفاصيل"
+    },
+    "tasks": {
+      "title": "نظرة عامة على المهام",
+      "subtitle": "هيكل المهام والإكمال",
+      "beta": "تجريبي",
+      "noTasksConfigured": "لا توجد مهام محددة",
+      "taskCompletionRate": "معدل إكمال المهام",
+      "totalTasks": "إجمالي المهام",
+      "avgTaskDuration": "متوسط مدة المهمة",
+      "successRate": "معدل النجاح",
+      "taskTypes": "أنواع المهام",
+      "viewTasks": "عرض المهام"
+    },
+    "storage": {
+      "title": "استخدام التخزين",
+      "subtitle": "ملفات الوسائط ومقاييس التخزين",
+      "beta": "تجريبي",
+      "storageUsed": "التخزين المستخدم",
+      "storageQuota": "تم استخدام {used} من {quota}",
+      "mediaFiles": "ملفات الوسائط",
+      "videoRecordings": "تسجيلات الفيديو",
+      "audioRecordings": "تسجيلات الصوت",
+      "screenRecordings": "تسجيلات الشاشة",
+      "storageBreakdown": "تفصيل التخزين",
+      "responsesData": "بيانات الردود",
+      "analyticsData": "بيانات التحليلات",
+      "manageStorage": "إدارة التخزين"
+    }
   }
 }

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -1139,5 +1139,69 @@
         "upcoming": "Bevorstehend"
       }
     }
+  },
+  "manager": {
+    "dashboard": {
+      "defaultTitle": "Benutzertest-Studie",
+      "unmoderatedStudy": "Unmoderierte Studie",
+      "moderatedStudy": "Moderierte Studie",
+      "active": "Aktiv",
+      "draft": "Entwurf",
+      "completed": "Abgeschlossen",
+      "archived": "Archiviert"
+    },
+    "studyOverview": {
+      "totalParticipants": "Gesamtteilnehmer",
+      "completed": "Abgeschlossen",
+      "rate": "{percentage}% Rate",
+      "inProgress": "In Bearbeitung",
+      "active": "{percentage}% aktiv",
+      "averageTime": "Durchschnittszeit",
+      "completionTime": "Abschlusszeit",
+      "minUnit": "{value} Min"
+    },
+    "managementModules": {
+      "title": "Verwaltungsmodule",
+      "description": "Umfassende Tools zur Verwaltung von Teilnehmern, Aufgaben, Einstellungen und Analyse Ihrer Studiendaten",
+      "additionalModules": "Platz für zusätzliche Module"
+    },
+    "participants": {
+      "title": "Teilnehmer",
+      "subtitle": "Übersicht der Testteilnahme",
+      "beta": "Beta",
+      "completed": "Abgeschlossen",
+      "notStarted": "Nicht Gestartet",
+      "pendingInvites": "Ausstehende Einladungen",
+      "overallProgress": "Gesamtfortschritt",
+      "participantsCompleted": "{completed} von {total} Teilnehmern abgeschlossen",
+      "details": "Details"
+    },
+    "tasks": {
+      "title": "Aufgabenübersicht",
+      "subtitle": "Aufgabenstruktur und Abschluss",
+      "beta": "Beta",
+      "noTasksConfigured": "Keine Aufgaben konfiguriert",
+      "taskCompletionRate": "Aufgabenabschlussrate",
+      "totalTasks": "Gesamtaufgaben",
+      "avgTaskDuration": "Durchschn. Aufgabendauer",
+      "successRate": "Erfolgsrate",
+      "taskTypes": "Aufgabentypen",
+      "viewTasks": "Aufgaben Anzeigen"
+    },
+    "storage": {
+      "title": "Speichernutzung",
+      "subtitle": "Mediendateien und Speichermetriken",
+      "beta": "Beta",
+      "storageUsed": "Genutzter Speicher",
+      "storageQuota": "{used} von {quota} genutzt",
+      "mediaFiles": "Mediendateien",
+      "videoRecordings": "Videoaufnahmen",
+      "audioRecordings": "Audioaufnahmen",
+      "screenRecordings": "Bildschirmaufnahmen",
+      "storageBreakdown": "Speicheraufschlüsselung",
+      "responsesData": "Antwortdaten",
+      "analyticsData": "Analysedaten",
+      "manageStorage": "Speicher Verwalten"
+    }
   }
 }

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -400,7 +400,7 @@
       "moveUp": "Move Up",
       "moveDown": "Move Down",
       "Question": "Question",
-      "Questions": "Questions", 
+      "Questions": "Questions",
       "noQuestions": "No Questions",
       "noDescriptions": "No Descriptions",
       "loading": "Loading..."
@@ -436,10 +436,10 @@
       "hideTextArea": "Hide text area"
     },
     "errors": {
-    "failedToLoadQuestionForm": "Failed to load question form. Please try again.",
-    "failedToLoadEditForm": "Failed to load edit form. Please try again.",
-    "invalidHeuristic": "Invalid heuristic selection",
-    "invalidQuestion": "Invalid question selection"
+      "failedToLoadQuestionForm": "Failed to load question form. Please try again.",
+      "failedToLoadEditForm": "Failed to load edit form. Please try again.",
+      "invalidHeuristic": "Invalid heuristic selection",
+      "invalidQuestion": "Invalid question selection"
     }
   },
   "HeuristicsOptionsTable": {
@@ -1222,5 +1222,69 @@
   "taskCreation": {
     "taskDescription": "Task Description",
     "taskDescriptionHelper": "Provide detailed instructions for participants. Include the goal, context, and any specific steps they should follow."
+  },
+  "manager": {
+    "dashboard": {
+      "defaultTitle": "User Test Study",
+      "unmoderatedStudy": "Unmoderated Study",
+      "moderatedStudy": "Moderated Study",
+      "active": "Active",
+      "draft": "Draft",
+      "completed": "Completed",
+      "archived": "Archived"
+    },
+    "studyOverview": {
+      "totalParticipants": "Total Participants",
+      "completed": "Completed",
+      "rate": "{percentage}% rate",
+      "inProgress": "In Progress",
+      "active": "{percentage}% active",
+      "averageTime": "Average Time",
+      "completionTime": "Completion time",
+      "minUnit": "{value} min"
+    },
+    "managementModules": {
+      "title": "Management Modules",
+      "description": "Comprehensive tools to manage participants, tasks, settings, and analyze your study data",
+      "additionalModules": "Space for additional modules"
+    },
+    "participants": {
+      "title": "Participants",
+      "subtitle": "Test participation overview",
+      "beta": "Beta",
+      "completed": "Completed",
+      "notStarted": "Not Started",
+      "pendingInvites": "Pending Invites",
+      "overallProgress": "Overall Progress",
+      "participantsCompleted": "{completed} of {total} participants completed",
+      "details": "Details"
+    },
+    "tasks": {
+      "title": "Tasks Overview",
+      "subtitle": "Task structure and completion",
+      "beta": "Beta",
+      "noTasksConfigured": "No tasks configured",
+      "taskCompletionRate": "Task Completion Rate",
+      "totalTasks": "Total Tasks",
+      "avgTaskDuration": "Avg. Task Duration",
+      "successRate": "Success Rate",
+      "taskTypes": "Task Types",
+      "viewTasks": "View Tasks"
+    },
+    "storage": {
+      "title": "Storage Usage",
+      "subtitle": "Media files and storage metrics",
+      "beta": "Beta",
+      "storageUsed": "Storage Used",
+      "storageQuota": "{used} of {quota} used",
+      "mediaFiles": "Media Files",
+      "videoRecordings": "Video Recordings",
+      "audioRecordings": "Audio Recordings",
+      "screenRecordings": "Screen Recordings",
+      "storageBreakdown": "Storage Breakdown",
+      "responsesData": "Responses Data",
+      "analyticsData": "Analytics Data",
+      "manageStorage": "Manage Storage"
+    }
   }
 }

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -1193,5 +1193,69 @@
         "upcoming": "Próximo"
       }
     }
+  },
+  "manager": {
+    "dashboard": {
+      "defaultTitle": "Estudio de Prueba de Usuario",
+      "unmoderatedStudy": "Estudio No Moderado",
+      "moderatedStudy": "Estudio Moderado",
+      "active": "Activo",
+      "draft": "Borrador",
+      "completed": "Completado",
+      "archived": "Archivado"
+    },
+    "studyOverview": {
+      "totalParticipants": "Total de Participantes",
+      "completed": "Completado",
+      "rate": "{percentage}% tasa",
+      "inProgress": "En Progreso",
+      "active": "{percentage}% activo",
+      "averageTime": "Tiempo Promedio",
+      "completionTime": "Tiempo de completación",
+      "minUnit": "{value} min"
+    },
+    "managementModules": {
+      "title": "Módulos de Gestión",
+      "description": "Herramientas completas para gestionar participantes, tareas, configuraciones y analizar los datos de tu estudio",
+      "additionalModules": "Espacio para módulos adicionales"
+    },
+    "participants": {
+      "title": "Participantes",
+      "subtitle": "Resumen de participación en pruebas",
+      "beta": "Beta",
+      "completed": "Completado",
+      "notStarted": "No Iniciado",
+      "pendingInvites": "Invitaciones Pendientes",
+      "overallProgress": "Progreso General",
+      "participantsCompleted": "{completed} de {total} participantes completados",
+      "details": "Detalles"
+    },
+    "tasks": {
+      "title": "Resumen de Tareas",
+      "subtitle": "Estructura y completación de tareas",
+      "beta": "Beta",
+      "noTasksConfigured": "No hay tareas configuradas",
+      "taskCompletionRate": "Tasa de Completación de Tareas",
+      "totalTasks": "Total de Tareas",
+      "avgTaskDuration": "Duración Promedio de Tarea",
+      "successRate": "Tasa de Éxito",
+      "taskTypes": "Tipos de Tareas",
+      "viewTasks": "Ver Tareas"
+    },
+    "storage": {
+      "title": "Uso de Almacenamiento",
+      "subtitle": "Archivos multimedia y métricas de almacenamiento",
+      "beta": "Beta",
+      "storageUsed": "Almacenamiento Usado",
+      "storageQuota": "{used} de {quota} usado",
+      "mediaFiles": "Archivos Multimedia",
+      "videoRecordings": "Grabaciones de Video",
+      "audioRecordings": "Grabaciones de Audio",
+      "screenRecordings": "Grabaciones de Pantalla",
+      "storageBreakdown": "Desglose de Almacenamiento",
+      "responsesData": "Datos de Respuestas",
+      "analyticsData": "Datos de Analítica",
+      "manageStorage": "Gestionar Almacenamiento"
+    }
   }
 }

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -1139,5 +1139,69 @@
         "upcoming": "À venir"
       }
     }
+  },
+  "manager": {
+    "dashboard": {
+      "defaultTitle": "Étude de Test Utilisateur",
+      "unmoderatedStudy": "Étude Non Modérée",
+      "moderatedStudy": "Étude Modérée",
+      "active": "Actif",
+      "draft": "Brouillon",
+      "completed": "Terminé",
+      "archived": "Archivé"
+    },
+    "studyOverview": {
+      "totalParticipants": "Total des Participants",
+      "completed": "Terminé",
+      "rate": "{percentage}% taux",
+      "inProgress": "En Cours",
+      "active": "{percentage}% actif",
+      "averageTime": "Temps Moyen",
+      "completionTime": "Temps de complétion",
+      "minUnit": "{value} min"
+    },
+    "managementModules": {
+      "title": "Modules de Gestion",
+      "description": "Outils complets pour gérer les participants, les tâches, les paramètres et analyser les données de votre étude",
+      "additionalModules": "Espace pour modules supplémentaires"
+    },
+    "participants": {
+      "title": "Participants",
+      "subtitle": "Aperçu de la participation aux tests",
+      "beta": "Bêta",
+      "completed": "Terminé",
+      "notStarted": "Non Commencé",
+      "pendingInvites": "Invitations en Attente",
+      "overallProgress": "Progression Globale",
+      "participantsCompleted": "{completed} sur {total} participants terminés",
+      "details": "Détails"
+    },
+    "tasks": {
+      "title": "Aperçu des Tâches",
+      "subtitle": "Structure et achèvement des tâches",
+      "beta": "Bêta",
+      "noTasksConfigured": "Aucune tâche configurée",
+      "taskCompletionRate": "Taux d'Achèvement des Tâches",
+      "totalTasks": "Total des Tâches",
+      "avgTaskDuration": "Durée Moyenne de Tâche",
+      "successRate": "Taux de Réussite",
+      "taskTypes": "Types de Tâches",
+      "viewTasks": "Voir les Tâches"
+    },
+    "storage": {
+      "title": "Utilisation du Stockage",
+      "subtitle": "Fichiers média et métriques de stockage",
+      "beta": "Bêta",
+      "storageUsed": "Stockage Utilisé",
+      "storageQuota": "{used} sur {quota} utilisé",
+      "mediaFiles": "Fichiers Média",
+      "videoRecordings": "Enregistrements Vidéo",
+      "audioRecordings": "Enregistrements Audio",
+      "screenRecordings": "Enregistrements d'Écran",
+      "storageBreakdown": "Répartition du Stockage",
+      "responsesData": "Données de Réponses",
+      "analyticsData": "Données Analytiques",
+      "manageStorage": "Gérer le Stockage"
+    }
   }
 }

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -1106,5 +1106,69 @@
         "upcoming": "आगामी"
       }
     }
+  },
+  "manager": {
+    "dashboard": {
+      "defaultTitle": "उपयोगकर्ता परीक्षण अध्ययन",
+      "unmoderatedStudy": "अनमोडरेटेड अध्ययन",
+      "moderatedStudy": "मोडरेटेड अध्ययन",
+      "active": "सक्रिय",
+      "draft": "ड्राफ्ट",
+      "completed": "पूर्ण",
+      "archived": "संग्रहीत"
+    },
+    "studyOverview": {
+      "totalParticipants": "कुल प्रतिभागी",
+      "completed": "पूर्ण",
+      "rate": "{percentage}% दर",
+      "inProgress": "प्रगति में",
+      "active": "{percentage}% सक्रिय",
+      "averageTime": "औसत समय",
+      "completionTime": "पूर्णता समय",
+      "minUnit": "{value} मिनट"
+    },
+    "managementModules": {
+      "title": "प्रबंधन मॉड्यूल",
+      "description": "प्रतिभागियों, कार्यों, सेटिंग्स को प्रबंधित करने और अपने अध्ययन डेटा का विश्लेषण करने के लिए व्यापक उपकरण",
+      "additionalModules": "अतिरिक्त मॉड्यूल के लिए स्थान"
+    },
+    "participants": {
+      "title": "प्रतिभागी",
+      "subtitle": "परीक्षण भागीदारी का अवलोकन",
+      "beta": "बीटा",
+      "completed": "पूर्ण",
+      "notStarted": "शुरू नहीं हुआ",
+      "pendingInvites": "लंबित आमंत्रण",
+      "overallProgress": "समग्र प्रगति",
+      "participantsCompleted": "{total} में से {completed} प्रतिभागियों ने पूरा किया",
+      "details": "विवरण"
+    },
+    "tasks": {
+      "title": "कार्य अवलोकन",
+      "subtitle": "कार्य संरचना और पूर्णता",
+      "beta": "बीटा",
+      "noTasksConfigured": "कोई कार्य कॉन्फ़िगर नहीं किया गया",
+      "taskCompletionRate": "कार्य पूर्णता दर",
+      "totalTasks": "कुल कार्य",
+      "avgTaskDuration": "औसत कार्य अवधि",
+      "successRate": "सफलता दर",
+      "taskTypes": "कार्य प्रकार",
+      "viewTasks": "कार्य देखें"
+    },
+    "storage": {
+      "title": "भंडारण उपयोग",
+      "subtitle": "मीडिया फ़ाइलें और भंडारण मेट्रिक्स",
+      "beta": "बीटा",
+      "storageUsed": "उपयोग किया गया भंडारण",
+      "storageQuota": "{quota} में से {used} उपयोग किया गया",
+      "mediaFiles": "मीडिया फ़ाइलें",
+      "videoRecordings": "वीडियो रिकॉर्डिंग",
+      "audioRecordings": "ऑडियो रिकॉर्डिंग",
+      "screenRecordings": "स्क्रीन रिकॉर्डिंग",
+      "storageBreakdown": "भंडारण विवरण",
+      "responsesData": "प्रतिक्रिया डेटा",
+      "analyticsData": "विश्लेषण डेटा",
+      "manageStorage": "भंडारण प्रबंधित करें"
+    }
   }
 }

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -1,38 +1,6 @@
 {
   "language": "言語",
   "auth": {
-    "signupSuccess": "サインアップに成功しました",
-    "logoutSuccess": "ログアウトに成功しました",
-    "resetPasswordSuccess": "パスワードリセット用のメールを送信しました",
-    "deleteSuccess": "アカウントが正常に削除されました",
-    "loginSuccess": "ログインに成功しました",
-    "SIGNIN": {
-      "sign-in": "ログイン",
-      "sign-in-title": "お帰りなさい",
-      "sign-in-subtitle": "続行するにはアカウントにサインインしてください",
-      "email": "メールアドレス",
-      "username": "ユーザー名",
-      "password": "パスワード",
-      "signupSubtitle": "開始するために情報を入力してください",
-      "dont-have-account": "アカウントをお持ちでないですか？登録",
-      "forgot-password": "パスワードをお忘れですか？",
-      "sign-up": "登録",
-      "contact": "連絡先番号",
-      "confirmPassword": "パスワードを確認",
-      "alreadyHaveAnAccount": "すでにアカウントをお持ちですか？ログイン",
-      "continueWithGoogle": "Googleで続行",
-      "rememberMe": "ログイン情報を保持する",
-      "or": "または"
-    },
-    "FORGOT_PASSWORD": {
-      "reset_password": "パスワードをリセット",
-      "email": "メールアドレス",
-      "instructions": "メールアドレスを入力してください。パスワードリセット用のリンクをお送りします。",
-      "reset_button": "リセットリンクを送信",
-      "back_to_signin": "サインインに戻る"
-    }
-  },
-  "auth": {
     "FORGOT_PASSWORD": {
       "reset_password": "パスワードをリセット",
       "email": "メールアドレス",
@@ -1128,6 +1096,70 @@
         "finished": "完了",
         "upcoming": "近日公開"
       }
+    }
+  },
+  "manager": {
+    "dashboard": {
+      "defaultTitle": "ユーザーテスト研究",
+      "unmoderatedStudy": "非モデレート型研究",
+      "moderatedStudy": "モデレート型研究",
+      "active": "アクティブ",
+      "draft": "下書き",
+      "completed": "完了",
+      "archived": "アーカイブ済み"
+    },
+    "studyOverview": {
+      "totalParticipants": "参加者総数",
+      "completed": "完了",
+      "rate": "{percentage}% 完了率",
+      "inProgress": "進行中",
+      "active": "{percentage}% アクティブ",
+      "averageTime": "平均時間",
+      "completionTime": "完了時間",
+      "minUnit": "{value} 分"
+    },
+    "managementModules": {
+      "title": "管理モジュール",
+      "description": "参加者、タスク、設定を管理し、研究データを分析するための包括的なツール",
+      "additionalModules": "追加モジュール用スペース"
+    },
+    "participants": {
+      "title": "参加者",
+      "subtitle": "テスト参加状況の概要",
+      "beta": "ベータ",
+      "completed": "完了",
+      "notStarted": "未開始",
+      "pendingInvites": "保留中の招待",
+      "overallProgress": "全体の進捗",
+      "participantsCompleted": "{total} 人中 {completed} 人の参加者が完了",
+      "details": "詳細"
+    },
+    "tasks": {
+      "title": "タスク概要",
+      "subtitle": "タスク構造と完了状況",
+      "beta": "ベータ",
+      "noTasksConfigured": "タスクが設定されていません",
+      "taskCompletionRate": "タスク完了率",
+      "totalTasks": "タスク総数",
+      "avgTaskDuration": "平均タスク時間",
+      "successRate": "成功率",
+      "taskTypes": "タスクタイプ",
+      "viewTasks": "タスクを見る"
+    },
+    "storage": {
+      "title": "ストレージ使用状況",
+      "subtitle": "メディアファイルとストレージ指標",
+      "beta": "ベータ",
+      "storageUsed": "使用済みストレージ",
+      "storageQuota": "{quota} 中 {used} 使用済み",
+      "mediaFiles": "メディアファイル",
+      "videoRecordings": "ビデオ録画",
+      "audioRecordings": "オーディオ録音",
+      "screenRecordings": "画面録画",
+      "storageBreakdown": "ストレージ内訳",
+      "responsesData": "レスポンスデータ",
+      "analyticsData": "分析データ",
+      "manageStorage": "ストレージ管理"
     }
   }
 }

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -1125,5 +1125,69 @@
         "upcoming": "Próximo"
       }
     }
+  },
+  "manager": {
+    "dashboard": {
+      "defaultTitle": "Estudo de Teste de Usuário",
+      "unmoderatedStudy": "Estudo Não Moderado",
+      "moderatedStudy": "Estudo Moderado",
+      "active": "Ativo",
+      "draft": "Rascunho",
+      "completed": "Concluído",
+      "archived": "Arquivado"
+    },
+    "studyOverview": {
+      "totalParticipants": "Total de Participantes",
+      "completed": "Concluído",
+      "rate": "{percentage}% taxa",
+      "inProgress": "Em Andamento",
+      "active": "{percentage}% ativo",
+      "averageTime": "Tempo Médio",
+      "completionTime": "Tempo de conclusão",
+      "minUnit": "{value} min"
+    },
+    "managementModules": {
+      "title": "Módulos de Gerenciamento",
+      "description": "Ferramentas abrangentes para gerenciar participantes, tarefas, configurações e analisar os dados do seu estudo",
+      "additionalModules": "Espaço para módulos adicionais"
+    },
+    "participants": {
+      "title": "Participantes",
+      "subtitle": "Visão geral da participação no teste",
+      "beta": "Beta",
+      "completed": "Concluído",
+      "notStarted": "Não Iniciado",
+      "pendingInvites": "Convites Pendentes",
+      "overallProgress": "Progresso Geral",
+      "participantsCompleted": "{completed} de {total} participantes concluídos",
+      "details": "Detalhes"
+    },
+    "tasks": {
+      "title": "Visão Geral das Tarefas",
+      "subtitle": "Estrutura e conclusão das tarefas",
+      "beta": "Beta",
+      "noTasksConfigured": "Nenhuma tarefa configurada",
+      "taskCompletionRate": "Taxa de Conclusão de Tarefas",
+      "totalTasks": "Total de Tarefas",
+      "avgTaskDuration": "Duração Média da Tarefa",
+      "successRate": "Taxa de Sucesso",
+      "taskTypes": "Tipos de Tarefas",
+      "viewTasks": "Ver Tarefas"
+    },
+    "storage": {
+      "title": "Uso de Armazenamento",
+      "subtitle": "Arquivos de mídia e métricas de armazenamento",
+      "beta": "Beta",
+      "storageUsed": "Armazenamento Usado",
+      "storageQuota": "{used} de {quota} usado",
+      "mediaFiles": "Arquivos de Mídia",
+      "videoRecordings": "Gravações de Vídeo",
+      "audioRecordings": "Gravações de Áudio",
+      "screenRecordings": "Gravações de Tela",
+      "storageBreakdown": "Detalhamento do Armazenamento",
+      "responsesData": "Dados de Respostas",
+      "analyticsData": "Dados de Análise",
+      "manageStorage": "Gerenciar Armazenamento"
+    }
   }
 }

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -1,38 +1,6 @@
 {
   "language": "Язык",
   "auth": {
-    "signupSuccess": "Регистрация успешна",
-    "logoutSuccess": "Выход успешен",
-    "resetPasswordSuccess": "Письмо для сброса пароля отправлено",
-    "deleteSuccess": "Аккаунт успешно удален",
-    "loginSuccess": "Вход выполнен успешно",
-    "SIGNIN": {
-      "sign-in": "Войти",
-      "sign-in-title": "С возвращением",
-      "sign-in-subtitle": "Войдите в свой аккаунт, чтобы продолжить",
-      "email": "Электронная почта",
-      "username": "Имя пользователя",
-      "password": "Пароль",
-      "signupSubtitle": "Заполните свои данные, чтобы начать",
-      "dont-have-account": "Нет аккаунта?",
-      "forgot-password": "Забыли пароль?",
-      "sign-up": "Создать аккаунт",
-      "contact": "Контактный номер",
-      "confirmPassword": "Подтвердите пароль",
-      "alreadyHaveAnAccount": "Уже есть аккаунт?",
-      "continueWithGoogle": "Продолжить с Google",
-      "rememberMe": "Запомнить меня",
-      "or": "или продолжить с"
-    },
-    "FORGOT_PASSWORD": {
-      "reset_password": "Сбросить пароль",
-      "email": "Электронная почта",
-      "instructions": "Введите свой адрес электронной почты, и мы отправим вам ссылку для сброса пароля.",
-      "reset_button": "Отправить ссылку сброса",
-      "back_to_signin": "Вернуться ко входу"
-    }
-  },
-  "auth": {
     "FORGOT_PASSWORD": {
       "reset_password": "Сбросить пароль",
       "email": "Электронная почта",
@@ -1151,6 +1119,70 @@
         "finished": "Завершено",
         "upcoming": "Предстоящее"
       }
+    }
+  },
+  "manager": {
+    "dashboard": {
+      "defaultTitle": "Исследование пользовательского тестирования",
+      "unmoderatedStudy": "Немодерируемое исследование",
+      "moderatedStudy": "Модерируемое исследование",
+      "active": "Активно",
+      "draft": "Черновик",
+      "completed": "Завершено",
+      "archived": "Архивировано"
+    },
+    "studyOverview": {
+      "totalParticipants": "Всего участников",
+      "completed": "Завершено",
+      "rate": "{percentage}% завершения",
+      "inProgress": "В процессе",
+      "active": "{percentage}% активно",
+      "averageTime": "Среднее время",
+      "completionTime": "Время завершения",
+      "minUnit": "{value} мин"
+    },
+    "managementModules": {
+      "title": "Модули управления",
+      "description": "Комплексные инструменты для управления участниками, задачами, настройками и анализа данных исследования",
+      "additionalModules": "Место для дополнительных модулей"
+    },
+    "participants": {
+      "title": "Участники",
+      "subtitle": "Обзор участия в тестировании",
+      "beta": "Бета",
+      "completed": "Завершено",
+      "notStarted": "Не начато",
+      "pendingInvites": "Ожидающие приглашения",
+      "overallProgress": "Общий прогресс",
+      "participantsCompleted": "{completed} из {total} участников завершили",
+      "details": "Подробнее"
+    },
+    "tasks": {
+      "title": "Обзор задач",
+      "subtitle": "Структура и выполнение задач",
+      "beta": "Бета",
+      "noTasksConfigured": "Задачи не настроены",
+      "taskCompletionRate": "Процент выполнения задач",
+      "totalTasks": "Всего задач",
+      "avgTaskDuration": "Средняя продолжительность",
+      "successRate": "Процент успеха",
+      "taskTypes": "Типы задач",
+      "viewTasks": "Посмотреть задачи"
+    },
+    "storage": {
+      "title": "Использование хранилища",
+      "subtitle": "Медиафайлы и метрики хранилища",
+      "beta": "Бета",
+      "storageUsed": "Использовано хранилища",
+      "storageQuota": "Использовано {used} из {quota}",
+      "mediaFiles": "Медиафайлы",
+      "videoRecordings": "Видеозаписи",
+      "audioRecordings": "Аудиозаписи",
+      "screenRecordings": "Записи экрана",
+      "storageBreakdown": "Разбивка хранилища",
+      "responsesData": "Данные ответов",
+      "analyticsData": "Аналитические данные",
+      "manageStorage": "Управление хранилищем"
     }
   }
 }

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -1,38 +1,6 @@
 {
   "language": "语言",
   "auth": {
-    "signupSuccess": "注册成功",
-    "logoutSuccess": "注销成功",
-    "resetPasswordSuccess": "密码重置邮件已发送",
-    "deleteSuccess": "账户删除成功",
-    "loginSuccess": "登录成功",
-    "SIGNIN": {
-      "sign-in": "登录",
-      "sign-in-title": "欢迎回来",
-      "sign-in-subtitle": "登录您的账户以继续",
-      "email": "电子邮箱",
-      "username": "用户名",
-      "password": "密码",
-      "signupSubtitle": "填写您的详细信息以开始",
-      "dont-have-account": "还没有账户？",
-      "forgot-password": "忘记密码？",
-      "sign-up": "创建账户",
-      "contact": "联系电话",
-      "confirmPassword": "确认密码",
-      "alreadyHaveAnAccount": "已有账户？",
-      "continueWithGoogle": "继续使用 Google",
-      "rememberMe": "记住我",
-      "or": "或继续使用"
-    },
-    "FORGOT_PASSWORD": {
-      "reset_password": "重置密码",
-      "email": "电子邮箱",
-      "instructions": "输入您的电子邮箱，我们将发送重置密码链接给您。",
-      "reset_button": "发送重置链接",
-      "back_to_signin": "返回登录"
-    }
-  },
-  "auth": {
     "FORGOT_PASSWORD": {
       "reset_password": "重置密码",
       "email": "邮箱",
@@ -1151,6 +1119,70 @@
         "finished": "已完成",
         "upcoming": "即将开始"
       }
+    }
+  },
+  "manager": {
+    "dashboard": {
+      "defaultTitle": "用户测试研究",
+      "unmoderatedStudy": "无主持研究",
+      "moderatedStudy": "有主持研究",
+      "active": "活跃",
+      "draft": "草稿",
+      "completed": "已完成",
+      "archived": "已归档"
+    },
+    "studyOverview": {
+      "totalParticipants": "总参与者",
+      "completed": "已完成",
+      "rate": "{percentage}% 完成率",
+      "inProgress": "进行中",
+      "active": "{percentage}% 活跃",
+      "averageTime": "平均时间",
+      "completionTime": "完成时间",
+      "minUnit": "{value} 分钟"
+    },
+    "managementModules": {
+      "title": "管理模块",
+      "description": "管理参与者、任务、设置并分析研究数据的综合工具",
+      "additionalModules": "额外模块空间"
+    },
+    "participants": {
+      "title": "参与者",
+      "subtitle": "测试参与情况概览",
+      "beta": "测试版",
+      "completed": "已完成",
+      "notStarted": "未开始",
+      "pendingInvites": "待处理邀请",
+      "overallProgress": "总体进度",
+      "participantsCompleted": "{total} 名参与者中有 {completed} 名已完成",
+      "details": "详情"
+    },
+    "tasks": {
+      "title": "任务概览",
+      "subtitle": "任务结构和完成情况",
+      "beta": "测试版",
+      "noTasksConfigured": "未配置任务",
+      "taskCompletionRate": "任务完成率",
+      "totalTasks": "任务总数",
+      "avgTaskDuration": "平均任务时长",
+      "successRate": "成功率",
+      "taskTypes": "任务类型",
+      "viewTasks": "查看任务"
+    },
+    "storage": {
+      "title": "存储使用情况",
+      "subtitle": "媒体文件和存储指标",
+      "beta": "测试版",
+      "storageUsed": "已用存储",
+      "storageQuota": "{quota} 中已使用 {used}",
+      "mediaFiles": "媒体文件",
+      "videoRecordings": "视频录制",
+      "audioRecordings": "音频录制",
+      "screenRecordings": "屏幕录制",
+      "storageBreakdown": "存储明细",
+      "responsesData": "响应数据",
+      "analyticsData": "分析数据",
+      "manageStorage": "管理存储"
     }
   }
 }

--- a/src/ux/UserTest/components/manager/ParticipantsInfo.vue
+++ b/src/ux/UserTest/components/manager/ParticipantsInfo.vue
@@ -1,8 +1,5 @@
 <template>
-  <v-card 
-    class="h-100 participants-card"
-    elevation="2"
-  >
+  <v-card class="h-100 participants-card" elevation="2">
     <!-- Header with gradient background -->
     <div class="participants-header pa-4">
       <div class="d-flex align-center justify-space-between">
@@ -11,8 +8,12 @@
             <v-icon color="white" size="24">mdi-account-group</v-icon>
           </div>
           <div>
-            <h3 class="text-h6 text-white mb-0">Participants</h3>
-            <p class="text-body-2 text-white opacity-90 mb-0">Test participation overview</p>
+            <h3 class="text-h6 text-white mb-0">
+              {{ t('manager.participants.title') }}
+            </h3>
+            <p class="text-body-2 text-white opacity-90 mb-0">
+              {{ t('manager.participants.subtitle') }}
+            </p>
           </div>
         </div>
         <v-chip
@@ -22,66 +23,81 @@
           class="border-white text-white"
         >
           <v-icon start size="16">mdi-flask</v-icon>
-          Beta
+          {{ t('manager.participants.beta') }}
         </v-chip>
       </div>
     </div>
-    
+
     <v-card-text class="pa-4">
       <!-- Clean Stats Grid -->
       <div class="stats-grid">
         <div class="stat-box stat-box-primary">
           <div class="stat-content">
             <div class="stat-number">{{ completedParticipants }}</div>
-            <div class="stat-label">Completed</div>
+            <div class="stat-label">
+              {{ t('manager.participants.completed') }}
+            </div>
           </div>
         </div>
-        
+
         <div class="stat-box stat-box-primary">
           <div class="stat-content">
             <div class="stat-number">{{ notStartedParticipants }}</div>
-            <div class="stat-label">Not Started</div>
+            <div class="stat-label">
+              {{ t('manager.participants.notStarted') }}
+            </div>
           </div>
         </div>
-        
+
         <div class="stat-box stat-box-primary">
           <div class="stat-content">
             <div class="stat-number">{{ pendingInvitations.length }}</div>
-            <div class="stat-label">Pending Invites</div>
+            <div class="stat-label">
+              {{ t('manager.participants.pendingInvites') }}
+            </div>
           </div>
         </div>
       </div>
-      
+
       <!-- Simple Progress Bar -->
       <div class="mt-4">
         <div class="d-flex justify-space-between align-center mb-2">
-          <span class="text-body-2">Overall Progress</span>
-          <span class="text-body-2 font-weight-bold">{{ completionPercentage }}%</span>
+          <span class="text-body-2">{{
+            t('manager.participants.overallProgress')
+          }}</span>
+          <span class="text-body-2 font-weight-bold"
+            >{{ completionPercentage }}%</span
+          >
         </div>
-        <v-progress-linear 
-          :model-value="completionPercentage" 
+        <v-progress-linear
+          :model-value="completionPercentage"
           :color="progressColor"
           height="6"
           rounded
           class="mb-2"
         />
         <div class="text-caption text-medium-emphasis text-center">
-          {{ completedParticipants }} of {{ totalParticipants }} participants completed
+          {{
+            t('manager.participants.participantsCompleted', {
+              completed: completedParticipants,
+              total: totalParticipants,
+            })
+          }}
         </div>
       </div>
     </v-card-text>
-    
+
     <v-card-actions class="pa-3 pt-0">
       <v-spacer />
-      <v-btn 
-        variant="text" 
+      <v-btn
+        variant="text"
         color="primary"
         size="small"
         class="view-all-btn"
         @click="viewParticipants"
       >
         <v-icon start size="14">mdi-eye</v-icon>
-        Details
+        {{ t('manager.participants.details') }}
       </v-btn>
     </v-card-actions>
   </v-card>
@@ -90,23 +106,25 @@
 <script setup>
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 
 const props = defineProps({
   test: {
     type: Object,
-    default: () => ({})
-  }
+    default: () => ({}),
+  },
 })
 
 const router = useRouter()
+const { t } = useI18n()
 
 // Get completed participants from answers
 const completedAnswers = computed(() => {
   const testAnswers = props.test?.answers || []
   if (Array.isArray(testAnswers)) {
-    return testAnswers.filter(answer => answer.submitted)
+    return testAnswers.filter((answer) => answer.submitted)
   } else if (typeof testAnswers === 'object' && testAnswers !== null) {
-    return Object.values(testAnswers).filter(answer => answer.submitted)
+    return Object.values(testAnswers).filter((answer) => answer.submitted)
   }
   return []
 })
@@ -119,12 +137,12 @@ const cooperators = computed(() => {
 
 // Get accepted cooperators (who can potentially participate)
 const acceptedCooperators = computed(() => {
-  return cooperators.value.filter(coop => coop.accepted === true)
+  return cooperators.value.filter((coop) => coop.accepted === true)
 })
 
 // Get pending invitations (cooperators who haven't accepted)
 const pendingInvitations = computed(() => {
-  return cooperators.value.filter(coop => coop.accepted === false)
+  return cooperators.value.filter((coop) => coop.accepted === false)
 })
 
 const totalParticipants = computed(() => {
@@ -144,7 +162,9 @@ const notStartedParticipants = computed(() => {
 
 const completionPercentage = computed(() => {
   if (totalParticipants.value === 0) return 0
-  return Math.round((completedParticipants.value / totalParticipants.value) * 100)
+  return Math.round(
+    (completedParticipants.value / totalParticipants.value) * 100,
+  )
 })
 
 const progressColor = computed(() => {
@@ -163,11 +183,10 @@ const progressColorClass = computed(() => {
   return 'text-error'
 })
 
-
-
 const viewParticipants = () => {
   // Navigate to participants/answers view
-  const testType = props.test?.testType === 'USER_MODERATED' ? 'moderated' : 'unmoderated'
+  const testType =
+    props.test?.testType === 'USER_MODERATED' ? 'moderated' : 'unmoderated'
   router.push(`/userTest/${testType}/cooperators/${props.test.id}`)
 }
 </script>
@@ -184,7 +203,11 @@ const viewParticipants = () => {
 }
 
 .participants-header {
-  background: linear-gradient(135deg, rgb(var(--v-theme-primary)) 0%, rgb(var(--v-theme-secondary)) 100%);
+  background: linear-gradient(
+    135deg,
+    rgb(var(--v-theme-primary)) 0%,
+    rgb(var(--v-theme-secondary)) 100%
+  );
   position: relative;
   overflow: hidden;
 }
@@ -196,7 +219,8 @@ const viewParticipants = () => {
   left: 0;
   right: 0;
   bottom: 0;
-  background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E") repeat;
+  background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")
+    repeat;
   opacity: 0.1;
 }
 

--- a/src/ux/UserTest/components/manager/StorageInfo.vue
+++ b/src/ux/UserTest/components/manager/StorageInfo.vue
@@ -1,8 +1,5 @@
 <template>
-  <v-card 
-    class="h-100 storage-card"
-    elevation="2"
-  >
+  <v-card class="h-100 storage-card" elevation="2">
     <!-- Header with gradient background -->
     <div class="storage-header pa-4">
       <div class="d-flex align-center justify-space-between">
@@ -11,8 +8,12 @@
             <v-icon color="white" size="24">mdi-database</v-icon>
           </div>
           <div>
-            <h3 class="text-h6 text-white mb-0">Storage Usage</h3>
-            <p class="text-body-2 text-white opacity-90 mb-0">Media files and storage metrics</p>
+            <h3 class="text-h6 text-white mb-0">
+              {{ t('manager.storage.title') }}
+            </h3>
+            <p class="text-body-2 text-white opacity-90 mb-0">
+              {{ t('manager.storage.subtitle') }}
+            </p>
           </div>
         </div>
         <v-chip
@@ -22,94 +23,111 @@
           class="border-white text-white"
         >
           <v-icon start size="16">mdi-flask</v-icon>
-          Beta
+          {{ t('manager.storage.beta') }}
         </v-chip>
       </div>
     </div>
-    
+
     <v-card-text class="pa-4">
       <div class="mb-4">
         <div class="d-flex justify-space-between align-center mb-2">
-          <span class="text-body-2">Storage Used</span>
-          <span class="text-body-2 font-weight-bold">{{ storageUsedFormatted }}</span>
+          <span class="text-body-2">{{
+            t('manager.storage.storageUsed')
+          }}</span>
+          <span class="text-body-2 font-weight-bold">{{
+            storageUsedFormatted
+          }}</span>
         </div>
-        <v-progress-linear 
-          :model-value="storagePercentage" 
-          :color="storageColor" 
+        <v-progress-linear
+          :model-value="storagePercentage"
+          :color="storageColor"
           height="8"
           rounded
         />
         <div class="text-caption text-medium-emphasis mt-1">
-          {{ storageUsedFormatted }} of {{ storageQuotaFormatted }} used
+          {{
+            t('manager.storage.storageQuota', {
+              used: storageUsedFormatted,
+              quota: storageQuotaFormatted,
+            })
+          }}
         </div>
       </div>
-      
+
       <div class="mb-3">
         <div class="d-flex justify-space-between align-center">
-          <span class="text-body-2">Media Files</span>
+          <span class="text-body-2">{{ t('manager.storage.mediaFiles') }}</span>
           <v-chip size="small" color="primary" variant="outlined">
             {{ totalMediaFiles }}
           </v-chip>
         </div>
       </div>
-      
+
       <div class="mb-3">
         <div class="d-flex justify-space-between align-center">
-          <span class="text-body-2">Video Recordings</span>
+          <span class="text-body-2">{{
+            t('manager.storage.videoRecordings')
+          }}</span>
           <v-chip size="small" color="success" variant="outlined">
             {{ videoCount }} ({{ videoSizeFormatted }})
           </v-chip>
         </div>
       </div>
-      
+
       <div class="mb-3">
         <div class="d-flex justify-space-between align-center">
-          <span class="text-body-2">Audio Recordings</span>
+          <span class="text-body-2">{{
+            t('manager.storage.audioRecordings')
+          }}</span>
           <v-chip size="small" color="warning" variant="outlined">
             {{ audioCount }} ({{ audioSizeFormatted }})
           </v-chip>
         </div>
       </div>
-      
+
       <div class="mb-3">
         <div class="d-flex justify-space-between align-center">
-          <span class="text-body-2">Screen Recordings</span>
+          <span class="text-body-2">{{
+            t('manager.storage.screenRecordings')
+          }}</span>
           <v-chip size="small" color="info" variant="outlined">
             {{ screenCount }} ({{ screenSizeFormatted }})
           </v-chip>
         </div>
       </div>
-      
+
       <!-- Storage breakdown -->
       <div class="mt-4">
-        <div class="text-caption text-medium-emphasis mb-2">Storage Breakdown</div>
+        <div class="text-caption text-medium-emphasis mb-2">
+          {{ t('manager.storage.storageBreakdown') }}
+        </div>
         <div class="d-flex flex-column gap-1">
           <div class="d-flex justify-space-between text-caption">
-            <span>Responses Data</span>
+            <span>{{ t('manager.storage.responsesData') }}</span>
             <span>{{ responseDataSize }}</span>
           </div>
           <div class="d-flex justify-space-between text-caption">
-            <span>Media Files</span>
+            <span>{{ t('manager.storage.mediaFiles') }}</span>
             <span>{{ mediaDataSize }}</span>
           </div>
           <div class="d-flex justify-space-between text-caption">
-            <span>Analytics Data</span>
+            <span>{{ t('manager.storage.analyticsData') }}</span>
             <span>{{ analyticsDataSize }}</span>
           </div>
         </div>
       </div>
     </v-card-text>
-    
+
     <v-card-actions>
       <v-spacer />
-      <v-btn 
-        variant="text" 
-        size="small" 
+      <v-btn
+        variant="text"
+        size="small"
         color="primary"
-        @click="manageStorage"
         disabled
+        @click="manageStorage"
       >
-        Manage Storage
+        {{ t('manager.storage.manageStorage') }}
       </v-btn>
     </v-card-actions>
   </v-card>
@@ -118,15 +136,17 @@
 <script setup>
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 
 const props = defineProps({
   test: {
     type: Object,
-    default: () => ({})
-  }
+    default: () => ({}),
+  },
 })
 
 const router = useRouter()
+const { t } = useI18n()
 
 // Storage quota (in bytes) - you can make this configurable
 const STORAGE_QUOTA = 5 * 1024 * 1024 * 1024 // 5GB default
@@ -138,9 +158,11 @@ const answers = computed(() => {
 
 const totalMediaFiles = computed(() => {
   let count = 0
-  answers.value.forEach(answer => {
-    const tasks = Array.isArray(answer.tasks) ? answer.tasks : Object.values(answer.tasks || {})
-    tasks.forEach(task => {
+  answers.value.forEach((answer) => {
+    const tasks = Array.isArray(answer.tasks)
+      ? answer.tasks
+      : Object.values(answer.tasks || {})
+    tasks.forEach((task) => {
       if (task.audioRecordURL) count++
       if (task.webcamRecordURL) count++
       if (task.screenRecordURL) count++
@@ -151,9 +173,11 @@ const totalMediaFiles = computed(() => {
 
 const videoCount = computed(() => {
   let count = 0
-  answers.value.forEach(answer => {
-    const tasks = Array.isArray(answer.tasks) ? answer.tasks : Object.values(answer.tasks || {})
-    tasks.forEach(task => {
+  answers.value.forEach((answer) => {
+    const tasks = Array.isArray(answer.tasks)
+      ? answer.tasks
+      : Object.values(answer.tasks || {})
+    tasks.forEach((task) => {
       if (task.webcamRecordURL) count++
     })
   })
@@ -162,9 +186,11 @@ const videoCount = computed(() => {
 
 const audioCount = computed(() => {
   let count = 0
-  answers.value.forEach(answer => {
-    const tasks = Array.isArray(answer.tasks) ? answer.tasks : Object.values(answer.tasks || {})
-    tasks.forEach(task => {
+  answers.value.forEach((answer) => {
+    const tasks = Array.isArray(answer.tasks)
+      ? answer.tasks
+      : Object.values(answer.tasks || {})
+    tasks.forEach((task) => {
       if (task.audioRecordURL) count++
     })
   })
@@ -173,9 +199,11 @@ const audioCount = computed(() => {
 
 const screenCount = computed(() => {
   let count = 0
-  answers.value.forEach(answer => {
-    const tasks = Array.isArray(answer.tasks) ? answer.tasks : Object.values(answer.tasks || {})
-    tasks.forEach(task => {
+  answers.value.forEach((answer) => {
+    const tasks = Array.isArray(answer.tasks)
+      ? answer.tasks
+      : Object.values(answer.tasks || {})
+    tasks.forEach((task) => {
       if (task.screenRecordURL) count++
     })
   })
@@ -189,12 +217,12 @@ const estimatedStorageUsed = computed(() => {
   const avgAudioSize = 10 * 1024 * 1024 // 10MB per audio
   const avgScreenSize = 100 * 1024 * 1024 // 100MB per screen recording
   const avgResponseSize = 10 * 1024 // 10KB per response
-  
+
   const videoStorage = videoCount.value * avgVideoSize
   const audioStorage = audioCount.value * avgAudioSize
   const screenStorage = screenCount.value * avgScreenSize
   const responseStorage = answers.value.length * avgResponseSize
-  
+
   return videoStorage + audioStorage + screenStorage + responseStorage
 })
 
@@ -208,7 +236,9 @@ const storageColor = computed(() => {
   return 'success'
 })
 
-const storageUsedFormatted = computed(() => formatBytes(estimatedStorageUsed.value))
+const storageUsedFormatted = computed(() =>
+  formatBytes(estimatedStorageUsed.value),
+)
 const storageQuotaFormatted = computed(() => formatBytes(STORAGE_QUOTA))
 
 const videoSizeFormatted = computed(() => {
@@ -235,10 +265,11 @@ const mediaDataSize = computed(() => {
   const avgVideoSize = 50 * 1024 * 1024
   const avgAudioSize = 10 * 1024 * 1024
   const avgScreenSize = 100 * 1024 * 1024
-  
-  const total = (videoCount.value * avgVideoSize) + 
-                (audioCount.value * avgAudioSize) + 
-                (screenCount.value * avgScreenSize)
+
+  const total =
+    videoCount.value * avgVideoSize +
+    audioCount.value * avgAudioSize +
+    screenCount.value * avgScreenSize
   return formatBytes(total)
 })
 
@@ -250,17 +281,18 @@ const analyticsDataSize = computed(() => {
 
 function formatBytes(bytes) {
   if (bytes === 0) return '0 B'
-  
+
   const k = 1024
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
   const i = Math.floor(Math.log(bytes) / Math.log(k))
-  
+
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i]
 }
 
 const manageStorage = () => {
   // Navigate to storage management or show storage details
-  const testType = props.test?.testType === 'USER_MODERATED' ? 'moderated' : 'unmoderated'
+  const testType =
+    props.test?.testType === 'USER_MODERATED' ? 'moderated' : 'unmoderated'
   router.push(`/userTest/${testType}/storage/${props.test.id}`)
 }
 </script>
@@ -277,7 +309,11 @@ const manageStorage = () => {
 }
 
 .storage-header {
-  background: linear-gradient(135deg, rgb(var(--v-theme-primary)) 0%, rgb(var(--v-theme-secondary)) 100%);
+  background: linear-gradient(
+    135deg,
+    rgb(var(--v-theme-primary)) 0%,
+    rgb(var(--v-theme-secondary)) 100%
+  );
   position: relative;
   overflow: hidden;
 }
@@ -289,7 +325,8 @@ const manageStorage = () => {
   left: 0;
   right: 0;
   bottom: 0;
-  background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E") repeat;
+  background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")
+    repeat;
   opacity: 0.1;
 }
 

--- a/src/ux/UserTest/components/manager/StudyOverview.vue
+++ b/src/ux/UserTest/components/manager/StudyOverview.vue
@@ -1,15 +1,14 @@
 <template>
-    <v-row>
+  <v-row>
     <!-- Total Users -->
     <v-col cols="12" md="6" class="py-0">
-      <v-card 
-        class="study-card study-card-primary-blur"
-        elevation="8"
-      >
+      <v-card class="study-card study-card-primary-blur" elevation="8">
         <v-card-text class="pa-4">
           <div class="d-flex justify-space-between align-center">
             <div class="flex-grow-1">
-              <h3 class="card-title-small mb-1 text-white">Total Participants</h3>
+              <h3 class="card-title-small mb-1 text-white">
+                {{ t('manager.studyOverview.totalParticipants') }}
+              </h3>
               <div class="metric-value-small text-white">{{ totalUsers }}</div>
             </div>
             <div class="icon-container-small">
@@ -21,17 +20,22 @@
     </v-col>
 
     <!-- Completed Tests -->
-    <v-col cols="12" md="6"  class="py-0">
-      <v-card 
-        class="study-card study-card-primary-blur"
-        elevation="8"
-      >
+    <v-col cols="12" md="6" class="py-0">
+      <v-card class="study-card study-card-primary-blur" elevation="8">
         <v-card-text class="pa-4">
           <div class="d-flex justify-space-between align-center">
             <div class="flex-grow-1">
-              <h3 class="card-title-small mb-1 text-white">Completed</h3>
-              <div class="metric-value-small text-white">{{ completedTests }}</div>
-              <span class="progress-text-small text-white opacity-90">{{ completionPercentage }}% rate</span>
+              <h3 class="card-title-small mb-1 text-white">
+                {{ t('manager.studyOverview.completed') }}
+              </h3>
+              <div class="metric-value-small text-white">
+                {{ completedTests }}
+              </div>
+              <span class="progress-text-small text-white opacity-90">{{
+                t('manager.studyOverview.rate', {
+                  percentage: completionPercentage,
+                })
+              }}</span>
             </div>
             <div class="icon-container-small">
               <v-icon size="20" color="white">mdi-check-circle</v-icon>
@@ -42,17 +46,22 @@
     </v-col>
 
     <!-- In Progress -->
-    <v-col cols="12" md="6" m >
-      <v-card 
-        class="study-card study-card-primary-blur"
-        elevation="8"
-      >
+    <v-col cols="12" md="6" m>
+      <v-card class="study-card study-card-primary-blur" elevation="8">
         <v-card-text class="pa-4">
           <div class="d-flex justify-space-between align-center">
             <div class="flex-grow-1">
-              <h3 class="card-title-small mb-1 text-white">In Progress</h3>
-              <div class="metric-value-small text-white">{{ inProgressTests }}</div>
-              <span class="progress-text-small text-white opacity-90">{{ inProgressPercentage }}% active</span>
+              <h3 class="card-title-small mb-1 text-white">
+                {{ t('manager.studyOverview.inProgress') }}
+              </h3>
+              <div class="metric-value-small text-white">
+                {{ inProgressTests }}
+              </div>
+              <span class="progress-text-small text-white opacity-90">{{
+                t('manager.studyOverview.active', {
+                  percentage: inProgressPercentage,
+                })
+              }}</span>
             </div>
             <div class="icon-container-small">
               <v-icon size="20" color="white">mdi-clock-outline</v-icon>
@@ -64,16 +73,19 @@
 
     <!-- Average Completion Time -->
     <v-col cols="12" md="6">
-      <v-card 
-        class="study-card study-card-primary-blur"
-        elevation="8"
-      >
+      <v-card class="study-card study-card-primary-blur" elevation="8">
         <v-card-text class="pa-4">
           <div class="d-flex justify-space-between align-center">
             <div class="flex-grow-1">
-              <h3 class="card-title-small mb-1 text-white">Average Time</h3>
-              <div class="metric-value-small text-white">{{ averageCompletionTime }}</div>
-              <span class="progress-text-small text-white opacity-90">Completion time</span>
+              <h3 class="card-title-small mb-1 text-white">
+                {{ t('manager.studyOverview.averageTime') }}
+              </h3>
+              <div class="metric-value-small text-white">
+                {{ averageCompletionTime }}
+              </div>
+              <span class="progress-text-small text-white opacity-90">{{
+                t('manager.studyOverview.completionTime')
+              }}</span>
             </div>
             <div class="icon-container-small">
               <v-icon size="20" color="white">mdi-timer-outline</v-icon>
@@ -87,18 +99,21 @@
 
 <script setup>
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps({
   test: {
     type: Object,
-    default: () => ({})
-  }
+    default: () => ({}),
+  },
 })
 
 // Combine answers and cooperators since both are participants
 const getAllParticipants = computed(() => {
   let participants = []
-  
+
   // Add answers if they exist
   const testAnswers = props.test?.answers || []
   if (Array.isArray(testAnswers)) {
@@ -106,15 +121,15 @@ const getAllParticipants = computed(() => {
   } else if (typeof testAnswers === 'object' && testAnswers !== null) {
     participants = Object.values(testAnswers)
   }
-  
+
   // Add cooperators since they are also participants who respond
   const cooperators = props.test?.cooperators || []
   if (Array.isArray(cooperators)) {
     participants = [...participants, ...cooperators]
   }
-  
-  return participants.filter(participant => 
-    typeof participant === 'object' && participant !== null
+
+  return participants.filter(
+    (participant) => typeof participant === 'object' && participant !== null,
   )
 })
 
@@ -123,12 +138,12 @@ const totalUsers = computed(() => {
 })
 
 const completedTests = computed(() => {
-  return getAllParticipants.value.filter(answer => answer.submitted).length
+  return getAllParticipants.value.filter((answer) => answer.submitted).length
 })
 
 const inProgressTests = computed(() => {
-  return getAllParticipants.value.filter(answer => 
-    !answer.submitted && (answer.progress || 0) > 0
+  return getAllParticipants.value.filter(
+    (answer) => !answer.submitted && (answer.progress || 0) > 0,
   ).length
 })
 
@@ -152,25 +167,29 @@ const timeEfficiencyPercentage = computed(() => {
 })
 
 const averageCompletionTime = computed(() => {
-  const completedAnswers = getAllParticipants.value.filter(answer => answer.submitted && answer.tasks)
-  
+  const completedAnswers = getAllParticipants.value.filter(
+    (answer) => answer.submitted && answer.tasks,
+  )
+
   if (completedAnswers.length === 0) return '0 min'
-  
+
   let totalTime = 0
   let taskCount = 0
-  
-  completedAnswers.forEach(answer => {
-    const tasks = Array.isArray(answer.tasks) ? answer.tasks : Object.values(answer.tasks || {})
-    tasks.forEach(task => {
+
+  completedAnswers.forEach((answer) => {
+    const tasks = Array.isArray(answer.tasks)
+      ? answer.tasks
+      : Object.values(answer.tasks || {})
+    tasks.forEach((task) => {
       if (task.taskTime) {
         totalTime += task.taskTime
         taskCount++
       }
     })
   })
-  
+
   if (taskCount === 0) return '0 min'
-  
+
   const avgMs = totalTime / taskCount
   const avgMinutes = Math.round(avgMs / 1000 / 60)
   return `${avgMinutes} min`
@@ -248,19 +267,17 @@ const averageCompletionTime = computed(() => {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2) !important;
 }
 
-
-
 /* Responsive Design */
 @media (max-width: 960px) {
   .study-card {
     min-height: 100px !important;
     max-height: 110px !important;
   }
-  
+
   .metric-value-small {
     font-size: 1.25rem !important;
   }
-  
+
   .icon-container-small {
     width: 32px !important;
     height: 32px !important;
@@ -272,15 +289,15 @@ const averageCompletionTime = computed(() => {
     min-height: 90px !important;
     max-height: 100px !important;
   }
-  
+
   .metric-value-small {
     font-size: 1.1rem !important;
   }
-  
+
   .card-title-small {
     font-size: 0.8rem !important;
   }
-  
+
   .progress-text-small {
     font-size: 0.65rem !important;
   }

--- a/src/ux/UserTest/components/manager/TasksInfo.vue
+++ b/src/ux/UserTest/components/manager/TasksInfo.vue
@@ -1,26 +1,18 @@
 <template>
-  <v-card 
-    class="h-100 tasks-card"
-    elevation="2"
-  >
+  <v-card class="h-100 tasks-card" elevation="2">
     <!-- Header with gradient background -->
     <div class="tasks-header pa-4">
       <div class="d-flex align-center justify-space-between">
         <div class="d-flex align-center">
           <div class="icon-container mr-3">
-            <v-icon
-              color="white"
-              size="24"
-            >
-              mdi-format-list-checks
-            </v-icon>
+            <v-icon color="white" size="24"> mdi-format-list-checks </v-icon>
           </div>
           <div>
             <h3 class="text-h6 text-white mb-0">
-              Tasks Overview
+              {{ t('manager.tasks.title') }}
             </h3>
             <p class="text-body-2 text-white opacity-90 mb-0">
-              Task structure and completion
+              {{ t('manager.tasks.subtitle') }}
             </p>
           </div>
         </div>
@@ -30,93 +22,75 @@
           variant="outlined"
           class="border-white text-white"
         >
-          <v-icon
-            start
-            size="16"
-          >
-            mdi-flask
-          </v-icon>
-          Beta
+          <v-icon start size="16"> mdi-flask </v-icon>
+          {{ t('manager.tasks.beta') }}
         </v-chip>
       </div>
     </div>
-    
+
     <v-card-text class="pa-4">
-      <div
-        v-if="!hasUserTasks"
-        class="text-center text-medium-emphasis py-8"
-      >
-        <v-icon
-          size="48"
-          color="grey-lighten-1"
-        >
+      <div v-if="!hasUserTasks" class="text-center text-medium-emphasis py-8">
+        <v-icon size="48" color="grey-lighten-1">
           mdi-clipboard-text-outline
         </v-icon>
         <div class="text-body-2 mt-2">
-          No tasks configured
+          {{ t('manager.tasks.noTasksConfigured') }}
         </div>
       </div>
-      
+
       <div v-else>
         <div class="mb-4">
           <div class="d-flex justify-space-between align-center mb-2">
-            <span class="text-body-2">Task Completion Rate</span>
-            <span class="text-body-2 font-weight-bold">{{ overallCompletionRate }}%</span>
+            <span class="text-body-2">{{
+              t('manager.tasks.taskCompletionRate')
+            }}</span>
+            <span class="text-body-2 font-weight-bold"
+              >{{ overallCompletionRate }}%</span
+            >
           </div>
-          <v-progress-linear 
-            :model-value="overallCompletionRate" 
-            color="primary" 
+          <v-progress-linear
+            :model-value="overallCompletionRate"
+            color="primary"
             height="8"
             rounded
           />
         </div>
-        
+
         <div class="mb-3">
           <div class="d-flex justify-space-between align-center">
-            <span class="text-body-2">Total Tasks</span>
-            <v-chip
-              size="small"
-              color="primary"
-              variant="outlined"
-            >
+            <span class="text-body-2">{{ t('manager.tasks.totalTasks') }}</span>
+            <v-chip size="small" color="primary" variant="outlined">
               {{ totalTasks }}
             </v-chip>
           </div>
         </div>
-        
+
         <div class="mb-3">
           <div class="d-flex justify-space-between align-center">
-            <span class="text-body-2">Avg. Task Duration</span>
-            <v-chip
-              size="small"
-              color="info"
-              variant="outlined"
-            >
+            <span class="text-body-2">{{
+              t('manager.tasks.avgTaskDuration')
+            }}</span>
+            <v-chip size="small" color="info" variant="outlined">
               {{ averageTaskDuration }}
             </v-chip>
           </div>
         </div>
-        
+
         <div class="mb-3">
           <div class="d-flex justify-space-between align-center">
-            <span class="text-body-2">Success Rate</span>
-            <v-chip
-              size="small"
-              color="success"
-              variant="outlined"
-            >
+            <span class="text-body-2">{{
+              t('manager.tasks.successRate')
+            }}</span>
+            <v-chip size="small" color="success" variant="outlined">
               {{ taskSuccessRate }}%
             </v-chip>
           </div>
         </div>
-        
+
         <!-- Task Types Summary -->
-        <div
-          v-if="taskTypes.length > 0"
-          class="mt-4"
-        >
+        <div v-if="taskTypes.length > 0" class="mt-4">
           <div class="text-caption text-medium-emphasis mb-2">
-            Task Types
+            {{ t('manager.tasks.taskTypes') }}
           </div>
           <div class="d-flex flex-wrap gap-1">
             <v-chip
@@ -132,16 +106,11 @@
         </div>
       </div>
     </v-card-text>
-    
+
     <v-card-actions v-if="hasUserTasks">
       <v-spacer />
-      <v-btn 
-        variant="text" 
-        size="small" 
-        color="primary"
-        @click="viewTasks"
-      >
-        View Tasks
+      <v-btn variant="text" size="small" color="primary" @click="viewTasks">
+        {{ t('manager.tasks.viewTasks') }}
       </v-btn>
     </v-card-actions>
   </v-card>
@@ -150,15 +119,17 @@
 <script setup>
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 
 const props = defineProps({
   test: {
     type: Object,
-    default: () => ({})
-  }
+    default: () => ({}),
+  },
 })
 
 const router = useRouter()
+const { t } = useI18n()
 
 const userTasks = computed(() => props.test?.testStructure?.userTasks || [])
 const hasUserTasks = computed(() => userTasks.value.length > 0)
@@ -171,13 +142,15 @@ const answers = computed(() => {
 
 const overallCompletionRate = computed(() => {
   if (!hasUserTasks.value || answers.value.length === 0) return 0
-  
+
   let totalAttempts = 0
   let completedAttempts = 0
-  
-  answers.value.forEach(answer => {
-    const tasks = Array.isArray(answer.tasks) ? answer.tasks : Object.values(answer.tasks || {})
-    tasks.forEach(task => {
+
+  answers.value.forEach((answer) => {
+    const tasks = Array.isArray(answer.tasks)
+      ? answer.tasks
+      : Object.values(answer.tasks || {})
+    tasks.forEach((task) => {
       if (task.attempted) {
         totalAttempts++
         if (task.completed) {
@@ -186,19 +159,23 @@ const overallCompletionRate = computed(() => {
       }
     })
   })
-  
-  return totalAttempts > 0 ? Math.round((completedAttempts / totalAttempts) * 100) : 0
+
+  return totalAttempts > 0
+    ? Math.round((completedAttempts / totalAttempts) * 100)
+    : 0
 })
 
 const taskSuccessRate = computed(() => {
   if (!hasUserTasks.value || answers.value.length === 0) return 0
-  
+
   let totalCompleted = 0
   let successfullyCompleted = 0
-  
-  answers.value.forEach(answer => {
-    const tasks = Array.isArray(answer.tasks) ? answer.tasks : Object.values(answer.tasks || {})
-    tasks.forEach(task => {
+
+  answers.value.forEach((answer) => {
+    const tasks = Array.isArray(answer.tasks)
+      ? answer.tasks
+      : Object.values(answer.tasks || {})
+    tasks.forEach((task) => {
       if (task.attempted) {
         totalCompleted++
         if (task.completed === true) {
@@ -207,28 +184,32 @@ const taskSuccessRate = computed(() => {
       }
     })
   })
-  
-  return totalCompleted > 0 ? Math.round((successfullyCompleted / totalCompleted) * 100) : 0
+
+  return totalCompleted > 0
+    ? Math.round((successfullyCompleted / totalCompleted) * 100)
+    : 0
 })
 
 const averageTaskDuration = computed(() => {
   if (!hasUserTasks.value || answers.value.length === 0) return '0 min'
-  
+
   let totalTime = 0
   let taskCount = 0
-  
-  answers.value.forEach(answer => {
-    const tasks = Array.isArray(answer.tasks) ? answer.tasks : Object.values(answer.tasks || {})
-    tasks.forEach(task => {
+
+  answers.value.forEach((answer) => {
+    const tasks = Array.isArray(answer.tasks)
+      ? answer.tasks
+      : Object.values(answer.tasks || {})
+    tasks.forEach((task) => {
       if (task.taskTime && task.attempted) {
         totalTime += task.taskTime
         taskCount++
       }
     })
   })
-  
+
   if (taskCount === 0) return '0 min'
-  
+
   const avgMs = totalTime / taskCount
   const avgMinutes = Math.round(avgMs / 1000 / 60)
   return `${avgMinutes} min`
@@ -236,30 +217,31 @@ const averageTaskDuration = computed(() => {
 
 const taskTypes = computed(() => {
   const typeCount = {}
-  
-  userTasks.value.forEach(task => {
+
+  userTasks.value.forEach((task) => {
     const type = task.taskType || 'standard'
     typeCount[type] = (typeCount[type] || 0) + 1
   })
-  
+
   return Object.entries(typeCount).map(([name, count]) => ({ name, count }))
 })
 
 const getTaskTypeColor = (type) => {
   const colors = {
     'text-area': 'blue',
-    'sus': 'green',
+    sus: 'green',
     'nasa-tlx': 'orange',
-    'sart': 'deep-blue',
+    sart: 'deep-blue',
     'post-test': 'purple',
     'post-form': 'teal',
-    'no-answer': 'grey'
+    'no-answer': 'grey',
   }
   return colors[type] || 'primary'
 }
 
 const viewTasks = () => {
-  const testType = props.test?.testType === 'USER_MODERATED' ? 'moderated' : 'unmoderated'
+  const testType =
+    props.test?.testType === 'USER_MODERATED' ? 'moderated' : 'unmoderated'
   router.push(`/userTest/${testType}/answer/${props.test.id}#tasks`)
 }
 </script>
@@ -276,7 +258,11 @@ const viewTasks = () => {
 }
 
 .tasks-header {
-  background: linear-gradient(135deg, rgb(var(--v-theme-primary)) 0%, rgb(var(--v-theme-secondary)) 100%);
+  background: linear-gradient(
+    135deg,
+    rgb(var(--v-theme-primary)) 0%,
+    rgb(var(--v-theme-secondary)) 100%
+  );
   position: relative;
   overflow: hidden;
 }
@@ -288,7 +274,8 @@ const viewTasks = () => {
   left: 0;
   right: 0;
   bottom: 0;
-  background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E") repeat;
+  background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")
+    repeat;
   opacity: 0.1;
 }
 

--- a/src/ux/UserTest/views/Unmoderated/ManagerView.vue
+++ b/src/ux/UserTest/views/Unmoderated/ManagerView.vue
@@ -23,10 +23,15 @@
                   </div>
                   <div class="flex-grow-1">
                     <h1 class="dashboard-title text-white mb-0">
-                      {{ test.testTitle || 'User Test Study' }}
+                      {{
+                        test.testTitle || t('manager.dashboard.defaultTitle')
+                      }}
                     </h1>
                     <p class="dashboard-subtitle text-white opacity-90 mb-0">
-                      {{ test.testDescription || 'User Test Study' }}
+                      {{
+                        test.testDescription ||
+                        t('manager.dashboard.defaultTitle')
+                      }}
                     </p>
                   </div>
                 </div>
@@ -40,7 +45,9 @@
                     <v-icon start size="16" color="white">
                       mdi-account-check-outline
                     </v-icon>
-                    <span class="text-white">Unmoderated Study</span>
+                    <span class="text-white">{{
+                      t('manager.dashboard.unmoderatedStudy')
+                    }}</span>
                   </v-chip>
                   <v-chip
                     class="status-chip"
@@ -52,7 +59,7 @@
                       {{ getStatusIcon(test.testStatus) }}
                     </v-icon>
                     <span class="text-white">{{
-                      test.testStatus || 'Active'
+                      test.testStatus || t('manager.dashboard.active')
                     }}</span>
                   </v-chip>
                 </div>
@@ -73,11 +80,10 @@
         <div class="section-header">
           <h2 class="section-title">
             <v-icon class="section-icon">mdi-view-dashboard</v-icon>
-            Management Modules
+            {{ t('manager.managementModules.title') }}
           </h2>
           <p class="section-description">
-            Comprehensive tools to manage participants, tasks, settings, and
-            analyze your study data
+            {{ t('manager.managementModules.description') }}
           </p>
         </div>
 
@@ -106,7 +112,9 @@
                 <v-icon size="48" class="mb-2">
                   mdi-plus-circle-outline
                 </v-icon>
-                <p class="text-body-2">Space for additional modules</p>
+                <p class="text-body-2">
+                  {{ t('manager.managementModules.additionalModules') }}
+                </p>
               </div>
             </v-card>
           </v-col>
@@ -122,6 +130,7 @@ import { ACCESS_LEVEL } from '@/shared/utils/accessLevel'
 import { computed, onMounted, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
+import { useI18n } from 'vue-i18n'
 import {
   getBottomCardsDefualt,
   getNavigatorDefault,
@@ -138,6 +147,7 @@ import StorageInfo from '@/ux/UserTest/components/manager/StorageInfo.vue'
 const store = useStore()
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 
 // Computed
 const user = computed(() => store.getters.user)


### PR DESCRIPTION
FIXES #1294 
### Summary
- Added i18n support for the Manager page
- Replaced hardcoded strings with translation keys
- Ensured consistency with existing i18n structure

### Screens / Notes
- No breaking changes

SCREENSHOTS
BEFORE
<img width="3022" height="1656" alt="image" src="https://github.com/user-attachments/assets/0ecefe98-87a1-4269-ba78-084879db2b54" />

AFTER
<img width="3022" height="1656" alt="image" src="https://github.com/user-attachments/assets/bce8f14c-0eb9-4ed6-897c-097ac7b7ba07" />
