### PR TITLE
fix : replace `npm install` to `npm ci` for better perfromance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
       - name: Cache node modules
         uses: actions/cache@v4
         env:
@@ -22,7 +27,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Test
         run: npm test


### PR DESCRIPTION
In this PR , I change the npm install to npm ci for better speed and add a stable version of node .

- Node.js LTS: Added a step to setup Node.js LTS version.
- Deterministic Install: Switched from npm install to npm ci to ensure the exact versions from package-lock.json are installed.