### PR TITLE
Fixed loading indicator in heuristic preview and answers tab

### DIFF
--- a/src/ux/Heuristic/views/HeuristicTestView.vue
+++ b/src/ux/Heuristic/views/HeuristicTestView.vue
@@ -41,12 +41,7 @@
       </v-card>
     </v-dialog>
 
-    <v-overlay v-model="loading">
-      <v-progress-circular
-        indeterminate
-        size="64"
-      />
-    </v-overlay>
+    <Loading />
 
     <v-dialog
       :model-value="fromlink && !noExistUser && !logined"
@@ -567,6 +562,7 @@ import AddCommentBtn from '@/ux/Heuristic/components/AddCommentBtn.vue'
 import HelpBtn from '@/ux/Heuristic/components/QuestionHelpBtn.vue'
 import TextClamp from 'vue3-text-clamp'
 import Snackbar from '@/shared/components/Snackbar';
+import Loading from '@/shared/components/Loading.vue'
 import HeuristicQuestionAnswer from '@/ux/Heuristic/models/HeuristicQuestionAnswer'
 import Heuristic from '@/ux/Heuristic/models/Heuristic'
 import {


### PR DESCRIPTION
fixes #1449 
before: 

https://github.com/user-attachments/assets/48ece067-9b9b-4f06-839c-53c61a485934

after:

https://github.com/user-attachments/assets/a294d27a-0fcf-456d-8ccb-af9320a29ffb



