### PR TITLE
Dashboard: real data + new user onboarding

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -1012,9 +1012,9 @@
       "progress": "Progress",
       "updated": "Last Updated on",
       "version": "Version:",
-      "noTests": "No tests found",
-      "noTemplates": "No templates found",
-      "noSessions": "No sessions found"
+      "noTests": "No studies yet. Create your first study to get started.",
+      "noTemplates": "No templates found. Create a template from an existing study or explore community templates.",
+      "noSessions": "No sessions scheduled. Sessions will appear here when you schedule moderated tests."
     },
     "navigation": {
       "dashboard": "Dashboard",

--- a/src/controllers/StudyController.js
+++ b/src/controllers/StudyController.js
@@ -24,7 +24,18 @@ export default class StudyController extends Controller {
     )
     payload.answersDocId = answerDoc.id
 
-    return await super.create(COLLECTION, payload.toFirestore())
+    const res = await super.create(COLLECTION, payload.toFirestore())
+    
+    // Link study to user
+    if (payload.testAdmin && payload.testAdmin.userDocId) {
+      await userController.addTestToUser(
+        payload.testAdmin.userDocId,
+        res.id,
+        { ...payload.toFirestore(), id: res.id }
+      )
+    }
+
+    return res
   }
   async duplicateStudy(payload) {
     try {
@@ -36,7 +47,18 @@ export default class StudyController extends Controller {
       const duplicatedStudy = payload.test
       duplicatedStudy.answersDocId = answerDoc.id
 
-      return await super.create(COLLECTION, duplicatedStudy.toFirestore())
+      const res = await super.create(COLLECTION, duplicatedStudy.toFirestore())
+
+      // Link study to user
+      if (duplicatedStudy.testAdmin && duplicatedStudy.testAdmin.userDocId) {
+        await userController.addTestToUser(
+          duplicatedStudy.testAdmin.userDocId,
+          res.id,
+          { ...duplicatedStudy.toFirestore(), id: res.id }
+        )
+      }
+
+      return res
     } catch (error) {
       throw error
     }

--- a/src/features/auth/controllers/UserController.js
+++ b/src/features/auth/controllers/UserController.js
@@ -220,6 +220,31 @@ export default class UserController extends Controller {
       throw error
     }
   }
+  async addTestToUser(userId, testId, testData) {
+    try {
+      const userDoc = await super.readOne(COLLECTION, userId)
+
+      if (!userDoc.exists()) {
+        console.log('User not found.')
+        return
+      }
+      const userData = userDoc.data()
+      
+      if (!userData.myTests) {
+        userData.myTests = {}
+      }
+
+      userData.myTests[testId] = testData
+
+      await super.update(COLLECTION, userId, userData)
+
+      console.log(`Test ${testId} added to user ${userId}'s data.`)
+    } catch (error) {
+      console.error('Error adding test to user:', error)
+      throw error
+    }
+  }
+
   async updateLevel(uid, accessLevel) {
     try {
       return super.update(COLLECTION, uid, { accessLevel })

--- a/src/features/dashboard/components/ActiveStudies.vue
+++ b/src/features/dashboard/components/ActiveStudies.vue
@@ -184,7 +184,7 @@ const studiesWithAnswers = ref([])
 const user = computed(() => store.getters.user)
 
 const studies = computed(() => {
-  return props.studies.length > 0 ? studiesWithAnswers.value : []
+  return studiesWithAnswers.value
 })
 
 const hasNoStudies = computed(() => {
@@ -316,51 +316,6 @@ const viewAllStudies = () => {
     new CustomEvent('change-section', { detail: 'studies' }),
   )
 }
-
-// Default studies if none provided
-const defaultStudies = [
-  {
-    id: 1,
-    title: 'Mobile Banking UX Study',
-    description:
-      'Evaluating user experience and accessibility of mobile banking features',
-    status: 'active',
-    progress: 75,
-    participants: 24,
-    daysLeft: 5,
-    typeIcon: 'mdi-cellphone',
-  },
-  {
-    id: 2,
-    title: 'E-commerce Card Sorting',
-    description: 'Understanding user mental models for product categorization',
-    status: 'recruiting',
-    progress: 45,
-    participants: 18,
-    daysLeft: 12,
-    typeIcon: 'mdi-sort-variant',
-  },
-  {
-    id: 3,
-    title: 'Voice Interface Testing',
-    description: 'Usability testing for voice-controlled smart home devices',
-    status: 'active',
-    progress: 90,
-    participants: 32,
-    daysLeft: 2,
-    typeIcon: 'mdi-microphone',
-  },
-  {
-    id: 4,
-    title: 'Accessibility Audit',
-    description: 'Comprehensive accessibility evaluation of web application',
-    status: 'paused',
-    progress: 30,
-    participants: 12,
-    daysLeft: 20,
-    typeIcon: 'mdi-wheelchair-accessibility',
-  },
-]
 
 const createNewStudy = () => {
   router.push({ name: 'study-create-step1' })

--- a/src/features/dashboard/views/DashboardView.vue
+++ b/src/features/dashboard/views/DashboardView.vue
@@ -9,7 +9,41 @@
         {{ $t('Dashboard.subtitle') }}
       </p>
     </div>
+  <!-- Onboarding for new users -->
+  <v-alert
+    v-if="!loading && userStudies.length === 0"
+    color="info"
+    variant="tonal"
+    icon="mdi-rocket-launch"
+    border="start"
+    class="mb-6 pa-4"
+  >
+    <div class="d-flex flex-column flex-md-row align-start align-md-center justify-space-between gap-4">
+      
+      <div>
+        <v-alert-title class="text-h6 mb-1">
+          {{ $t('Get started with your first study') }}
+        </v-alert-title>
+        
+        <p class="text-body-2 text-medium-emphasis mb-0">
+          {{ $t('Create a study, invite participants, and start collecting insights.') }}
+        </p>
+      </div>
 
+      <v-btn
+        color="primary"
+        size="default"
+        density="comfortable"
+        prepend-icon="mdi-plus"
+        to="/choose"
+        variant="flat"
+        class="text-none"
+      >
+        {{ $t('Create your first study') }}
+      </v-btn>
+
+    </div>
+  </v-alert>
     <!-- Stats Cards Row -->
     <StatsCards
       :total-studies="totalStudies"
@@ -21,12 +55,12 @@
     <v-row class="mb-6">
       <v-col cols="12" lg="8">
         <div class="component-height">
-          <ActiveStudies :studies="items" />
+          <ActiveStudies :studies="userStudies" />
         </div>
       </v-col>
       <v-col cols="12" lg="4">
         <div class="component-height">
-          <ActivityTimeline />
+          <ActivityTimeline :activities="activities" />
         </div>
       </v-col>
     </v-row>
@@ -57,6 +91,8 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
 import { useStore } from 'vuex'
+import { useRouter } from 'vue-router'
+import { formatDistanceToNow } from 'date-fns'
 import StatsCards from '@/features/dashboard/components/StatsCards.vue'
 import ActivityTimeline from '@/features/dashboard/components/ActivityTimeline.vue'
 import ActiveStudies from '@/features/dashboard/components/ActiveStudies.vue'
@@ -65,24 +101,18 @@ import UpcomingWebinar from '@/features/dashboard/components/UpcomingWebinar.vue
 import TopMethods from '@/features/dashboard/components/TopMethods.vue'
 import NextSession from '@/features/dashboard/components/NextSession.vue'
 import { getMethodDefinition } from '@/shared/constants/methodDefinitions'
-
-const props = defineProps({
-  items: {
-    type: Array,
-    required: true,
-    default: () => [],
-  },
-  sessions: {
-    type: Array,
-    required: true,
-    default: () => [],
-  },
-})
+import UserController from '@/features/auth/controllers/UserController'
 
 const store = useStore()
+const router = useRouter()
+const userController = new UserController()
 
+const items = ref([])
+const sessions = ref([])
+const activities = ref([])
 const usedStorage = ref(0)
 const nextSession = ref(null)
+const loading = ref(true)
 
 const userDisplayName = computed(() => {
   const user = store.getters.user
@@ -96,9 +126,9 @@ const userStorageUsage = computed(() => {
 
 const userStudies = computed(() => {
   const user = store.getters.user
-  if (!user || !props.items) return []
+  if (!user || !items.value) return []
 
-  return props.items.filter((study) => study?.testAdmin?.userDocId === user.id)
+  return items.value.filter((study) => study?.testAdmin?.userDocId === user.id)
 })
 
 const totalStudies = computed(() => userStudies.value.length)
@@ -144,16 +174,66 @@ const topMethodsData = computed(() => {
     }))
 })
 
+const mapNotificationsToActivities = (notifications) => {
+  if (!notifications) return []
+  // Sort by date descending
+  const sorted = [...notifications].sort((a, b) => b.createdDate - a.createdDate)
+  
+  return sorted.slice(0, 5).map((n, index) => ({
+    id: n.id || index,
+    time: n.createdDate ? formatDistanceToNow(new Date(n.createdDate), { addSuffix: true }) : '',
+    color: n.read ? 'grey' : 'primary',
+    user: {
+      name: 'System', 
+    },
+    action: 'Notification',
+    description: n.message || 'New notification',
+  }))
+}
+
+const fetchDashboardData = async () => {
+    loading.value = true
+    try {
+        const user = store.getters.user
+        if (user) {
+            // Fetch complete user data including studies
+            const completeUser = await userController.getUserWithStudies(user.id)
+            
+            // Extract studies
+            const myTests = Object.values(completeUser.myTests || {})
+            items.value = myTests
+
+             // Extract sessions from studies
+            sessions.value = myTests
+                .filter(s => s.endDate && new Date(s.endDate) > new Date())
+                .map(s => ({
+                    ...s,
+                    testDate: s.endDate 
+                }))
+            
+            // Extract activities from notifications
+            activities.value = mapNotificationsToActivities(completeUser.notifications || [])
+            
+            // Update storage if needed
+            usedStorage.value = completeUser.storageUsageMB || 0
+        }
+    } catch (error) {
+        console.error('Error fetching dashboard data:', error)
+    } finally {
+        loading.value = false
+    }
+}
+
 watch(
-  () => props.sessions,
-  (sessions) => {
-    if (!sessions?.length) {
+  () => sessions.value,
+  (newSessions) => {
+    if (!newSessions?.length) {
       nextSession.value = null
       return
     }
 
     const now = new Date()
-    const futureSessions = sessions.filter((s) => new Date(s.testDate) > now)
+    const futureSessions = newSessions.filter((s) => new Date(s.testDate) > now)
 
     if (!futureSessions.length) {
       nextSession.value = null
@@ -163,7 +243,7 @@ watch(
     futureSessions.sort((a, b) => new Date(a.testDate) - new Date(b.testDate))
     nextSession.value = futureSessions[0]
   },
-  { immediate: true, deep: true },
+  { deep: true },
 )
 
 watch(
@@ -176,6 +256,7 @@ watch(
 
 onMounted(() => {
   store.dispatch('Dashboard/fetchUpcomingWebinar')
+  fetchDashboardData()
 })
 </script>
 


### PR DESCRIPTION
This PR adds real user data to the dashboard and improves onboarding for new users. It removes hardcoded/stub data, links studies to users, and shows only the user’s actual studies and sessions. It also adds a simple onboarding prompt when no studies exist to help first-time users get started.

Overall, this makes the dashboard more accurate, useful, and less fake.

### After:

https://github.com/user-attachments/assets/629345ad-9123-41b4-a96b-8e81381867f3

## FUTURE CHANGES:
We can remove create study in sidebar and add: https://github.com/ruxailab/RUXAILAB/pull/1461
