### PR TITLE
feat(i18n): localize method filter options in Community Studies

### DIFF
--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -170,10 +170,10 @@
       "allMethods": "جميع الطرق",
       "all": "الكل",
       "heuristicEvaluation": "التقييم الإرشادي",
-      "userStudyUnmoderated": "دراسة المستخدم (غير مراقبة)",
-      "userStudyModerated": "دراسة المستخدم (مراقبة)",
-      "manualAccessibility": "إمكانية الوصول اليدوية",
-      "automaticAccessibility": "إمكانية الوصول التلقائية"
+      "moderatedUserTest": "اختبار المستخدم المراقب",
+      "unmoderatedUserTest": "اختبار المستخدم غير المراقب",
+      "accessibilityManual": "تقييم إمكانية الوصول اليدوي",
+      "accessibilityAutomatic": "تقييم إمكانية الوصول التلقائي"
     }
   },
   "notificationsPage": {

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -170,10 +170,10 @@
       "allMethods": "Alle Methoden",
       "all": "Alle",
       "heuristicEvaluation": "Heuristische Bewertung",
-      "userStudyUnmoderated": "Benutzerstudie (Unmoderiert)",
-      "userStudyModerated": "Benutzerstudie (Moderiert)",
-      "manualAccessibility": "Manuelle Barrierefreiheit",
-      "automaticAccessibility": "Automatische Barrierefreiheit"
+      "moderatedUserTest": "Moderierter Benutzertest",
+      "unmoderatedUserTest": "Unmoderierter Benutzertest",
+      "accessibilityManual": "Manuelle Barrierefreiheitsprüfung",
+      "accessibilityAutomatic": "Automatische Barrierefreiheitsprüfung"
     }
   },
   "notificationsPage": {

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -170,10 +170,10 @@
       "allMethods": "All Methods",
       "all": "All",
       "heuristicEvaluation": "Heuristic Evaluation",
-      "userStudyUnmoderated": "User Study (Unmoderated)",
-      "userStudyModerated": "User Study (Moderated)",
-      "manualAccessibility": "Manual Accessibility",
-      "automaticAccessibility": "Automatic Accessibility"
+      "moderatedUserTest": "Moderated User Test",
+      "unmoderatedUserTest": "Unmoderated User Test",
+      "accessibilityManual": "Accessibility Manual Evaluation",
+      "accessibilityAutomatic": "Accessibility Automatic Evaluation"
     }
   },
   "notificationsPage": {

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -170,10 +170,10 @@
       "allMethods": "Todos los métodos",
       "all": "Todos",
       "heuristicEvaluation": "Evaluación heurística",
-      "userStudyUnmoderated": "Estudio de usuario (No moderado)",
-      "userStudyModerated": "Estudio de usuario (Moderado)",
-      "manualAccessibility": "Accesibilidad manual",
-      "automaticAccessibility": "Accesibilidad automática"
+      "moderatedUserTest": "Prueba de usuario moderada",
+      "unmoderatedUserTest": "Prueba de usuario no moderada",
+      "accessibilityManual": "Evaluación de accesibilidad manual",
+      "accessibilityAutomatic": "Evaluación de accesibilidad automática"
     }
   },
   "notificationsPage": {

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -170,10 +170,10 @@
       "allMethods": "Toutes les méthodes",
       "all": "Tous",
       "heuristicEvaluation": "Évaluation heuristique",
-      "userStudyUnmoderated": "Étude utilisateur (Non modérée)",
-      "userStudyModerated": "Étude utilisateur (Modérée)",
-      "manualAccessibility": "Accessibilité manuelle",
-      "automaticAccessibility": "Accessibilité automatique"
+      "moderatedUserTest": "Test utilisateur modéré",
+      "unmoderatedUserTest": "Test utilisateur non modéré",
+      "accessibilityManual": "Évaluation d'accessibilité manuelle",
+      "accessibilityAutomatic": "Évaluation d'accessibilité automatique"
     }
   },
   "notificationsPage": {

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -170,10 +170,10 @@
       "allMethods": "सभी विधियाँ",
       "all": "सभी",
       "heuristicEvaluation": "हेयुरिस्टिक मूल्यांकन",
-      "userStudyUnmoderated": "उपयोगकर्ता अध्ययन (अनमोडरेटेड)",
-      "userStudyModerated": "उपयोगकर्ता अध्ययन (मोडरेटेड)",
-      "manualAccessibility": "मैन्युअल एक्सेसिबिलिटी",
-      "automaticAccessibility": "स्वचालित एक्सेसिबिलिटी"
+      "moderatedUserTest": "मोडरेटेड उपयोगकर्ता परीक्षण",
+      "unmoderatedUserTest": "अनमोडरेटेड उपयोगकर्ता परीक्षण",
+      "accessibilityManual": "एक्सेसिबिलिटी मैन्युअल मूल्यांकन",
+      "accessibilityAutomatic": "एक्सेसिबिलिटी स्वचालित मूल्यांकन"
     }
   },
   "notificationsPage": {

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -170,10 +170,10 @@
       "allMethods": "すべての方法",
       "all": "すべて",
       "heuristicEvaluation": "ヒューリスティック評価",
-      "userStudyUnmoderated": "ユーザー調査（非モデレート）",
-      "userStudyModerated": "ユーザー調査（モデレート）",
-      "manualAccessibility": "手動アクセシビリティ",
-      "automaticAccessibility": "自動アクセシビリティ"
+      "moderatedUserTest": "モデレートユーザーテスト",
+      "unmoderatedUserTest": "非モデレートユーザーテスト",
+      "accessibilityManual": "手動アクセシビリティ評価",
+      "accessibilityAutomatic": "自動アクセシビリティ評価"
     }
   },
   "notificationsPage": {

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -170,10 +170,10 @@
       "allMethods": "Todos os métodos",
       "all": "Todos",
       "heuristicEvaluation": "Avaliação heurística",
-      "userStudyUnmoderated": "Estudo de usuário (Não moderado)",
-      "userStudyModerated": "Estudo de usuário (Moderado)",
-      "manualAccessibility": "Acessibilidade manual",
-      "automaticAccessibility": "Acessibilidade automática"
+      "moderatedUserTest": "Teste de usuário moderado",
+      "unmoderatedUserTest": "Teste de usuário não moderado",
+      "accessibilityManual": "Avaliação de acessibilidade manual",
+      "accessibilityAutomatic": "Avaliação de acessibilidade automática"
     }
   },
   "notificationsPage": {

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -170,10 +170,10 @@
       "allMethods": "Все методы",
       "all": "Все",
       "heuristicEvaluation": "Эвристическая оценка",
-      "userStudyUnmoderated": "Пользовательское исследование (Немодерируемое)",
-      "userStudyModerated": "Пользовательское исследование (Модерируемое)",
-      "manualAccessibility": "Ручная доступность",
-      "automaticAccessibility": "Автоматическая доступность"
+      "moderatedUserTest": "Модерируемый пользовательский тест",
+      "unmoderatedUserTest": "Немодерируемый пользовательский тест",
+      "accessibilityManual": "Ручная оценка доступности",
+      "accessibilityAutomatic": "Автоматическая оценка доступности"
     }
   },
   "notificationsPage": {

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -170,10 +170,10 @@
       "allMethods": "所有方法",
       "all": "全部",
       "heuristicEvaluation": "启发式评估",
-      "userStudyUnmoderated": "用户研究（无主持）",
-      "userStudyModerated": "用户研究（有主持）",
-      "manualAccessibility": "手动无障碍",
-      "automaticAccessibility": "自动无障碍"
+      "moderatedUserTest": "有主持用户测试",
+      "unmoderatedUserTest": "无主持用户测试",
+      "accessibilityManual": "手动无障碍评估",
+      "accessibilityAutomatic": "自动无障碍评估"
     }
   },
   "notificationsPage": {

--- a/src/features/navigation/components/navbarSections/CommunityStudiesSection.vue
+++ b/src/features/navigation/components/navbarSections/CommunityStudiesSection.vue
@@ -27,7 +27,11 @@
         variant="tonal"
         icon
         size="small"
-        :title="showFilters ? $t('community.hideFilters') : $t('community.showFilters')"
+        :title="
+          showFilters
+            ? $t('community.hideFilters')
+            : $t('community.showFilters')
+        "
         @click="toggleFilters"
       >
         <v-icon>{{
@@ -42,7 +46,9 @@
         <v-row dense>
           <!-- 📅 Creation date -->
           <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">{{ $t('community.filters.creationDate') }}</div>
+            <div class="filter-label">
+              {{ $t('community.filters.creationDate') }}
+            </div>
             <v-menu
               :close-on-content-click="false"
               transition="scale-transition"
@@ -113,7 +119,9 @@
 
           <!-- 👥 Ownership filter -->
           <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">{{ $t('community.filters.ownership') }}</div>
+            <div class="filter-label">
+              {{ $t('community.filters.ownership') }}
+            </div>
             <v-select
               v-model="selectedOwnershipFilter"
               :items="ownershipOptions"
@@ -127,7 +135,9 @@
 
           <!-- 👤 Participants filter -->
           <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">{{ $t('community.filters.participants') }}</div>
+            <div class="filter-label">
+              {{ $t('community.filters.participants') }}
+            </div>
             <v-select
               v-model="selectedParticipantsFilter"
               :items="participantsOptions"
@@ -226,13 +236,29 @@ const hasActiveFilters = computed(() => {
 })
 
 // ===== Method options =====
-const methodOptions = computed(() => {
-  const options = getMethodOptions('es', METHOD_STATUSES.AVAILABLE.id)
-  return [
-    { value: 'all', text: t('community.method.allMethods') },
-    ...options.map((option) => ({ value: option.value, text: option.text })),
-  ]
-})
+const methodOptions = computed(() => [
+  { value: 'all', text: t('community.method.allMethods') },
+  {
+    value: METHOD_DEFINITIONS.HEURISTICS.id,
+    text: t('community.method.heuristicEvaluation'),
+  },
+  {
+    value: METHOD_DEFINITIONS.USER_MODERATED.id,
+    text: t('community.method.moderatedUserTest'),
+  },
+  {
+    value: METHOD_DEFINITIONS.USER_UNMODERATED.id,
+    text: t('community.method.unmoderatedUserTest'),
+  },
+  {
+    value: METHOD_DEFINITIONS.ACCESSIBILITY_MANUAL.id,
+    text: t('community.method.accessibilityManual'),
+  },
+  {
+    value: METHOD_DEFINITIONS.ACCESSIBILITY_AUTOMATIC.id,
+    text: t('community.method.accessibilityAutomatic'),
+  },
+])
 
 // ===== Data and filtering logic =====
 const tests = computed(() => store.getters.publicTests || [])


### PR DESCRIPTION
FIXES #1294 
## Summary
Adds i18n support for the method filter dropdown in the Community Studies page.

## Changes
- **CommunityStudiesSection.vue**: Replaced hardcoded method names with i18n translation keys
- Updated all 10 locale files with translated method options:
  - Heuristic Evaluation
  - Moderated User Test
  - Unmoderated User Test
  - Accessibility Manual Evaluation
  - Accessibility Automatic Evaluation

## Languages Updated
English, Hindi, Spanish, French, German, Portuguese (BR), Arabic, Japanese, Russian, Chinese

##SCREENSHOTS
BEFORE
<img width="1600" height="693" alt="image" src="https://github.com/user-attachments/assets/14303e4c-5865-4b01-a71f-080d78acc39e" />
AFTER
<img width="3024" height="1644" alt="image" src="https://github.com/user-attachments/assets/d9aa3ea8-27ff-43b3-b0ec-d9a5242725fe" />
