### PR TITLE
feat(i18n): add translations for Edit Test page and question/option counts

### DIFF
--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -554,6 +554,10 @@
       "failedToLoadEditForm": "فشل تحميل نموذج التحرير. يرجى المحاولة مرة أخرى.",
       "invalidHeuristic": "اختيار استدلال غير صالح",
       "invalidQuestion": "اختيار سؤال غير صالح"
+    },
+    "count": {
+      "question": "سؤال",
+      "questions": "أسئلة"
     }
   },
   "HeuristicsOptionsTable": {
@@ -565,7 +569,11 @@
       "startAddingOptions": "ابدأ بإضافة خيارات لأسئلتك التجريبية"
     },
     "placeHolders": {},
-    "actions": {}
+    "actions": {},
+    "count": {
+      "option": "خيار",
+      "options": "خيارات"
+    }
   },
   "HeuristicsWeightsTable": {
     "titles": {
@@ -613,6 +621,8 @@
     }
   },
   "HeuristicsEditTest": {
+    "pageTitle": "تحرير الاختبار",
+    "pageSubtitle": "خصص إعدادات وتفضيلات اختبارك",
     "titles": {
       "heuristics": "الاستدلالات",
       "options": "الخيارات",

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -554,6 +554,10 @@
       "failedToLoadEditForm": "Fehler beim Laden des Bearbeitungsformulars. Bitte versuchen Sie es erneut.",
       "invalidHeuristic": "Ungültige Heuristikauswahl",
       "invalidQuestion": "Ungültige Frageauswahl"
+    },
+    "count": {
+      "question": "Frage",
+      "questions": "Fragen"
     }
   },
   "HeuristicsOptionsTable": {
@@ -565,7 +569,11 @@
       "startAddingOptions": "Beginnen Sie mit dem Hinzufügen von Optionen zu Ihren heuristischen Fragen"
     },
     "placeHolders": {},
-    "actions": {}
+    "actions": {},
+    "count": {
+      "option": "Option",
+      "options": "Optionen"
+    }
   },
   "HeuristicsWeightsTable": {
     "titles": {
@@ -613,6 +621,8 @@
     }
   },
   "HeuristicsEditTest": {
+    "pageTitle": "Test bearbeiten",
+    "pageSubtitle": "Passen Sie die Einstellungen und Präferenzen Ihres Tests an",
     "titles": {
       "heuristics": "Heuristiken",
       "options": "Optionen",

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -554,6 +554,10 @@
       "failedToLoadEditForm": "Failed to load edit form. Please try again.",
       "invalidHeuristic": "Invalid heuristic selection",
       "invalidQuestion": "Invalid question selection"
+    },
+    "count": {
+      "question": "Question",
+      "questions": "Questions"
     }
   },
   "HeuristicsOptionsTable": {
@@ -565,7 +569,11 @@
       "startAddingOptions": "Start adding options to your heuristic questions"
     },
     "placeHolders": {},
-    "actions": {}
+    "actions": {},
+    "count": {
+      "option": "option",
+      "options": "options"
+    }
   },
   "HeuristicsWeightsTable": {
     "titles": {
@@ -613,6 +621,8 @@
     }
   },
   "HeuristicsEditTest": {
+    "pageTitle": "Edit Test",
+    "pageSubtitle": "Customize the settings and preferences of your test",
     "titles": {
       "heuristics": "Heuristics",
       "options": "Options",

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -554,6 +554,10 @@
       "failedToLoadEditForm": "Error al cargar el formulario de edición. Por favor, inténtalo de nuevo.",
       "invalidHeuristic": "Selección de heurística no válida",
       "invalidQuestion": "Selección de pregunta no válida"
+    },
+    "count": {
+      "question": "Pregunta",
+      "questions": "Preguntas"
     }
   },
   "HeuristicsOptionsTable": {
@@ -565,7 +569,11 @@
       "startAddingOptions": "Comience a agregar opciones a sus preguntas heurísticas"
     },
     "placeHolders": {},
-    "actions": {}
+    "actions": {},
+    "count": {
+      "option": "opción",
+      "options": "opciones"
+    }
   },
   "HeuristicsWeightsTable": {
     "titles": {
@@ -613,6 +621,8 @@
     }
   },
   "HeuristicsEditTest": {
+    "pageTitle": "Editar prueba",
+    "pageSubtitle": "Personaliza la configuración y preferencias de tu prueba",
     "titles": {
       "heuristics": "Heurísticas",
       "options": "Opciones",

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -554,6 +554,10 @@
       "failedToLoadEditForm": "Échec du chargement du formulaire d'édition. Veuillez réessayer.",
       "invalidHeuristic": "Sélection d'heuristique invalide",
       "invalidQuestion": "Sélection de question invalide"
+    },
+    "count": {
+      "question": "Question",
+      "questions": "Questions"
     }
   },
   "HeuristicsOptionsTable": {
@@ -565,7 +569,11 @@
       "startAddingOptions": "Commencez à ajouter des options à vos questions heuristiques"
     },
     "placeHolders": {},
-    "actions": {}
+    "actions": {},
+    "count": {
+      "option": "option",
+      "options": "options"
+    }
   },
   "HeuristicsWeightsTable": {
     "titles": {
@@ -613,6 +621,8 @@
     }
   },
   "HeuristicsEditTest": {
+    "pageTitle": "Modifier le test",
+    "pageSubtitle": "Personnalisez les paramètres et préférences de votre test",
     "titles": {
       "heuristics": "Heuristiques",
       "options": "Options",

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -554,6 +554,10 @@
       "failedToLoadEditForm": "संपादन फॉर्म लोड करने में विफल। कृपया पुनः प्रयास करें।",
       "invalidHeuristic": "अमान्य हीयुरिस्टिक चयन",
       "invalidQuestion": "अमान्य प्रश्न चयन"
+    },
+    "count": {
+      "question": "प्रश्न",
+      "questions": "प्रश्न"
     }
   },
   "HeuristicsOptionsTable": {
@@ -565,7 +569,11 @@
       "startAddingOptions": "अपने अनुमानी प्रश्नों में विकल्प जोड़ना शुरू करें"
     },
     "placeHolders": {},
-    "actions": {}
+    "actions": {},
+    "count": {
+      "option": "विकल्प",
+      "options": "विकल्प"
+    }
   },
   "HeuristicsWeightsTable": {
     "titles": {
@@ -613,6 +621,8 @@
     }
   },
   "HeuristicsEditTest": {
+    "pageTitle": "परीक्षण संपादित करें",
+    "pageSubtitle": "अपने परीक्षण की सेटिंग्स और प्राथमिकताओं को अनुकूलित करें",
     "titles": {
       "heuristics": "हीयुरिस्टिक्स",
       "options": "विकल्प",

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -554,6 +554,10 @@
       "failedToLoadEditForm": "編集フォームの読み込みに失敗しました。もう一度お試しください。",
       "invalidHeuristic": "無効なヒューリスティック選択です",
       "invalidQuestion": "無効な質問選択です"
+    },
+    "count": {
+      "question": "質問",
+      "questions": "質問"
     }
   },
   "HeuristicsOptionsTable": {
@@ -565,7 +569,11 @@
       "startAddingOptions": "ヒューリスティックな質問へのオプションの追加を開始してください"
     },
     "placeHolders": {},
-    "actions": {}
+    "actions": {},
+    "count": {
+      "option": "オプション",
+      "options": "オプション"
+    }
   },
   "HeuristicsWeightsTable": {
     "titles": {
@@ -613,6 +621,8 @@
     }
   },
   "HeuristicsEditTest": {
+    "pageTitle": "テストを編集",
+    "pageSubtitle": "テストの設定と環境設定をカスタマイズ",
     "titles": {
       "heuristics": "ヒューリスティック",
       "options": "オプション",

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -554,6 +554,10 @@
       "failedToLoadEditForm": "Falha ao carregar o formulário de edição. Por favor, tente novamente.",
       "invalidHeuristic": "Seleção de heurística inválida",
       "invalidQuestion": "Seleção de pergunta inválida"
+    },
+    "count": {
+      "question": "Pergunta",
+      "questions": "Perguntas"
     }
   },
   "HeuristicsOptionsTable": {
@@ -565,7 +569,11 @@
       "startAddingOptions": "Comece a adicionar opções às suas perguntas heurísticas"
     },
     "placeHolders": {},
-    "actions": {}
+    "actions": {},
+    "count": {
+      "option": "opção",
+      "options": "opções"
+    }
   },
   "HeuristicsWeightsTable": {
     "titles": {
@@ -613,6 +621,8 @@
     }
   },
   "HeuristicsEditTest": {
+    "pageTitle": "Editar teste",
+    "pageSubtitle": "Personalize as configurações e preferências do seu teste",
     "titles": {
       "heuristics": "Heurísticas",
       "options": "Opções",

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -554,6 +554,10 @@
       "failedToLoadEditForm": "Не удалось загрузить форму редактирования. Пожалуйста, попробуйте снова.",
       "invalidHeuristic": "Неверный выбор эвристики",
       "invalidQuestion": "Неверный выбор вопроса"
+    },
+    "count": {
+      "question": "Вопрос",
+      "questions": "Вопросы"
     }
   },
   "HeuristicsOptionsTable": {
@@ -565,7 +569,11 @@
       "startAddingOptions": "Начните добавлять варианты к вашим эвристическим вопросам"
     },
     "placeHolders": {},
-    "actions": {}
+    "actions": {},
+    "count": {
+      "option": "вариант",
+      "options": "варианты"
+    }
   },
   "HeuristicsWeightsTable": {
     "titles": {
@@ -613,6 +621,8 @@
     }
   },
   "HeuristicsEditTest": {
+    "pageTitle": "Редактировать тест",
+    "pageSubtitle": "Настройте параметры и предпочтения вашего теста",
     "titles": {
       "heuristics": "Эвристики",
       "options": "Варианты",

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -554,6 +554,10 @@
       "failedToLoadEditForm": "加载编辑表单失败。请重试。",
       "invalidHeuristic": "无效的启发式选择",
       "invalidQuestion": "无效的问题选择"
+    },
+    "count": {
+      "question": "问题",
+      "questions": "问题"
     }
   },
   "HeuristicsOptionsTable": {
@@ -565,7 +569,11 @@
       "startAddingOptions": "开始为您的启发式问题添加选项"
     },
     "placeHolders": {},
-    "actions": {}
+    "actions": {},
+    "count": {
+      "option": "选项",
+      "options": "选项"
+    }
   },
   "HeuristicsWeightsTable": {
     "titles": {
@@ -613,6 +621,8 @@
     }
   },
   "HeuristicsEditTest": {
+    "pageTitle": "编辑测试",
+    "pageSubtitle": "自定义测试的设置和偏好",
     "titles": {
       "heuristics": "启发式",
       "options": "选项",

--- a/src/ux/Heuristic/components/HeuristicsTable.vue
+++ b/src/ux/Heuristic/components/HeuristicsTable.vue
@@ -1,612 +1,606 @@
 <template>
+  <v-card elevation="2" class="pa-6">
+    <!-- Header Section -->
+    <div class="d-flex align-center justify-space-between mb-8 mobile-header">
+      <div>
+        <h1 class="text-h4 font-weight-bold text-on-surface">
+          {{ $t('HeuristicsTable.titles.currentHeuristics') }}
+        </h1>
+      </div>
 
-      <v-card
-        elevation="2"
-        class="pa-6"
+      <v-btn
+        color="primary"
+        prepend-icon="mdi-plus"
+        variant="elevated"
+        size="large"
+        :disabled="testAnswerDocLength > 0"
+        class="text-none add-heuristic-btn"
+        @click="dialogHeuris = true"
       >
-        <!-- Header Section -->
-        <div class="d-flex align-center justify-space-between mb-8 mobile-header">
-          <div>
-            <h1 class="text-h4 font-weight-bold text-on-surface">
-              {{ $t('HeuristicsTable.titles.currentHeuristics') }}
-            </h1>
-          </div>
-          
+        {{ $t('HeuristicsTable.titles.addNewHeuristic') }}
+      </v-btn>
+    </div>
+
+    <!-- Search Row -->
+    <v-row>
+      <v-col cols="12">
+        <v-text-field
+          v-model="search"
+          prepend-inner-icon="mdi-magnify"
+          :label="$t('HeuristicsTable.titles.searchHeuristics')"
+          variant="outlined"
+          density="comfortable"
+          hide-details
+          clearable
+          class="search-field"
+        />
+      </v-col>
+    </v-row>
+
+    <!-- Heuristics Cards -->
+    <v-row>
+      <v-col
+        v-for="(heuristic, index) in filteredHeuristics"
+        :key="heuristic.id"
+        cols="12"
+      >
+        <v-card
+          elevation="2"
+          class="heuristic-card"
+          :class="{ expanded: itemSelect === index }"
+        >
+          <!-- Heuristic Header -->
+          <v-card-title class="d-flex align-center pa-4 heuristic-header">
+            <v-btn
+              :icon="
+                itemSelect === index ? 'mdi-chevron-up' : 'mdi-chevron-down'
+              "
+              variant="text"
+              size="small"
+              class="me-3 toggle-btn"
+              @click="toggleHeuristic(index)"
+            />
+
+            <div class="flex-grow-1 heuristic-info">
+              <h3
+                class="text-h6 font-weight-medium text-on-surface heuristic-title"
+              >
+                {{ heuristic.id + 1 }} - {{ heuristic.title }}
+              </h3>
+              <p class="text-body-2 text-ternary ma-0 mt-1 question-count">
+                {{ heuristic.questions.length }}
+                {{ $t('HeuristicsTable.titles.questions') }}
+              </p>
+            </div>
+
+            <div class="d-flex gap-2 heuristic-actions">
+              <v-btn
+                icon="mdi-arrow-up"
+                variant="text"
+                size="small"
+                color="accent"
+                :disabled="index === 0 || testAnswerDocLength > 0"
+                class="action-btn"
+                @click="moveItemUp(index)"
+              >
+                <v-icon>mdi-arrow-up</v-icon>
+                <v-tooltip activator="parent" location="top">
+                  {{ $t('HeuristicsTable.titles.moveUp') }}
+                </v-tooltip>
+              </v-btn>
+              <v-btn
+                icon="mdi-arrow-down"
+                variant="text"
+                size="small"
+                color="accent"
+                :disabled="
+                  index === filteredHeuristics.length - 1 ||
+                  testAnswerDocLength > 0
+                "
+                class="action-btn"
+                @click="moveItemDown(index)"
+              >
+                <v-icon>mdi-arrow-down</v-icon>
+                <v-tooltip activator="parent" location="top">
+                  {{ $t('HeuristicsTable.titles.moveDown') }}
+                </v-tooltip>
+              </v-btn>
+              <v-btn
+                icon="mdi-plus"
+                variant="text"
+                size="small"
+                color="accent"
+                :disabled="testAnswerDocLength > 0"
+                class="action-btn"
+                @click="setupQuestion(index)"
+              >
+                <v-icon>mdi-plus</v-icon>
+                <v-tooltip activator="parent" location="top">
+                  {{ $t('HeuristicsTable.titles.addNewQuestion') }}
+                </v-tooltip>
+              </v-btn>
+              <span>
+                <v-btn
+                  icon="mdi-pencil"
+                  variant="text"
+                  size="small"
+                  color="primary"
+                  :disabled="testAnswerDocLength > 0"
+                  class="action-btn"
+                  @click="editHeuris(heuristic)"
+                >
+                  <v-icon>mdi-pencil</v-icon>
+                </v-btn>
+                <v-tooltip activator="parent" location="top">
+                  <template v-if="testAnswerDocLength > 0">
+                    This study has answers
+                  </template>
+                  <template v-else>
+                    {{ $t('HeuristicsTable.titles.editHeuristic') }}
+                  </template>
+                </v-tooltip>
+              </span>
+              <span>
+                <v-btn
+                  icon="mdi-delete"
+                  variant="text"
+                  size="small"
+                  color="error"
+                  :disabled="testAnswerDocLength > 0"
+                  class="action-btn"
+                  @click="deleteHeuristic(index)"
+                >
+                  <v-icon>mdi-delete</v-icon>
+                </v-btn>
+                <v-tooltip activator="parent" location="top">
+                  <template v-if="testAnswerDocLength > 0">
+                    This study has answers
+                  </template>
+                  <template v-else>
+                    {{ $t('HeuristicsTable.titles.deleteHeuristic') }}
+                  </template>
+                </v-tooltip>
+              </span>
+            </div>
+          </v-card-title>
+
+          <!-- Expanded Content -->
+          <v-expand-transition>
+            <div v-if="itemSelect === index">
+              <v-divider />
+              <v-card-text class="pa-4">
+                <!-- Updated Questions Header - Matches heuristic header style -->
+                <div class="d-flex align-center mb-4 questions-header">
+                  <div class="flex-grow-1">
+                    <h4 class="text-h6 font-weight-medium text-on-surface">
+                      {{ $t('HeuristicsTable.titles.questions') }}
+                    </h4>
+                  </div>
+                  <v-chip
+                    :color="
+                      heuristic.questions.length > 0 ? 'success' : 'warning'
+                    "
+                    variant="tonal"
+                    size="small"
+                    class="ms-2"
+                  >
+                    {{ heuristic.questions.length }}
+                    {{
+                      heuristic.questions.length === 1
+                        ? $t('HeuristicsTable.count.question')
+                        : $t('HeuristicsTable.count.questions')
+                    }}
+                  </v-chip>
+                </div>
+
+                <!-- Questions Grid - UPDATED STRUCTURE -->
+                <div
+                  v-if="heuristic.questions.length > 0"
+                  class="questions-list"
+                >
+                  <v-card
+                    v-for="(question, qIndex) in heuristic.questions"
+                    :key="question.id"
+                    variant="outlined"
+                    class="question-card mb-3"
+                    @click="questionSelect = qIndex"
+                  >
+                    <!-- Question Header - EXACTLY LIKE HEURISTIC HEADER -->
+                    <div class="d-flex align-center pa-3 question-header">
+                      <div
+                        class="d-flex align-center flex-grow-1 question-info"
+                      >
+                        <v-chip
+                          color="primary"
+                          variant="tonal"
+                          size="small"
+                          class="me-3 question-chip"
+                        >
+                          Q{{ qIndex + 1 }}
+                        </v-chip>
+                        <div>
+                          <h5
+                            class="text-subtitle-1 font-weight-medium text-on-surface question-title mb-0"
+                          >
+                            {{ question.title }}
+                          </h5>
+                          <!-- Optional: Add question description/subtitle if needed -->
+                          <!-- <p class="text-body-2 text-ternary ma-0 mt-1 question-desc">
+                                {{ question.description || 'No description' }}
+                              </p> -->
+                        </div>
+                      </div>
+
+                      <div class="d-flex gap-1 question-actions">
+                        <v-btn
+                          icon="mdi-pencil"
+                          variant="text"
+                          size="small"
+                          color="primary"
+                          class="action-btn"
+                          @click.stop="editQuestions(question)"
+                        />
+                        <v-btn
+                          icon="mdi-delete"
+                          variant="text"
+                          size="small"
+                          color="error"
+                          :disabled="testAnswerDocLength > 0"
+                          class="action-btn"
+                          @click.stop="deleteQuestion(qIndex)"
+                        />
+                      </div>
+                    </div>
+
+                    <!-- Question Expanded Content (for descriptions) -->
+                    <v-expand-transition>
+                      <div v-if="questionSelect === qIndex">
+                        <v-divider />
+                        <!-- Descriptions Section - UPDATED FOR RESPONSIVENESS -->
+                        <v-card class="mt-3 mx-3 mb-2 description-card">
+                          <v-card-text class="pa-3">
+                            <div
+                              class="d-flex align-center justify-space-between mb-3 description-header"
+                            >
+                              <h4 class="text-h6 text-on-surface mb-0">
+                                {{ $t('HeuristicsTable.titles.descriptions') }}
+                              </h4>
+                              <!-- Updated Add Description Button -->
+                              <AddDescBtn
+                                :ref="(el) => (descBtn[index] = el)"
+                                :question-index="questionSelect"
+                                :heuristic-index="itemSelect"
+                                class="add-desc-btn"
+                                @update-description="updateDescription"
+                              />
+                            </div>
+
+                            <!-- Responsive Data Table -->
+                            <div class="responsive-table-wrapper">
+                              <v-data-table
+                                :headers="headers"
+                                :items="
+                                  Array.isArray(
+                                    heuristic.questions[questionSelect]
+                                      ?.descriptions,
+                                  )
+                                    ? heuristic.questions[questionSelect]
+                                        .descriptions
+                                    : Object.values(
+                                        heuristic.questions[questionSelect]
+                                          ?.descriptions || {},
+                                      )
+                                "
+                                :items-per-page="5"
+                                class="elevation-0 description-table"
+                                hide-default-footer
+                              >
+                                <template #item.title="{ item }">
+                                  <div class="description-title">
+                                    {{ item.title || 'No title' }}
+                                  </div>
+                                </template>
+                                <template #item.actions="{ item }">
+                                  <div class="description-actions">
+                                    <v-btn
+                                      icon
+                                      size="small"
+                                      variant="text"
+                                      color="primary"
+                                      class="table-action-btn"
+                                      @click="editDescription(item)"
+                                    >
+                                      <v-icon size="small"> mdi-pencil </v-icon>
+                                    </v-btn>
+                                    <v-btn
+                                      icon
+                                      size="small"
+                                      variant="text"
+                                      color="error"
+                                      class="table-action-btn"
+                                      @click="deleteItem(item)"
+                                    >
+                                      <v-icon size="small"> mdi-delete </v-icon>
+                                    </v-btn>
+                                  </div>
+                                </template>
+                                <template #no-data>
+                                  <div class="text-center py-4 no-data-message">
+                                    <v-icon
+                                      icon="mdi-text-box-remove-outline"
+                                      size="48"
+                                      color="grey-lighten-1"
+                                      class="mb-2"
+                                    />
+                                    <p class="text-body-2 text-grey">
+                                      {{
+                                        $t(
+                                          'HeuristicsTable.messages.noDescriptions',
+                                        )
+                                      }}
+                                    </p>
+                                  </div>
+                                </template>
+                              </v-data-table>
+
+                              <!-- Custom Pagination for better mobile control -->
+                              <div
+                                v-if="
+                                  heuristic.questions[questionSelect]
+                                    ?.descriptions?.length > 0
+                                "
+                                class="custom-pagination"
+                              >
+                                <div
+                                  class="d-flex align-center justify-space-between flex-wrap gap-2 pa-2"
+                                >
+                                  <div
+                                    class="d-flex align-center items-per-page"
+                                  >
+                                    <span class="text-caption text-grey mr-2">
+                                      {{ $t('common.itemsPerPage') }}
+                                    </span>
+                                    <v-select
+                                      :items="[3, 5, 10, 20]"
+                                      :model-value="5"
+                                      density="compact"
+                                      variant="outlined"
+                                      hide-details
+                                      class="items-select"
+                                      @update:model-value="handleItemsPerPage"
+                                    />
+                                  </div>
+                                  <div
+                                    class="pagination-info text-caption text-grey"
+                                  >
+                                    {{
+                                      getPaginationInfo(
+                                        heuristic.questions[questionSelect]
+                                          ?.descriptions?.length || 0,
+                                      )
+                                    }}
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </v-card-text>
+                        </v-card>
+                      </div>
+                    </v-expand-transition>
+                  </v-card>
+                </div>
+
+                <!-- Empty State for Questions -->
+                <v-card
+                  v-else
+                  variant="outlined"
+                  class="text-center pa-8 empty-questions"
+                  style="border-style: dashed"
+                >
+                  <v-icon
+                    icon="mdi-help-circle-outline"
+                    size="48"
+                    color="secondary"
+                    class="mb-4"
+                  />
+                  <h4 class="text-h6 text-secondary mb-2">
+                    {{ $t('HeuristicsTable.titles.noQuestions') }}
+                  </h4>
+                  <p class="text-body-2 text-secondary mb-4 empty-state-text">
+                    {{ $t('HeuristicsTable.messages.startAddingQuestions') }}
+                  </p>
+                  <v-btn
+                    color="primary"
+                    variant="outlined"
+                    prepend-icon="mdi-plus"
+                    :disabled="testAnswerDocLength > 0"
+                    @click="setupQuestion(index)"
+                  >
+                    {{ $t('HeuristicsTable.titles.addNewQuestion') }}
+                  </v-btn>
+                </v-card>
+              </v-card-text>
+            </div>
+          </v-expand-transition>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <!-- Empty State for No Heuristics -->
+    <v-row v-if="filteredHeuristics.length === 0">
+      <v-col cols="12">
+        <v-card class="text-center pa-8 empty-heuristics" variant="outlined">
+          <v-icon
+            icon="mdi-file-remove"
+            size="64"
+            color="primary"
+            class="mb-4"
+          />
+          <h3 class="text-h5 text-ternary mb-2">
+            {{ $t('HeuristicsTable.titles.noHeuristicsFound') }}
+          </h3>
+          <p class="text-body-1 text-ternary empty-state-text">
+            {{ $t('HeuristicsTable.messages.noHeuristics') }}
+          </p>
           <v-btn
             color="primary"
+            variant="outlined"
             prepend-icon="mdi-plus"
-            variant="elevated"
-            size="large"
             :disabled="testAnswerDocLength > 0"
-            class="text-none add-heuristic-btn"
             @click="dialogHeuris = true"
           >
             {{ $t('HeuristicsTable.titles.addNewHeuristic') }}
           </v-btn>
-        </div>
+        </v-card>
+      </v-col>
+    </v-row>
 
-        <!-- Search Row -->
-        <v-row>
-          <v-col cols="12">
+    <!-- Add/Edit Heuristic Dialog -->
+    <v-dialog v-model="dialogHeuris" max-width="600" persistent>
+      <v-card>
+        <v-card-title
+          class="text-h5 pa-6"
+          style="background-color: #00213f; color: white"
+        >
+          {{ $t('HeuristicsTable.titles.creatingHeuristic') }}
+        </v-card-title>
+        <v-card-text class="pa-6">
+          <v-form ref="formHeurisRef" @keyup.enter="addHeuris">
             <v-text-field
-              v-model="search"
-              prepend-inner-icon="mdi-magnify"
-              :label="$t('HeuristicsTable.titles.searchHeuristics')"
+              v-model="heuristicForm.title"
+              :label="$t('HeuristicsTable.placeholders.titleYourHeuristic')"
               variant="outlined"
               density="comfortable"
-              hide-details
-              clearable
-              class="search-field"
+              :rules="nameRequired"
+              class="mb-4"
+              autofocus
             />
-          </v-col>
-        </v-row>
-
-        <!-- Heuristics Cards -->
-        <v-row>
-          <v-col
-            v-for="(heuristic, index) in filteredHeuristics"
-            :key="heuristic.id"
-            cols="12"
-          >
-            <v-card
-              elevation="2"
-              class="heuristic-card"
-              :class="{ 'expanded': itemSelect === index }"
-            >
-              <!-- Heuristic Header -->
-              <v-card-title class="d-flex align-center pa-4 heuristic-header">
-                <v-btn
-                  :icon="itemSelect === index ? 'mdi-chevron-up' : 'mdi-chevron-down'"
-                  variant="text"
-                  size="small"
-                  class="me-3 toggle-btn"
-                  @click="toggleHeuristic(index)"
-                />
-                
-                <div class="flex-grow-1 heuristic-info">
-                  <h3 class="text-h6 font-weight-medium text-on-surface heuristic-title">
-                    {{ heuristic.id + 1 }} - {{ heuristic.title }}
-                  </h3>
-                  <p class="text-body-2 text-ternary ma-0 mt-1 question-count">
-                    {{ heuristic.questions.length }} {{ $t('HeuristicsTable.titles.questions') }}
-                  </p>
-                </div>
-
-                <div class="d-flex gap-2 heuristic-actions">
-                  <v-btn
-                    icon="mdi-arrow-up"
-                    variant="text"
-                    size="small"
-                    color="accent"
-                    :disabled="index === 0 || testAnswerDocLength > 0"
-                    class="action-btn"
-                    @click="moveItemUp(index)"
-                  >
-                    <v-icon>mdi-arrow-up</v-icon>
-                    <v-tooltip
-                      activator="parent"
-                      location="top"
-                    >
-                      {{ $t('HeuristicsTable.titles.moveUp') }}
-                    </v-tooltip>
-                  </v-btn>
-                  <v-btn
-                    icon="mdi-arrow-down"
-                    variant="text"
-                    size="small"
-                    color="accent"
-                    :disabled="index === filteredHeuristics.length - 1 || testAnswerDocLength > 0"
-                    class="action-btn"
-                    @click="moveItemDown(index)"
-                  >
-                    <v-icon>mdi-arrow-down</v-icon>
-                    <v-tooltip
-                      activator="parent"
-                      location="top"
-                    >
-                      {{ $t('HeuristicsTable.titles.moveDown') }}
-                    </v-tooltip>
-                  </v-btn>
-                  <v-btn
-                    icon="mdi-plus"
-                    variant="text"
-                    size="small"
-                    color="accent"
-                    :disabled="testAnswerDocLength > 0"
-                    class="action-btn"
-                    @click="setupQuestion(index)"
-                  >
-                    <v-icon>mdi-plus</v-icon>
-                    <v-tooltip
-                      activator="parent"
-                      location="top"
-                    >
-                      {{ $t('HeuristicsTable.titles.addNewQuestion') }}
-                    </v-tooltip>
-                  </v-btn>
-                <span>
-                  <v-btn
-                    icon="mdi-pencil"
-                    variant="text"
-                    size="small"
-                    color="primary"
-                    :disabled="testAnswerDocLength > 0"
-                    class="action-btn"
-                    @click="editHeuris(heuristic)"
-                  >
-                    <v-icon>mdi-pencil</v-icon>
-                  </v-btn>
-                  <v-tooltip
-                    activator="parent"
-                    location="top"
-                  >
-                    <template v-if="testAnswerDocLength > 0">
-                      This study has answers
-                    </template>
-                    <template v-else>
-                      {{ $t('HeuristicsTable.titles.editHeuristic') }}
-                    </template>
-                  </v-tooltip>
-                </span>
-                <span>
-                  <v-btn
-                    icon="mdi-delete"
-                    variant="text"
-                    size="small"
-                    color="error"
-                    :disabled="testAnswerDocLength > 0"
-                    class="action-btn"
-                    @click="deleteHeuristic(index)"
-                  >
-                    <v-icon>mdi-delete</v-icon>
-                        </v-btn>
-                    <v-tooltip
-                    activator="parent"
-                    location="top"
-                  >
-                    <template v-if="testAnswerDocLength > 0">
-                      This study has answers
-                    </template>
-                    <template v-else>
-                      {{ $t('HeuristicsTable.titles.deleteHeuristic') }}
-                    </template>
-                  </v-tooltip>
-
-
-            
-                  </span>
-                </div>
-              </v-card-title>
-
-              <!-- Expanded Content -->
-              <v-expand-transition>
-                <div v-if="itemSelect === index">
-                  <v-divider />
-                  <v-card-text class="pa-4">
-                    <!-- Updated Questions Header - Matches heuristic header style -->
-                    <div class="d-flex align-center mb-4 questions-header">
-                      <div class="flex-grow-1">
-                        <h4 class="text-h6 font-weight-medium text-on-surface">
-                          {{ $t('HeuristicsTable.titles.questions') }}
-                        </h4>
-                      </div>
-                      <v-chip
-                        :color="heuristic.questions.length > 0 ? 'success' : 'warning'"
-                        variant="tonal"
-                        size="small"
-                        class="ms-2"
-                      >
-                        {{ heuristic.questions.length }} {{ heuristic.questions.length === 1 ? $t('Question') : $t('Questions') }}
-                      </v-chip>
-                    </div>
-
-                    <!-- Questions Grid - UPDATED STRUCTURE -->
-                    <div
-                      v-if="heuristic.questions.length > 0"
-                      class="questions-list"
-                    >
-                      <v-card
-                        v-for="(question, qIndex) in heuristic.questions"
-                        :key="question.id"
-                        variant="outlined"
-                        class="question-card mb-3"
-                        @click="questionSelect = qIndex"
-                      >
-                        <!-- Question Header - EXACTLY LIKE HEURISTIC HEADER -->
-                        <div class="d-flex align-center pa-3 question-header">
-                          <div class="d-flex align-center flex-grow-1 question-info">
-                            <v-chip
-                              color="primary"
-                              variant="tonal"
-                              size="small"
-                              class="me-3 question-chip"
-                            >
-                              Q{{ qIndex + 1 }}
-                            </v-chip>
-                            <div>
-                              <h5 class="text-subtitle-1 font-weight-medium text-on-surface question-title mb-0">
-                                {{ question.title }}
-                              </h5>
-                              <!-- Optional: Add question description/subtitle if needed -->
-                              <!-- <p class="text-body-2 text-ternary ma-0 mt-1 question-desc">
-                                {{ question.description || 'No description' }}
-                              </p> -->
-                            </div>
-                          </div>
-
-                          <div class="d-flex gap-1 question-actions">
-                            <v-btn
-                              icon="mdi-pencil"
-                              variant="text"
-                              size="small"
-                              color="primary"
-                              class="action-btn"
-                              @click.stop="editQuestions(question)"
-                            />
-                            <v-btn
-                              icon="mdi-delete"
-                              variant="text"
-                              size="small"
-                              color="error"
-                              :disabled="testAnswerDocLength > 0"
-                              class="action-btn"
-                              @click.stop="deleteQuestion(qIndex)"
-                            />
-                          </div>
-                        </div>
-
-                        <!-- Question Expanded Content (for descriptions) -->
-                        <v-expand-transition>
-                          <div v-if="questionSelect === qIndex">
-                            <v-divider />
-                            <!-- Descriptions Section - UPDATED FOR RESPONSIVENESS -->
-                            <v-card
-                              class="mt-3 mx-3 mb-2 description-card"
-                            >
-                              <v-card-text class="pa-3">
-                                <div class="d-flex align-center justify-space-between mb-3 description-header">
-                                  <h4 class="text-h6 text-on-surface mb-0">
-                                    {{ $t('HeuristicsTable.titles.descriptions') }}
-                                  </h4>
-                                  <!-- Updated Add Description Button -->
-                                  <AddDescBtn
-                                    :ref="el => descBtn[index] = el"
-                                    :question-index="questionSelect"
-                                    :heuristic-index="itemSelect"
-                                    class="add-desc-btn"
-                                    @update-description="updateDescription"
-                                  />
-                                </div>
-                                
-                                <!-- Responsive Data Table -->
-                                <div class="responsive-table-wrapper">
-                                  <v-data-table
-                                    :headers="headers"
-                                    :items="Array.isArray(heuristic.questions[questionSelect]?.descriptions)
-                                    ? heuristic.questions[questionSelect].descriptions
-                                    : Object.values(heuristic.questions[questionSelect]?.descriptions || {})"
-                                    :items-per-page="5"
-                                    class="elevation-0 description-table"
-                                    hide-default-footer
-                                  >
-                                    <template #item.title="{ item }">
-                                      <div class="description-title">
-                                        {{ item.title || 'No title' }}
-                                      </div>
-                                    </template>
-                                    <template #item.actions="{ item }">
-                                      <div class="description-actions">
-                                        <v-btn
-                                          icon
-                                          size="small"
-                                          variant="text"
-                                          color="primary"
-                                          class="table-action-btn"
-                                          @click="editDescription(item)"
-                                        >
-                                          <v-icon size="small">
-                                            mdi-pencil
-                                          </v-icon>
-                                        </v-btn>
-                                        <v-btn
-                                          icon
-                                          size="small"
-                                          variant="text"
-                                          color="error"
-                                          class="table-action-btn"
-                                          @click="deleteItem(item)"
-                                        >
-                                          <v-icon size="small">
-                                            mdi-delete
-                                          </v-icon>
-                                        </v-btn>
-                                      </div>
-                                    </template>
-                                    <template #no-data>
-                                      <div class="text-center py-4 no-data-message">
-                                        <v-icon
-                                          icon="mdi-text-box-remove-outline"
-                                          size="48"
-                                          color="grey-lighten-1"
-                                          class="mb-2"
-                                        />
-                                        <p class="text-body-2 text-grey">
-                                          {{ $t('HeuristicsTable.messages.noDescriptions') }}
-                                        </p>
-                                      </div>
-                                    </template>
-                                  </v-data-table>
-                                  
-                                  <!-- Custom Pagination for better mobile control -->
-                                  <div v-if="heuristic.questions[questionSelect]?.descriptions?.length > 0" class="custom-pagination">
-                                    <div class="d-flex align-center justify-space-between flex-wrap gap-2 pa-2">
-                                      <div class="d-flex align-center items-per-page">
-                                        <span class="text-caption text-grey mr-2">
-                                          {{ $t('common.itemsPerPage') }}
-                                        </span>
-                                        <v-select
-                                          :items="[3, 5, 10, 20]"
-                                          :model-value="5"
-                                          density="compact"
-                                          variant="outlined"
-                                          hide-details
-                                          class="items-select"
-                                          @update:model-value="handleItemsPerPage"
-                                        />
-                                      </div>
-                                      <div class="pagination-info text-caption text-grey">
-                                        {{ getPaginationInfo(heuristic.questions[questionSelect]?.descriptions?.length || 0) }}
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </v-card-text>
-                            </v-card>
-                          </div>
-                        </v-expand-transition>
-                      </v-card>
-                    </div>
-
-                    <!-- Empty State for Questions -->
-                    <v-card
-                      v-else
-                      variant="outlined"
-                      class="text-center pa-8 empty-questions"
-                      style="border-style: dashed;"
-                    >
-                      <v-icon
-                        icon="mdi-help-circle-outline"
-                        size="48"
-                        color="secondary"
-                        class="mb-4"
-                      />
-                      <h4 class="text-h6 text-secondary mb-2">
-                        {{ $t('HeuristicsTable.titles.noQuestions') }}
-                      </h4>
-                      <p class="text-body-2 text-secondary mb-4 empty-state-text">
-                        {{ $t('HeuristicsTable.messages.startAddingQuestions') }}
-                      </p>
-                      <v-btn
-                        color="primary"
-                        variant="outlined"
-                        prepend-icon="mdi-plus"
-                        :disabled="testAnswerDocLength > 0"
-                        @click="setupQuestion(index)"
-                      >
-                        {{ $t('HeuristicsTable.titles.addNewQuestion') }}
-                      </v-btn>
-                    </v-card>
-                  </v-card-text>
-                </div>
-              </v-expand-transition>
-            </v-card>
-          </v-col>
-        </v-row>
-
-        <!-- Empty State for No Heuristics -->
-        <v-row v-if="filteredHeuristics.length === 0">
-          <v-col cols="12">
-            <v-card
-              class="text-center pa-8 empty-heuristics"
+            <v-text-field
+              v-model="heuristicForm.questions[0].title"
+              :label="$t('HeuristicsTable.placeholders.titleYourQuestion')"
               variant="outlined"
-            >
-              <v-icon
-                icon="mdi-file-remove"
-                size="64"
-                color="primary"
-                class="mb-4"
-              />
-              <h3 class="text-h5 text-ternary mb-2">
-                {{ $t('HeuristicsTable.titles.noHeuristicsFound') }}
-              </h3>
-              <p class="text-body-1 text-ternary empty-state-text">
-                {{ $t('HeuristicsTable.messages.noHeuristics') }}
-              </p>
-              <v-btn
-                color="primary"
-                variant="outlined"
-                prepend-icon="mdi-plus"
-                :disabled="testAnswerDocLength > 0"
-                @click="dialogHeuris = true"
-              >
-                {{ $t('HeuristicsTable.titles.addNewHeuristic') }}
-              </v-btn>
-            </v-card>
-          </v-col>
-        </v-row>
-
-        <!-- Add/Edit Heuristic Dialog -->
-        <v-dialog
-          v-model="dialogHeuris"
-          max-width="600"
-          persistent
-        >
-          <v-card>
-            <v-card-title
-              class="text-h5 pa-6"
-              style="background-color: #00213F; color: white;"
-            >
-              {{ $t('HeuristicsTable.titles.creatingHeuristic') }}
-            </v-card-title>
-            <v-card-text class="pa-6">
-              <v-form
-                ref="formHeurisRef"
-                @keyup.enter="addHeuris"
-              >
-                <v-text-field
-                  v-model="heuristicForm.title"
-                  :label="$t('HeuristicsTable.placeholders.titleYourHeuristic')"
-                  variant="outlined"
-                  density="comfortable"
-                  :rules="nameRequired"
-                  class="mb-4"
-                  autofocus
-                />
-                <v-text-field
-                  v-model="heuristicForm.questions[0].title"
-                  :label="$t('HeuristicsTable.placeholders.titleYourQuestion')"
-                  variant="outlined"
-                  density="comfortable"
-                  :rules="questionRequired"
-                />
-              </v-form>
-            </v-card-text>
-            <v-card-actions class="pa-6 pt-0">
-              <v-spacer />
-              <v-btn
-                variant="text"
-                @click="closeDialog('dialogHeuris')"
-              >
-                {{ $t('HeuristicsTable.titles.cancel') }}
-              </v-btn>
-              <v-btn
-                color="primary"
-                variant="elevated"
-                @click="addHeuris"
-              >
-                {{ $t('HeuristicsTable.titles.add') }}
-              </v-btn>
-            </v-card-actions>
-          </v-card>
-        </v-dialog>
-
-        <!-- Add Question Dialog -->
-        <v-dialog
-          v-model="dialogQuestion"
-          max-width="600"
-          persistent
-        >
-          <v-card>
-            <v-card-title
-              class="text-h5 pa-6"
-              style="background-color: #fca326; color: white;"
-            >
-              {{ $t('HeuristicsTable.titles.newQuestion') }}
-            </v-card-title>
-            <v-card-text class="pa-6 pt-0">
-              <v-form
-                ref="formQuestionRef"
-                @submit.prevent="addQuestion"
-              >
-                <v-text-field
-                  v-if="dialogQuestion && newQuestion"
-                  v-model="newQuestion.title"
-                  :label="$t('HeuristicsTable.placeholders.titleNewQuestion')"
-                  variant="outlined"
-                  density="comfortable"
-                  :rules="questionRequired"
-                  autofocus
-                />
-                <v-alert v-else-if="dialogQuestion" type="error" class="mt-4">
-                  {{ $t('HeuristicsTable.errors.failedToLoadQuestionForm') }}
-                </v-alert>
-              </v-form>
-            </v-card-text>
-            <v-card-actions class="pa-6 pt-0">
-              <v-spacer />
-              <v-btn
-                variant="text"
-                @click="closeDialog('dialogQuestion')"
-              >
-                {{ $t('HeuristicsTable.titles.cancel') }}
-              </v-btn>
-              <v-btn color="primary" variant="elevated" :disabled="!newQuestion" @click="addQuestion">
-                {{ $t('HeuristicsTable.titles.add') }}
-              </v-btn>
-            </v-card-actions>
-          </v-card>
-        </v-dialog>
-
-        <!-- Edit Heuristic/Question Dialog -->
-        <v-dialog
-          v-model="dialogEdit"
-          max-width="600"
-          persistent
-        >
-          <v-card>
-            <v-card-title
-              class="text-h5 pa-6"
-              style="background-color: #fca326; color: white;"
-            >
-              {{ itemEdit && !isDialogClosing ? itemEdit.title : $t('HeuristicsTable.titles.loading') }}
-            </v-card-title>
-            <v-card-text class="pa-6 pt-0">
-              <v-form
-                ref="formEditRef"
-                @submit.prevent="validateEdit"
-              >
-                <v-text-field
-                  v-if="itemEdit && !isDialogClosing"
-                  v-model="itemEdit.titleEdit"
-                  :label="
-                    itemEdit && itemEdit.title === $t('HeuristicsTable.titles.editHeuristic')
-                      ? $t('HeuristicsTable.placeholders.titleHeuristic')
-                      : $t('HeuristicsTable.placeholders.titleQuestion')
-                  "
-                  variant="outlined"
-                  density="comfortable"
-                  :rules="itemEdit ? itemEdit.rule : []"
-                  autofocus
-                />
-                <v-alert
-                  v-else-if="dialogEdit"
-                  type="error"
-                  class="mt-4"
-                >
-                  {{ $t('HeuristicsTable.errors.failedToLoadEditForm') }}
-                </v-alert>
-              </v-form>
-            </v-card-text>
-            <v-card-actions class="pa-6 pt-0">
-              <v-spacer />
-              <v-btn
-                variant="text"
-                :disabled="isProcessing"
-                @click="closeDialog('dialogEdit')"
-              >
-                {{ $t('HeuristicsTable.titles.cancel') }}
-              </v-btn>
-              <v-btn
-                color="primary"
-                variant="elevated"
-                :disabled="isProcessing || !itemEdit || isDialogClosing"
-                @click="validateEdit"
-              >
-                {{ $t('HeuristicsTable.titles.ok') }}
-              </v-btn>
-            </v-card-actions>
-          </v-card>
-        </v-dialog>
+              density="comfortable"
+              :rules="questionRequired"
+            />
+          </v-form>
+        </v-card-text>
+        <v-card-actions class="pa-6 pt-0">
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog('dialogHeuris')">
+            {{ $t('HeuristicsTable.titles.cancel') }}
+          </v-btn>
+          <v-btn color="primary" variant="elevated" @click="addHeuris">
+            {{ $t('HeuristicsTable.titles.add') }}
+          </v-btn>
+        </v-card-actions>
       </v-card>
+    </v-dialog>
+
+    <!-- Add Question Dialog -->
+    <v-dialog v-model="dialogQuestion" max-width="600" persistent>
+      <v-card>
+        <v-card-title
+          class="text-h5 pa-6"
+          style="background-color: #fca326; color: white"
+        >
+          {{ $t('HeuristicsTable.titles.newQuestion') }}
+        </v-card-title>
+        <v-card-text class="pa-6 pt-0">
+          <v-form ref="formQuestionRef" @submit.prevent="addQuestion">
+            <v-text-field
+              v-if="dialogQuestion && newQuestion"
+              v-model="newQuestion.title"
+              :label="$t('HeuristicsTable.placeholders.titleNewQuestion')"
+              variant="outlined"
+              density="comfortable"
+              :rules="questionRequired"
+              autofocus
+            />
+            <v-alert v-else-if="dialogQuestion" type="error" class="mt-4">
+              {{ $t('HeuristicsTable.errors.failedToLoadQuestionForm') }}
+            </v-alert>
+          </v-form>
+        </v-card-text>
+        <v-card-actions class="pa-6 pt-0">
+          <v-spacer />
+          <v-btn variant="text" @click="closeDialog('dialogQuestion')">
+            {{ $t('HeuristicsTable.titles.cancel') }}
+          </v-btn>
+          <v-btn
+            color="primary"
+            variant="elevated"
+            :disabled="!newQuestion"
+            @click="addQuestion"
+          >
+            {{ $t('HeuristicsTable.titles.add') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Edit Heuristic/Question Dialog -->
+    <v-dialog v-model="dialogEdit" max-width="600" persistent>
+      <v-card>
+        <v-card-title
+          class="text-h5 pa-6"
+          style="background-color: #fca326; color: white"
+        >
+          {{
+            itemEdit && !isDialogClosing
+              ? itemEdit.title
+              : $t('HeuristicsTable.titles.loading')
+          }}
+        </v-card-title>
+        <v-card-text class="pa-6 pt-0">
+          <v-form ref="formEditRef" @submit.prevent="validateEdit">
+            <v-text-field
+              v-if="itemEdit && !isDialogClosing"
+              v-model="itemEdit.titleEdit"
+              :label="
+                itemEdit &&
+                itemEdit.title === $t('HeuristicsTable.titles.editHeuristic')
+                  ? $t('HeuristicsTable.placeholders.titleHeuristic')
+                  : $t('HeuristicsTable.placeholders.titleQuestion')
+              "
+              variant="outlined"
+              density="comfortable"
+              :rules="itemEdit ? itemEdit.rule : []"
+              autofocus
+            />
+            <v-alert v-else-if="dialogEdit" type="error" class="mt-4">
+              {{ $t('HeuristicsTable.errors.failedToLoadEditForm') }}
+            </v-alert>
+          </v-form>
+        </v-card-text>
+        <v-card-actions class="pa-6 pt-0">
+          <v-spacer />
+          <v-btn
+            variant="text"
+            :disabled="isProcessing"
+            @click="closeDialog('dialogEdit')"
+          >
+            {{ $t('HeuristicsTable.titles.cancel') }}
+          </v-btn>
+          <v-btn
+            color="primary"
+            variant="elevated"
+            :disabled="isProcessing || !itemEdit || isDialogClosing"
+            @click="validateEdit"
+          >
+            {{ $t('HeuristicsTable.titles.ok') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-card>
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted, nextTick } from 'vue';
-import { useStore } from 'vuex';
-import { useI18n } from 'vue-i18n';
-import AddDescBtn from '@/ux/Heuristic/components/AddDescBtn.vue';
+import { ref, computed, watch, onMounted, nextTick } from 'vue'
+import { useStore } from 'vuex'
+import { useI18n } from 'vue-i18n'
+import AddDescBtn from '@/ux/Heuristic/components/AddDescBtn.vue'
 import { showError, showWarning } from '@/shared/utils/toast'
-
 
 const emit = defineEmits(['change'])
 const store = useStore()
@@ -631,27 +625,40 @@ const itemsPerPage = ref(5)
 const isDialogClosing = ref(false)
 
 const headers = ref([
-  { title: t('HeuristicsTable.titles.titles'), align: 'start', value: 'title', width: '70%' },
-  { title: t('HeuristicsTable.titles.actions'), value: 'actions', align: 'end', sortable: false, width: '30%' },
+  {
+    title: t('HeuristicsTable.titles.titles'),
+    align: 'start',
+    value: 'title',
+    width: '70%',
+  },
+  {
+    title: t('HeuristicsTable.titles.actions'),
+    value: 'actions',
+    align: 'end',
+    sortable: false,
+    width: '30%',
+  },
 ])
 
-const nameRequired = ref([(v) => !!v || t('HeuristicsTable.validation.nameRequired')]);
-const questionRequired = ref([(v) => !!v || t('HeuristicsTable.validation.questionRequired')]);
+const nameRequired = ref([
+  (v) => !!v || t('HeuristicsTable.validation.nameRequired'),
+])
+const questionRequired = ref([
+  (v) => !!v || t('HeuristicsTable.validation.questionRequired'),
+])
 
-const test = computed(() => store.getters.test);
-
+const test = computed(() => store.getters.test)
 
 const heuristics = computed(() => {
-  const source =
-    store.getters.heuristics?.length
-      ? store.getters.heuristics
-      : store.state.Tests?.Test.testStructure || [];
+  const source = store.getters.heuristics?.length
+    ? store.getters.heuristics
+    : store.state.Tests?.Test.testStructure || []
 
   return Array.isArray(source)
-    ? source.map(h => ({
+    ? source.map((h) => ({
         ...h,
         questions: Array.isArray(h.questions)
-          ? h.questions.map(q => ({
+          ? h.questions.map((q) => ({
               ...q,
               descriptions: Array.isArray(q.descriptions)
                 ? q.descriptions
@@ -659,8 +666,8 @@ const heuristics = computed(() => {
             }))
           : [],
       }))
-    : [];
-});
+    : []
+})
 
 const filteredHeuristics = computed(() => {
   const searchLower = search.value.toLowerCase()
@@ -675,18 +682,19 @@ const filteredHeuristics = computed(() => {
 })
 
 const testAnswerDocLength = computed(() => {
-  return Object.keys(store.getters.testAnswerDocument?.heuristicAnswers ?? {}).length;
-});
+  return Object.keys(store.getters.testAnswerDocument?.heuristicAnswers ?? {})
+    .length
+})
 const getPaginationInfo = (totalItems) => {
-  const page = 1;
-  const start = (page - 1) * itemsPerPage.value + 1;
-  const end = Math.min(page * itemsPerPage.value, totalItems);
-  return `${start}-${end} of ${totalItems}`;
-};
+  const page = 1
+  const start = (page - 1) * itemsPerPage.value + 1
+  const end = Math.min(page * itemsPerPage.value, totalItems)
+  return `${start}-${end} of ${totalItems}`
+}
 
 const handleItemsPerPage = (value) => {
-  itemsPerPage.value = value;
-};
+  itemsPerPage.value = value
+}
 
 watch(dialogHeuris, (newVal) => {
   if (!newVal && heuristics.value.length > 0 && !itemEdit.value) {
@@ -695,8 +703,8 @@ watch(dialogHeuris, (newVal) => {
       title: '',
       total: 0,
       questions: [{ id: 0, title: '', comparison: [], descriptions: [] }],
-    };
-    heuristicForm.value.total = heuristicForm.value.questions.length;
+    }
+    heuristicForm.value.total = heuristicForm.value.questions.length
   }
   if (newVal && formHeurisRef.value) {
     formHeurisRef.value.resetValidation()
@@ -706,20 +714,22 @@ watch(dialogHeuris, (newVal) => {
 
 watch(itemSelect, (newVal) => {
   if (newVal !== null) {
-    questionSelect.value = null;
+    questionSelect.value = null
   }
-});
+})
 
 onMounted(() => {
   heuristicForm.value = {
-    id: heuristics.value.length ? heuristics.value[heuristics.value.length - 1].id + 1 : 0,
+    id: heuristics.value.length
+      ? heuristics.value[heuristics.value.length - 1].id + 1
+      : 0,
     total: 0,
     title: '',
     questions: [{ id: 0, title: '', descriptions: [], comparison: [] }],
-  };
-  store.commit("SET_HEURISTICS", heuristics.value)
-  heuristicForm.value.total = heuristicForm.value.questions.length;
-});
+  }
+  store.commit('SET_HEURISTICS', heuristics.value)
+  heuristicForm.value.total = heuristicForm.value.questions.length
+})
 
 const toggleHeuristic = (index) => {
   itemSelect.value = itemSelect.value === index ? null : index
@@ -727,62 +737,67 @@ const toggleHeuristic = (index) => {
 
 const moveItemUp = (index) => {
   if (index > 0) {
-    const newHeuristics = [...heuristics.value];
-    const itemToMove = newHeuristics[index];
-    const itemAbove = newHeuristics[index - 1];
+    const newHeuristics = [...heuristics.value]
+    const itemToMove = newHeuristics[index]
+    const itemAbove = newHeuristics[index - 1]
 
-    newHeuristics[index] = itemAbove;
-    newHeuristics[index - 1] = itemToMove;
+    newHeuristics[index] = itemAbove
+    newHeuristics[index - 1] = itemToMove
 
-    itemToMove.id = index - 1;
-    itemAbove.id = index;
+    itemToMove.id = index - 1
+    itemAbove.id = index
 
-    store.dispatch('setHeuristics', newHeuristics);
-    showWarning('HeuristicsTable.messages.changeWeights');
-    emit('change');
+    store.dispatch('setHeuristics', newHeuristics)
+    showWarning('HeuristicsTable.messages.changeWeights')
+    emit('change')
   }
 }
 
 const moveItemDown = (index) => {
   if (index < filteredHeuristics.value.length - 1) {
-    const newHeuristics = [...heuristics.value];
-    const itemToMove = newHeuristics[index];
-    const itemBelow = newHeuristics[index + 1];
+    const newHeuristics = [...heuristics.value]
+    const itemToMove = newHeuristics[index]
+    const itemBelow = newHeuristics[index + 1]
 
-    newHeuristics[index] = itemBelow;
-    newHeuristics[index + 1] = itemToMove;
+    newHeuristics[index] = itemBelow
+    newHeuristics[index + 1] = itemToMove
 
-    itemToMove.id = index + 1;
-    itemBelow.id = index;
+    itemToMove.id = index + 1
+    itemBelow.id = index
 
-    store.dispatch('setHeuristics', newHeuristics);
-    showWarning('HeuristicsTable.messages.changeWeights');
-    emit('change');
+    store.dispatch('setHeuristics', newHeuristics)
+    showWarning('HeuristicsTable.messages.changeWeights')
+    emit('change')
   }
-};
+}
 
 const deleteHeuristic = (index) => {
-  const config = confirm(`${t('alerts.deleteHeuristic')} ${heuristics.value[index].title}?`);
+  const config = confirm(
+    `${t('alerts.deleteHeuristic')} ${heuristics.value[index].title}?`,
+  )
   if (config) {
-    store.commit('REMOVE_HEURISTIC', index);
-    itemSelect.value = null;
-    questionSelect.value = null;
-    emit('change');
+    store.commit('REMOVE_HEURISTIC', index)
+    itemSelect.value = null
+    questionSelect.value = null
+    emit('change')
   }
-};
+}
 
 const deleteQuestion = (qIndex) => {
   if (heuristics.value[itemSelect.value].questions.length > 1) {
     const config = confirm(
-      `${t('alerts.deleteQuestion')} ${heuristics.value[itemSelect.value].questions[qIndex].title}?`
-    );
+      `${t('alerts.deleteQuestion')} ${
+        heuristics.value[itemSelect.value].questions[qIndex].title
+      }?`,
+    )
     if (config) {
-      const newHeuristics = [...heuristics.value];
-      newHeuristics[itemSelect.value].questions.splice(qIndex, 1);
-      newHeuristics[itemSelect.value].total = newHeuristics[itemSelect.value].questions.length;
-      store.dispatch('setHeuristics', newHeuristics);
-      questionSelect.value = null;
-      emit('change');
+      const newHeuristics = [...heuristics.value]
+      newHeuristics[itemSelect.value].questions.splice(qIndex, 1)
+      newHeuristics[itemSelect.value].total =
+        newHeuristics[itemSelect.value].questions.length
+      store.dispatch('setHeuristics', newHeuristics)
+      questionSelect.value = null
+      emit('change')
     }
   } else {
     showWarning('HeuristicsTable.messages.cantDeleteAllQuestions')
@@ -790,10 +805,10 @@ const deleteQuestion = (qIndex) => {
 }
 
 const editHeuris = (item) => {
-  const heuristicIndex = heuristics.value.findIndex(h => h.id === item.id)
+  const heuristicIndex = heuristics.value.findIndex((h) => h.id === item.id)
   if (heuristicIndex === -1) {
-    console.warn('Heuristic not found:', item);
-    showError(t('HeuristicsTable.errors.invalidHeuristic'));
+    console.warn('Heuristic not found:', item)
+    showError(t('HeuristicsTable.errors.invalidHeuristic'))
     return
   }
   itemEdit.value = {
@@ -808,21 +823,27 @@ const editHeuris = (item) => {
 
 const editQuestions = (item) => {
   if (itemSelect.value == null || !heuristics.value[itemSelect.value]) {
-    console.warn('Invalid heuristic for question edit, itemSelect:', itemSelect.value);
-    showError('HeuristicsTable.errors.invalidHeuristic');
-    return;
+    console.warn(
+      'Invalid heuristic for question edit, itemSelect:',
+      itemSelect.value,
+    )
+    showError('HeuristicsTable.errors.invalidHeuristic')
+    return
   }
   itemEdit.value = {
     title: t('HeuristicsTable.titles.editQuestion'),
     titleEdit: item.title || '',
     rule: questionRequired.value,
     id: item.id,
-  };
-  dialogEdit.value = true;
-};
+  }
+  dialogEdit.value = true
+}
 
 const editDescription = (desc) => {
-  const ind = heuristics.value[itemSelect.value].questions[questionSelect.value].descriptions.indexOf(desc)
+  const ind =
+    heuristics.value[itemSelect.value].questions[
+      questionSelect.value
+    ].descriptions.indexOf(desc)
   const btn = descBtn.value[itemSelect.value]
   if (btn && typeof btn.editSetup === 'function') {
     btn.editSetup(ind)
@@ -836,9 +857,10 @@ const setupQuestion = (heuristicIndex) => {
     showError('HeuristicsTable.errors.invalidHeuristic')
     return
   }
-  questionHeuristicIndex.value = heuristicIndex  // remember index
+  questionHeuristicIndex.value = heuristicIndex // remember index
   const questions = heuristics.value[heuristicIndex].questions || []
-  const lastQuestionId = questions.length > 0 ? questions[questions.length - 1].id : -1
+  const lastQuestionId =
+    questions.length > 0 ? questions[questions.length - 1].id : -1
   newQuestion.value = {
     id: lastQuestionId + 1,
     title: '',
@@ -849,59 +871,61 @@ const setupQuestion = (heuristicIndex) => {
 }
 
 const deleteItem = (item) => {
-  const newHeuristics = [...heuristics.value];
-  newHeuristics[itemSelect.value].questions[questionSelect.value].descriptions.splice(
-    newHeuristics[itemSelect.value].questions[questionSelect.value].descriptions.indexOf(item),
-    1
-  );
-  store.dispatch('setHeuristics', newHeuristics);
-  emit('change');
-};
+  const newHeuristics = [...heuristics.value]
+  newHeuristics[itemSelect.value].questions[
+    questionSelect.value
+  ].descriptions.splice(
+    newHeuristics[itemSelect.value].questions[
+      questionSelect.value
+    ].descriptions.indexOf(item),
+    1,
+  )
+  store.dispatch('setHeuristics', newHeuristics)
+  emit('change')
+}
 
 const addHeuris = () => {
   if (formHeurisRef.value.validate()) {
-    dialogHeuris.value = false;
-    const newHeuristics = [...heuristics.value, { ...heuristicForm.value }];
-    store.dispatch('setHeuristics', newHeuristics);
-    itemSelect.value = newHeuristics.length - 1;
-    formHeurisRef.value.resetValidation();
-    emit('change');
+    dialogHeuris.value = false
+    const newHeuristics = [...heuristics.value, { ...heuristicForm.value }]
+    store.dispatch('setHeuristics', newHeuristics)
+    itemSelect.value = newHeuristics.length - 1
+    formHeurisRef.value.resetValidation()
+    emit('change')
   }
-};
+}
 
 const closeDialog = (dialogName) => {
-  if (isProcessing.value) return;
+  if (isProcessing.value) return
   if (dialogName === 'dialogHeuris') {
     if (formHeurisRef.value) {
       formHeurisRef.value.resetValidation()
       formHeurisRef.value.reset()
     }
-    dialogHeuris.value = false;
-  }
-  else if (dialogName === 'dialogQuestion') {
-    dialogQuestion.value = false;
+    dialogHeuris.value = false
+  } else if (dialogName === 'dialogQuestion') {
+    dialogQuestion.value = false
     setTimeout(() => {
       if (formQuestionRef.value) {
-        formQuestionRef.value.resetValidation();
-        formQuestionRef.value.reset();
+        formQuestionRef.value.resetValidation()
+        formQuestionRef.value.reset()
       }
-      newQuestion.value = null;
-      questionHeuristicIndex.value = null;
-    }, 150);
-  }
-  else if (dialogName === 'dialogEdit') {
-    isDialogClosing.value = true;
+      newQuestion.value = null
+      questionHeuristicIndex.value = null
+    }, 150)
+  } else if (dialogName === 'dialogEdit') {
+    isDialogClosing.value = true
     if (formEditRef.value) {
       formEditRef.value.resetValidation()
       formEditRef.value.reset()
     }
-    dialogEdit.value = false;
+    dialogEdit.value = false
     setTimeout(() => {
-      isDialogClosing.value = false;
-      itemEdit.value = null;
-    }, 300);
+      isDialogClosing.value = false
+      itemEdit.value = null
+    }, 300)
   }
-};
+}
 
 const addQuestion = () => {
   if (!newQuestion.value || questionHeuristicIndex.value === null) {
@@ -911,8 +935,11 @@ const addQuestion = () => {
   if (formQuestionRef.value.validate()) {
     try {
       const newHeuristics = [...heuristics.value]
-      newHeuristics[questionHeuristicIndex.value].questions.push({ ...newQuestion.value })
-      newHeuristics[questionHeuristicIndex.value].total = newHeuristics[questionHeuristicIndex.value].questions.length
+      newHeuristics[questionHeuristicIndex.value].questions.push({
+        ...newQuestion.value,
+      })
+      newHeuristics[questionHeuristicIndex.value].total =
+        newHeuristics[questionHeuristicIndex.value].questions.length
       store.dispatch('setHeuristics', newHeuristics)
       closeDialog('dialogQuestion')
       emit('change')
@@ -925,52 +952,53 @@ const addQuestion = () => {
 
 const validateEdit = () => {
   if (isProcessing.value) {
-    console.warn('Validation in progress, aborting');
-    return;
+    console.warn('Validation in progress, aborting')
+    return
   }
   if (!itemEdit.value) {
-    console.warn('itemEdit is null, aborting validation');
-    dialogEdit.value = false;
-    return;
+    console.warn('itemEdit is null, aborting validation')
+    dialogEdit.value = false
+    return
   }
   if (itemSelect.value == null || !heuristics.value[itemSelect.value]) {
-    console.warn('Invalid itemSelect or heuristic not found:', itemSelect.value);
-    dialogEdit.value = false;
-    showError('HeuristicsTable.errors.invalidHeuristic');
-    return;
+    console.warn('Invalid itemSelect or heuristic not found:', itemSelect.value)
+    dialogEdit.value = false
+    showError('HeuristicsTable.errors.invalidHeuristic')
+    return
   }
-  isProcessing.value = true;
+  isProcessing.value = true
 
   if (formEditRef.value.validate()) {
-    const newHeuristics = [...heuristics.value];
+    const newHeuristics = [...heuristics.value]
     if (itemEdit.value.title === t('HeuristicsTable.titles.editHeuristic')) {
-      newHeuristics[itemSelect.value].title = itemEdit.value.titleEdit;
+      newHeuristics[itemSelect.value].title = itemEdit.value.titleEdit
     } else {
       const questionIndex = newHeuristics[itemSelect.value].questions.findIndex(
-        (q) => q.id === itemEdit.value.id
-      );
+        (q) => q.id === itemEdit.value.id,
+      )
       if (questionIndex !== -1) {
-        newHeuristics[itemSelect.value].questions[questionIndex].title = itemEdit.value.titleEdit;
+        newHeuristics[itemSelect.value].questions[questionIndex].title =
+          itemEdit.value.titleEdit
       } else {
-        console.warn('Question not found for id:', itemEdit.value.id);
+        console.warn('Question not found for id:', itemEdit.value.id)
         showError('HeuristicsTable.errors.invalidQuestion')
       }
     }
-    store.dispatch('setHeuristics', newHeuristics);
-    emit('change');
-    dialogEdit.value = false;
+    store.dispatch('setHeuristics', newHeuristics)
+    emit('change')
+    dialogEdit.value = false
     nextTick(() => {
       dialogEdit.value = false
       isProcessing.value = false
-    });
+    })
   } else {
-    isProcessing.value = false;
+    isProcessing.value = false
   }
-};
+}
 
 const updateDescription = () => {
-  emit('change');
-};
+  emit('change')
+}
 </script>
 
 <style scoped>
@@ -1271,7 +1299,7 @@ const updateDescription = () => {
   .heuristic-header {
     flex-wrap: wrap;
   }
-  
+
   .heuristic-actions {
     margin-top: 8px;
     width: 100%;
@@ -1291,31 +1319,31 @@ const updateDescription = () => {
   .v-card.pa-6 {
     padding: 12px !important;
   }
-  
+
   /* Adjust card title padding */
   .v-card-title.pa-4 {
     padding: 12px !important;
   }
-  
+
   /* Make title even smaller on very small screens */
   .text-h4.font-weight-bold.text-on-surface {
     font-size: 1.5rem !important;
   }
-  
+
   /* Adjust toggle button */
   .toggle-btn {
     min-width: 32px !important;
     width: 32px !important;
     height: 32px !important;
   }
-  
+
   /* Better text wrapping for very small screens */
   .empty-state-text {
     font-size: 13px !important; /* Smaller for iPhone */
     line-height: 1.5;
     margin-bottom: 10px !important;
   }
-  
+
   .empty-heuristics h3.text-h5 {
     font-size: 1.25rem !important;
     margin-bottom: 12px !important;
@@ -1440,12 +1468,12 @@ const updateDescription = () => {
     line-height: 1.4;
     margin-bottom: 8px !important;
   }
-  
+
   .empty-heuristics h3.text-h5 {
     font-size: 1rem !important;
     margin-bottom: 10px !important;
   }
-  
+
   /* ULTRA COMPACT button for very small screens */
   .empty-heuristics .v-btn {
     font-size: 11px !important;
@@ -1542,8 +1570,9 @@ const updateDescription = () => {
   .description-table :deep(th:first-child .v-data-table-header__content) {
     font-size: 0;
   }
-  
-  .description-table :deep(th:first-child .v-data-table-header__content::after) {
+
+  .description-table
+    :deep(th:first-child .v-data-table-header__content::after) {
     content: 'Title';
     font-size: 0.75rem;
   }

--- a/src/ux/Heuristic/components/OptionsTable.vue
+++ b/src/ux/Heuristic/components/OptionsTable.vue
@@ -1,5 +1,4 @@
 <template>
-
   <v-card elevation="2" class="pa-6">
     <!-- Header Section - Made Responsive -->
     <div class="d-flex align-center justify-space-between mb-8 mobile-header">
@@ -10,8 +9,14 @@
       </div>
 
       <v-btn
-color="primary" prepend-icon="mdi-plus" variant="elevated" size="large" :disabled="testAnswerDocLength > 0"
-        class="text-none add-option-btn" @click="dialog = true">
+        color="primary"
+        prepend-icon="mdi-plus"
+        variant="elevated"
+        size="large"
+        :disabled="testAnswerDocLength > 0"
+        class="text-none add-option-btn"
+        @click="dialog = true"
+      >
         {{ $t('HeuristicsTable.titles.addOption') }}
       </v-btn>
     </div>
@@ -20,16 +25,26 @@ color="primary" prepend-icon="mdi-plus" variant="elevated" size="large" :disable
     <!-- Options Table - Made Responsive -->
     <div class="options-table-container">
       <!-- Desktop Table View (only show when there are items) -->
-      <v-card v-if="optionsWithFormattedValue.length > 0" class="options-table-card desktop-table">
+      <v-card
+        v-if="optionsWithFormattedValue.length > 0"
+        class="options-table-card desktop-table"
+      >
         <v-data-table
-:headers="headers" :items="optionsWithFormattedValue" :items-per-page="-1"
-          class="elevation-0 options-data-table" hide-default-footer>
+          :headers="headers"
+          :items="optionsWithFormattedValue"
+          :items-per-page="-1"
+          class="elevation-0 options-data-table"
+          hide-default-footer
+        >
           <!-- Custom header styling -->
           <template #headers="{ columns }">
             <tr class="table-header">
               <th
-v-for="column in columns" :key="column.key" class="text-left font-weight-medium text-ternary pa-4"
-                :style="{ width: column.width }">
+                v-for="column in columns"
+                :key="column.key"
+                class="text-left font-weight-medium text-ternary pa-4"
+                :style="{ width: column.width }"
+              >
                 {{ column.title }}
               </th>
             </tr>
@@ -40,27 +55,47 @@ v-for="column in columns" :key="column.key" class="text-left font-weight-medium 
             <tr class="table-row">
               <td class="pa-4 title-cell">
                 <div class="cell-content">
-                  <span class="text-body-1 text-on-surface option-text">{{ item.text }}</span>
+                  <span class="text-body-1 text-on-surface option-text">{{
+                    item.text
+                  }}</span>
                 </div>
               </td>
               <td class="pa-4 description-cell">
                 <div class="cell-content">
-                  <span class="text-body-2 text-on-surface option-description">{{ item.description || '-' }}</span>
+                  <span
+                    class="text-body-2 text-on-surface option-description"
+                    >{{ item.description || '-' }}</span
+                  >
                 </div>
               </td>
               <td class="pa-4 value-cell">
                 <div class="cell-content">
-                  <span class="text-body-1 text-on-surface font-weight-medium option-value">{{ item.value }}</span>
+                  <span
+                    class="text-body-1 text-on-surface font-weight-medium option-value"
+                    >{{ item.value }}</span
+                  >
                 </div>
               </td>
               <td class="pa-4 actions-cell">
                 <div class="d-flex gap-2 option-actions">
                   <v-btn
-icon="mdi-pencil" variant="text" size="small" color="primary"
-                    :disabled="testAnswerDocLength > 0" class="table-action-btn" @click="editItem(item)" />
+                    icon="mdi-pencil"
+                    variant="text"
+                    size="small"
+                    color="primary"
+                    :disabled="testAnswerDocLength > 0"
+                    class="table-action-btn"
+                    @click="editItem(item)"
+                  />
                   <v-btn
-icon="mdi-delete" variant="text" size="small" color="error" :disabled="testAnswerDocLength > 0"
-                    class="table-action-btn" @click="deleteItem(item)" />
+                    icon="mdi-delete"
+                    variant="text"
+                    size="small"
+                    color="error"
+                    :disabled="testAnswerDocLength > 0"
+                    class="table-action-btn"
+                    @click="deleteItem(item)"
+                  />
                 </div>
               </td>
             </tr>
@@ -69,7 +104,10 @@ icon="mdi-delete" variant="text" size="small" color="error" :disabled="testAnswe
       </v-card>
 
       <!-- Desktop Empty State (outside the table) -->
-      <v-card v-if="optionsWithFormattedValue.length === 0" class="desktop-empty-state options-table-card">
+      <v-card
+        v-if="optionsWithFormattedValue.length === 0"
+        class="desktop-empty-state options-table-card"
+      >
         <div class="text-center empty-options-card--desktop" variant="outlined">
           <v-icon icon="mdi-cog-outline" class="empty-icon" color="primary" />
           <h3 class="empty-title">
@@ -83,21 +121,33 @@ icon="mdi-delete" variant="text" size="small" color="error" :disabled="testAnswe
 
       <!-- Mobile List View (similar to heuristics) -->
       <div class="mobile-options-list">
-        <div v-for="(item, index) in optionsWithFormattedValue" :key="item.timestamp" class="option-item-mobile">
+        <div
+          v-for="item in optionsWithFormattedValue"
+          :key="item.timestamp"
+          class="option-item-mobile"
+        >
           <v-card variant="outlined" class="mb-3 option-card-mobile">
             <!-- Option Header - EXACTLY LIKE HEURISTIC HEADER -->
             <div class="d-flex align-center pa-3 option-header-mobile">
               <div class="d-flex align-center flex-grow-1 option-info-mobile">
-                <v-chip color="primary" variant="tonal" size="small" class="me-3 option-chip-mobile">
+                <v-chip
+                  color="primary"
+                  variant="tonal"
+                  size="small"
+                  class="me-3 option-chip-mobile"
+                >
                   {{ item.value }}
                 </v-chip>
                 <div class="option-content-mobile">
-                  <h5 class="text-subtitle-1 font-weight-medium text-on-surface option-title-mobile mb-0">
+                  <h5
+                    class="text-subtitle-1 font-weight-medium text-on-surface option-title-mobile mb-0"
+                  >
                     {{ item.text }}
                   </h5>
                   <p
-v-if="item.description && item.description !== '-'"
-                    class="text-body-2 text-ternary ma-0 mt-1 option-desc-mobile">
+                    v-if="item.description && item.description !== '-'"
+                    class="text-body-2 text-ternary ma-0 mt-1 option-desc-mobile"
+                  >
                     {{ item.description }}
                   </p>
                 </div>
@@ -105,20 +155,43 @@ v-if="item.description && item.description !== '-'"
 
               <div class="d-flex gap-1 option-actions-mobile">
                 <v-btn
-icon="mdi-pencil" variant="text" size="small" color="primary" :disabled="testAnswerDocLength > 0"
-                  class="action-btn-mobile" @click.stop="editItem(item)" />
+                  icon="mdi-pencil"
+                  variant="text"
+                  size="small"
+                  color="primary"
+                  :disabled="testAnswerDocLength > 0"
+                  class="action-btn-mobile"
+                  @click.stop="editItem(item)"
+                />
                 <v-btn
-icon="mdi-delete" variant="text" size="small" color="error" :disabled="testAnswerDocLength > 0"
-                  class="action-btn-mobile" @click.stop="deleteItem(item)" />
+                  icon="mdi-delete"
+                  variant="text"
+                  size="small"
+                  color="error"
+                  :disabled="testAnswerDocLength > 0"
+                  class="action-btn-mobile"
+                  @click.stop="deleteItem(item)"
+                />
               </div>
             </div>
           </v-card>
         </div>
 
         <!-- Empty state for mobile -->
-        <div v-if="optionsWithFormattedValue.length === 0" class="mobile-empty-state">
-          <v-card class="text-center pa-8 empty-options-card-mobile" variant="outlined">
-            <v-icon icon="mdi-cog-outline" size="64" color="primary" class="mb-4" />
+        <div
+          v-if="optionsWithFormattedValue.length === 0"
+          class="mobile-empty-state"
+        >
+          <v-card
+            class="text-center pa-8 empty-options-card-mobile"
+            variant="outlined"
+          >
+            <v-icon
+              icon="mdi-cog-outline"
+              size="64"
+              color="primary"
+              class="mb-4"
+            />
             <h3 class="text-h6 text-ternary mb-2">
               {{ $t('HeuristicsOptionsTable.titles.noOptions') }}
             </h3>
@@ -131,16 +204,29 @@ icon="mdi-delete" variant="text" size="small" color="error" :disabled="testAnswe
 
       <!-- Footer with count -->
       <div v-if="optionsWithFormattedValue.length > 0" class="options-footer">
-        <div class="d-flex align-center justify-space-between flex-wrap gap-2 pa-3">
+        <div
+          class="d-flex align-center justify-space-between flex-wrap gap-2 pa-3"
+        >
           <div class="d-flex align-center items-count">
             <span class="text-caption text-grey">
-              {{ optionsWithFormattedValue.length }} {{ optionsWithFormattedValue.length === 1 ? 'option' : 'options' }}
+              {{ optionsWithFormattedValue.length }}
+              {{
+                optionsWithFormattedValue.length === 1
+                  ? $t('HeuristicsOptionsTable.count.option')
+                  : $t('HeuristicsOptionsTable.count.options')
+              }}
             </span>
           </div>
           <div class="d-flex align-center gap-2">
             <v-btn
-v-if="testAnswerDocLength === 0" color="primary" variant="outlined" size="small"
-              prepend-icon="mdi-plus" class="mobile-add-btn" @click="dialog = true">
+              v-if="testAnswerDocLength === 0"
+              color="primary"
+              variant="outlined"
+              size="small"
+              prepend-icon="mdi-plus"
+              class="mobile-add-btn"
+              @click="dialog = true"
+            >
               Add Option
             </v-btn>
           </div>
@@ -150,21 +236,26 @@ v-if="testAnswerDocLength === 0" color="primary" variant="outlined" size="small"
 
     <!-- AddOptionBtn Component -->
     <AddOptionBtn
-v-model:dialog="dialog" :option="option" :has-value="hasValue" @change-has-value="updateHasValue"
-      @add-option="updateOptions" @change="emitChange" />
+      v-model:dialog="dialog"
+      :option="option"
+      :has-value="hasValue"
+      @change-has-value="updateHasValue"
+      @add-option="updateOptions"
+      @change="emitChange"
+    />
   </v-card>
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue';
-import { useStore } from 'vuex';
-import { useI18n } from 'vue-i18n';
-import AddOptionBtn from '@/ux/Heuristic/components/AddOptionBtn';
+import { ref, computed, watch } from 'vue'
+import { useStore } from 'vuex'
+import { useI18n } from 'vue-i18n'
+import AddOptionBtn from '@/ux/Heuristic/components/AddOptionBtn'
 
-const store = useStore();
-const { t } = useI18n();
+const store = useStore()
+const { t } = useI18n()
 
-const emit = defineEmits(['change']);
+const emit = defineEmits(['change'])
 
 const headers = ref([
   {
@@ -192,90 +283,94 @@ const headers = ref([
     sortable: false,
     width: '25%',
   },
-]);
+])
 
 const option = ref({
   text: '',
   description: '',
   value: null,
   timestamp: null,
-});
+})
 
-const dialog = ref(false);
-const editIndex = ref(-1);
-const hasValue = ref(true);
+const dialog = ref(false)
+const editIndex = ref(-1)
+const hasValue = ref(true)
 
 const optionsWithFormattedValue = computed(() =>
   (store.state.Tests.Test.testOptions || []).map((opt) => ({
     ...opt,
     value: opt.value === null ? '-' : opt.value,
   })),
-);
+)
 
 const testAnswerDocLength = computed(() => {
   const testAnswerDocument = store.getters.testAnswerDocument
   if (!testAnswerDocument) return 0
   const heuristicAnswers = testAnswerDocument.heuristicAnswers
   return Object.keys(heuristicAnswers || {}).length
-});
+})
 
 watch(dialog, (newVal) => {
   if (!newVal) {
-    resetForm();
+    resetForm()
   }
-});
+})
 
 const updateHasValue = (newValue) => {
-  hasValue.value = newValue;
-};
+  hasValue.value = newValue
+}
 
 const updateOptions = (newOption) => {
   if (editIndex.value === -1) {
     store.state.Tests.Test.testOptions.push({
       ...newOption,
       timestamp: Date.now(),
-    });
+    })
   } else {
     store.state.Tests.Test.testOptions[editIndex.value] = {
       ...newOption,
       timestamp: store.state.Tests.Test.testOptions[editIndex.value].timestamp,
-    };
-    editIndex.value = -1;
+    }
+    editIndex.value = -1
   }
-  resetForm();
-  emitChange();
-};
+  resetForm()
+  emitChange()
+}
 
 const deleteItem = (item) => {
-  const index = store.state.Tests.Test.testOptions.findIndex((opt) => opt.timestamp === item.timestamp);
+  const index = store.state.Tests.Test.testOptions.findIndex(
+    (opt) => opt.timestamp === item.timestamp,
+  )
   if (index !== -1) {
-    store.state.Tests.Test.testOptions.splice(index, 1);
+    store.state.Tests.Test.testOptions.splice(index, 1)
   }
-  emitChange();
-};
+  emitChange()
+}
 
 const editItem = (item) => {
-  editIndex.value = store.state.Tests.Test.testOptions.findIndex((opt) => opt.timestamp === item.timestamp);
-  option.value = { ...store.state.Tests.Test.testOptions[editIndex.value] };
-  hasValue.value = option.value.value !== null;
-  dialog.value = true;
-};
+  editIndex.value = store.state.Tests.Test.testOptions.findIndex(
+    (opt) => opt.timestamp === item.timestamp,
+  )
+  option.value = { ...store.state.Tests.Test.testOptions[editIndex.value] }
+  hasValue.value = option.value.value !== null
+  dialog.value = true
+}
 
 const emitChange = () => {
-  emit('change');
-};
+  emit('change')
+}
 
 const resetForm = () => {
-  option.value = { text: '', value: null, description: '', timestamp: null };
-  hasValue.value = true;
-  editIndex.value = -1;
-};
+  option.value = { text: '', value: null, description: '', timestamp: null }
+  hasValue.value = true
+  editIndex.value = -1
+}
 </script>
 
 <style scoped>
 /* Base styles */
 .table-header {
-  background-color: #F8FAFC;
+  background-color: #f8fafc;
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 }
 
@@ -337,7 +432,6 @@ const resetForm = () => {
 
 /* Responsive styles for mobile devices */
 @media (max-width: 768px) {
-
   /* Header section */
   .mobile-header {
     flex-direction: column;
@@ -584,7 +678,6 @@ const resetForm = () => {
 
 /* Very small mobile screens */
 @media (max-width: 480px) {
-
   /* Further reduce padding */
   .v-container.fluid.pa-6,
   .v-card.pa-6 {

--- a/src/ux/Heuristic/views/EditTest.vue
+++ b/src/ux/Heuristic/views/EditTest.vue
@@ -1,19 +1,13 @@
 <template>
-  <PageWrapper
-    title="Edit Test"
-    :side-gap="true"
-  >
+  <PageWrapper :title="$t('HeuristicsEditTest.pageTitle')" :side-gap="true">
     <template #subtitle>
       <p class="text-body-1 text-grey-darken-1">
-        Customize the settings and preferences of your test
+        {{ $t('HeuristicsEditTest.pageSubtitle') }}
       </p>
     </template>
 
     <v-container>
-      <ButtonSave
-        :visible="change"
-        @click="save"
-      />
+      <ButtonSave :visible="change" @click="save" />
 
       <div>
         <!-- Desktop Tabs -->
@@ -50,14 +44,8 @@
         </v-select>
 
         <div class="mt-4">
-          <HeuristicsTable
-            v-if="index == 0"
-            @change="change = true"
-          />
-          <OptionsTable
-            v-if="index == 1"
-            @change="change = true"
-          />
+          <HeuristicsTable v-if="index == 0" @change="change = true" />
+          <OptionsTable v-if="index == 1" @change="change = true" />
           <WeightTable v-if="index == 2" />
           <HeuristicsSettings v-if="index == 3" />
         </div>
@@ -67,23 +55,23 @@
 </template>
 
 <script setup>
-import ButtonSave from '@/shared/components/buttons/ButtonSave.vue';
-import PageWrapper from '@/shared/views/template/PageWrapper.vue';
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
-import HeuristicsTable from '../components/HeuristicsTable.vue';
-import OptionsTable from '../components/OptionsTable.vue';
-import WeightTable from '../components/weights_evaluation/WeightTable.vue';
-import HeuristicsSettings from '../components/HeuristicsSettings.vue';
-import { useStore } from 'vuex';
-import { useRoute } from 'vue-router';
-import { instantiateStudyByType } from '@/shared/constants/methodDefinitions';
+import ButtonSave from '@/shared/components/buttons/ButtonSave.vue'
+import PageWrapper from '@/shared/views/template/PageWrapper.vue'
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import HeuristicsTable from '../components/HeuristicsTable.vue'
+import OptionsTable from '../components/OptionsTable.vue'
+import WeightTable from '../components/weights_evaluation/WeightTable.vue'
+import HeuristicsSettings from '../components/HeuristicsSettings.vue'
+import { useStore } from 'vuex'
+import { useRoute } from 'vue-router'
+import { instantiateStudyByType } from '@/shared/constants/methodDefinitions'
 
-const store = useStore();
-const route = useRoute();
+const store = useStore()
+const route = useRoute()
 
-const index = ref(0);
-const change = ref(false);
-const windowWidth = ref(window.innerWidth);
+const index = ref(0)
+const change = ref(false)
+const windowWidth = ref(window.innerWidth)
 
 // Tab items for mobile dropdown
 const tabItems = computed(() => [
@@ -91,36 +79,36 @@ const tabItems = computed(() => [
   { title: 'OPTIONS', value: 1 },
   { title: 'WEIGHTS', value: 2 },
   { title: 'SETTINGS', value: 3 },
-]);
+])
 
 // Check if mobile
-const isMobile = computed(() => windowWidth.value < 960);
+const isMobile = computed(() => windowWidth.value < 960)
 
 // Handle window resize
 const handleResize = () => {
-  windowWidth.value = window.innerWidth;
-};
+  windowWidth.value = window.innerWidth
+}
 
 onMounted(() => {
-  window.addEventListener('resize', handleResize);
-});
+  window.addEventListener('resize', handleResize)
+})
 
 onBeforeUnmount(() => {
-  window.removeEventListener('resize', handleResize);
-});
+  window.removeEventListener('resize', handleResize)
+})
 
 const save = async () => {
-  change.value = false;
+  change.value = false
 
   const rawData = {
     ...store.getters.test,
     testStructure: store.getters.heuristics,
     testOptions: store.state.Tests.Test.testOptions,
-    testWeights: store.getters.testWeights
-  };
+    testWeights: store.getters.testWeights,
+  }
 
-  const study = instantiateStudyByType(rawData.testType, rawData);
-  await store.dispatch('updateStudy', study);
+  const study = instantiateStudyByType(rawData.testType, rawData)
+  await store.dispatch('updateStudy', study)
   await store.dispatch('getStudy', { id: route.params.id })
 }
 </script>


### PR DESCRIPTION
FIXES #1294 
##Summary
Adds internationalization support for the Heuristic Test editing interface.

##Changes
-Localized Edit Test page title and subtitle
-Replaced hardcoded "Question/Questions" count in HeuristicsTable.vue
-Replaced hardcoded "option/options" count in OptionsTable.vue
-Added HeuristicsTable.count and HeuristicsOptionsTable.count keys to all 10 locale files

##Languages Updated
en, hi, es, fr, de, pt_br, ar, ja, ru, zh

## SCREENSHOTS
BEFORE
<img width="3024" height="1644" alt="image" src="https://github.com/user-attachments/assets/1e4dd2c7-174d-4a89-815c-063e9d400d31" />

AFTER
<img width="3024" height="1644" alt="image" src="https://github.com/user-attachments/assets/4ab1e847-0cac-4a38-88a6-780f15c0e64b" />
