### PR TITLE
fix(UserTestView): include attempted tasks in progress

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -296,8 +296,8 @@
                         taskIndex > idx
                           ? 'success'
                           : taskIndex === idx
-                          ? 'primary'
-                          : 'grey'
+                            ? 'primary'
+                            : 'grey'
                       "
                       complete-icon="mdi-check"
                     />
@@ -1002,7 +1002,10 @@ const calculateProgress = () => {
       localTestAnswer.tasks.length > 0
     ) {
       for (let i = 0; i < localTestAnswer.tasks.length; i++) {
-        if (localTestAnswer.tasks[i]?.completed) {
+        if (
+          localTestAnswer.tasks[i]?.completed ||
+          localTestAnswer.tasks[i]?.attempted
+        ) {
           tasksCompleted++
         }
       }
@@ -1265,7 +1268,9 @@ onMounted(async () => {
 
     if (data.calibrationId) {
       calibrationCompleted.value = true
-      calibrationPopup.value.close()
+      if (calibrationPopup.value) {
+        calibrationPopup.value.close()
+      }
     }
   })
 })
@@ -1354,7 +1359,8 @@ onBeforeUnmount(() => {
   --v-stepper-header-title-color: #fff !important;
   --v-stepper-item-title-color: #fff !important;
   --v-stepper-item-color: #fff !important;
-  transition: background 1s cubic-bezier(0.4, 0, 0.2, 1),
+  transition:
+    background 1s cubic-bezier(0.4, 0, 0.2, 1),
     opacity 1s cubic-bezier(0.4, 0, 0.2, 1);
 }
 


### PR DESCRIPTION
## Fix #1495

### Progress Calculation
The progress bar now counts tasks that are either **completed** or **attempted**.  
Previously, only completed tasks were included, which resulted in inaccurate progress reporting.

### Calibration Safety
Added a null guard for `calibrationPopup.value` before calling `.close()` inside `onMounted`.  
This prevents a potential runtime error when the popup reference is not yet initialized while calibration data loads.


After - 

https://github.com/user-attachments/assets/b75352f3-286c-4230-ac73-385ce74caaaf



Before -

https://github.com/user-attachments/assets/e0c0ae11-7f7e-4a53-83f9-aaf9d08ab162


