### PR TITLE
feat(ux): add sign-out confirmation dialog with i18n support

### DIFF
--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -1168,6 +1168,12 @@
     "genericSuccess": "تمت العملية بنجاح",
     "savedChanges": "تم حفظ التغييرات بنجاح"
   },
+  "dialogs": {
+    "signOutConfirm": {
+      "title": "تسجيل الخروج",
+      "message": "هل أنت متأكد أنك تريد تسجيل الخروج؟"
+    }
+  },
   "buttons": {
     "next": "التالي",
     "previous": "السابق",

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -1169,6 +1169,12 @@
     "genericSuccess": "Vorgang erfolgreich",
     "savedChanges": "Änderungen erfolgreich gespeichert"
   },
+  "dialogs": {
+    "signOutConfirm": {
+      "title": "Abmelden",
+      "message": "Sind Sie sicher, dass Sie sich abmelden möchten?"
+    }
+  },
   "buttons": {
     "next": "Weiter",
     "previous": "Zurück",

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -1168,6 +1168,12 @@
     "genericSuccess": "Operation successful",
     "savedChanges": "Changes saved successfully"
   },
+  "dialogs": {
+    "signOutConfirm": {
+      "title": "Sign Out",
+      "message": "Are you sure you want to sign out?"
+    }
+  },
   "buttons": {
     "next": "Next",
     "previous": "Previous",

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -1168,6 +1168,12 @@
     "genericSuccess": "Operación exitosa",
     "savedChanges": "Cambios guardados con éxito"
   },
+  "dialogs": {
+    "signOutConfirm": {
+      "title": "Cerrar sesión",
+      "message": "¿Estás seguro de que deseas cerrar sesión?"
+    }
+  },
   "buttons": {
     "next": "Siguiente",
     "previous": "Anterior",

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -1168,6 +1168,12 @@
     "genericSuccess": "Opération réussie",
     "savedChanges": "Modifications enregistrées avec succès"
   },
+  "dialogs": {
+    "signOutConfirm": {
+      "title": "Déconnexion",
+      "message": "Êtes-vous sûr de vouloir vous déconnecter ?"
+    }
+  },
   "buttons": {
     "next": "Suivant",
     "previous": "Précédent",

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -1168,6 +1168,12 @@
     "genericSuccess": "ऑपरेशन सफल रहा",
     "savedChanges": "परिवर्तनों को सफलतापूर्वक सहेजा गया"
   },
+  "dialogs": {
+    "signOutConfirm": {
+      "title": "साइन आउट",
+      "message": "क्या आप वाकई साइन आउट करना चाहते हैं?"
+    }
+  },
   "buttons": {
     "next": "अगला",
     "previous": "पिछला",

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -1168,6 +1168,12 @@
     "genericSuccess": "操作が成功しました",
     "savedChanges": "変更が保存されました"
   },
+  "dialogs": {
+    "signOutConfirm": {
+      "title": "ログアウト",
+      "message": "ログアウトしてもよろしいですか？"
+    }
+  },
   "buttons": {
     "next": "次へ",
     "previous": "前へ",

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -1168,6 +1168,12 @@
     "genericSuccess": "Operação bem-sucedida",
     "savedChanges": "Alterações salvas com sucesso"
   },
+  "dialogs": {
+    "signOutConfirm": {
+      "title": "Sair",
+      "message": "Tem certeza de que deseja sair?"
+    }
+  },
   "buttons": {
     "next": "Próximo",
     "previous": "Anterior",

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -1168,6 +1168,12 @@
     "genericSuccess": "Операция выполнена успешно",
     "savedChanges": "Изменения успешно сохранены"
   },
+  "dialogs": {
+    "signOutConfirm": {
+      "title": "Выход",
+      "message": "Вы уверены, что хотите выйти?"
+    }
+  },
   "buttons": {
     "next": "Далее",
     "previous": "Назад",

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -1168,6 +1168,12 @@
     "genericSuccess": "操作成功",
     "savedChanges": "更改保存成功"
   },
+  "dialogs": {
+    "signOutConfirm": {
+      "title": "退出登录",
+      "message": "您确定要退出登录吗？"
+    }
+  },
   "buttons": {
     "next": "下一步",
     "previous": "上一步",

--- a/src/features/navigation/components/UserMenu.vue
+++ b/src/features/navigation/components/UserMenu.vue
@@ -93,7 +93,10 @@
               <div
                 class="d-flex align-center px-4 py-3 rounded-lg cursor-pointer"
                 :class="{ 'error lighten-5': isHovering }"
-                @click="signOut(), (menu = false)"
+                @click="
+                  showSignOutConfirm = true
+                  menu = false
+                "
               >
                 <v-icon color="error" size="20"> mdi-logout </v-icon>
                 <span
@@ -108,6 +111,36 @@
         </div>
       </template>
     </v-menu>
+
+    <!-- Sign Out Confirmation Dialog -->
+    <v-dialog
+      v-model="showSignOutConfirm"
+      max-width="400"
+      role="dialog"
+      aria-labelledby="signout-dialog-title"
+    >
+      <v-card class="rounded-lg">
+        <v-card-title
+          id="signout-dialog-title"
+          class="text-h6 d-flex align-center"
+        >
+          <v-icon color="warning" class="mr-2">mdi-logout</v-icon>
+          {{ $t('dialogs.signOutConfirm.title') }}
+        </v-card-title>
+        <v-card-text class="text-body-1">
+          {{ $t('dialogs.signOutConfirm.message') }}
+        </v-card-text>
+        <v-card-actions class="pa-4 pt-0">
+          <v-spacer />
+          <v-btn variant="text" @click="showSignOutConfirm = false">
+            {{ $t('buttons.cancel') }}
+          </v-btn>
+          <v-btn color="error" variant="flat" @click="confirmedSignOut">
+            {{ $t('buttons.signout') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 
@@ -127,6 +160,7 @@ const store = useStore()
 const menu = ref(false)
 const username = ref(null)
 const profileImage = ref(null)
+const showSignOutConfirm = ref(false)
 
 // Computed
 const user = computed(() => store.getters.user)
@@ -178,6 +212,11 @@ const goToProfile = () => {
 const signOut = async () => {
   await store.dispatch('logout')
   router.push('/').catch(() => {})
+}
+
+const confirmedSignOut = async () => {
+  showSignOutConfirm.value = false
+  await signOut()
 }
 
 // Watchers


### PR DESCRIPTION
FIXES #1476 
Summary

Adds a confirmation dialog before signing out to prevent accidental logouts and improve user experience.

Changes
	•	Added a confirmation v-dialog in UserMenu.vue triggered on Sign out
	•	Dialog includes Cancel and Sign out actions
	•	Added accessibility attributes (role="dialog", aria-labelledby)
	•	Introduced showSignOutConfirm state and confirmSignOut handler
	•	Added localized strings under dialogs.signOutConfirm in all 10 supported languages

Testing
	•	✅ ESLint passes
	•	✅ App builds successfully
	•	✅ Dialog opens on sign-out click
	•	✅ Cancel keeps user logged in
	•	✅ Confirm signs out and redirects correctly

Screenshots
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/544b3e17-0526-401d-b387-c5daeeb23a54" />
