### PR TITLE
Fix: serialise proxy objects when saving pre-post test variables

### DIFF
--- a/src/ux/UserTest/components/UserVariables.vue
+++ b/src/ux/UserTest/components/UserVariables.vue
@@ -182,9 +182,9 @@ const allItemsValid = computed(() => {
 // to get the correct data source dynamically
 const currentVariables = computed(() => {
   if (props.type === 'pre-test') {
-    return store.getters.preTest || []
+    return store.getters['UserStudy/preTest'] || []
   } else {
-    return store.getters.postTest || []
+    return store.getters['UserStudy/postTest'] || []
   }
 })
 

--- a/src/ux/UserTest/views/EditTestView.vue
+++ b/src/ux/UserTest/views/EditTestView.vue
@@ -59,7 +59,7 @@
             <UserVariables
               type="pre-test"
               @change="change = true"
-              @update="store.dispatch('setPreTest', $event)"
+              @update="store.dispatch('UserStudy/setPreTest', $event)"
             />
           </div>
 
@@ -72,7 +72,7 @@
             <UserVariables
               type="post-test"
               @change="change = true"
-              @update="store.dispatch('setPostTest', $event)"
+              @update="store.dispatch('UserStudy/setPostTest', $event)"
             />
           </div>
 
@@ -133,17 +133,17 @@ const getConsent = () => {
 
 const getTasks = () => {
   const tasksData = test.value.testStructure.userTasks || []
-  store.dispatch('UserStudy/setTasks', JSON.parse(JSON.stringify(tasksData)))
+  store.dispatch('UserStudy/setTasks', structuredClone(tasksData))
 }
 
 const getPreTest = () => {
   const preTestData = test.value.testStructure.preTest || []
-  store.dispatch('UserStudy/setPreTest', JSON.parse(JSON.stringify(preTestData)))
+  store.dispatch('UserStudy/setPreTest', structuredClone(preTestData))
 }
 
 const getPostTest = () => {
   const postTestData = test.value.testStructure.postTest || []
-  store.dispatch('UserStudy/setPostTest', JSON.parse(JSON.stringify(postTestData)))
+  store.dispatch('UserStudy/setPostTest', structuredClone(postTestData))
 }
 
 const hasEyeTracking = computed(() => {
@@ -179,9 +179,9 @@ const save = async () => {
     const testStructure = {
       welcomeMessage: welcomeMessage.value,
       finalMessage: finalMessage.value,
-      preTest: JSON.parse(JSON.stringify(store.getters['UserStudy/preTest'])),
-      userTasks: JSON.parse(JSON.stringify(store.getters['UserStudy/tasks'])),
-      postTest: JSON.parse(JSON.stringify(store.getters['UserStudy/postTest'])),
+      preTest: structuredClone(store.getters['UserStudy/preTest']),
+      userTasks: structuredClone(store.getters['UserStudy/tasks']),
+      postTest: structuredClone(store.getters['UserStudy/postTest']),
       consent: consent.value,
     }
 

--- a/src/ux/UserTest/views/EditTestView.vue
+++ b/src/ux/UserTest/views/EditTestView.vue
@@ -132,18 +132,18 @@ const getConsent = () => {
 }
 
 const getTasks = () => {
-  store.dispatch('UserStudy/setTasks', test.value.testStructure.userTasks || [])
+  const tasksData = test.value.testStructure.userTasks || []
+  store.dispatch('UserStudy/setTasks', JSON.parse(JSON.stringify(tasksData)))
 }
 
 const getPreTest = () => {
-  store.dispatch('UserStudy/setPreTest', test.value.testStructure.preTest || [])
+  const preTestData = test.value.testStructure.preTest || []
+  store.dispatch('UserStudy/setPreTest', JSON.parse(JSON.stringify(preTestData)))
 }
 
 const getPostTest = () => {
-  store.dispatch(
-    'UserStudy/setPostTest',
-    test.value.testStructure.postTest || [],
-  )
+  const postTestData = test.value.testStructure.postTest || []
+  store.dispatch('UserStudy/setPostTest', JSON.parse(JSON.stringify(postTestData)))
 }
 
 const hasEyeTracking = computed(() => {
@@ -179,9 +179,9 @@ const save = async () => {
     const testStructure = {
       welcomeMessage: welcomeMessage.value,
       finalMessage: finalMessage.value,
-      preTest: store.getters['UserStudy/preTest'],
-      userTasks: store.getters['UserStudy/tasks'],
-      postTest: store.getters['UserStudy/postTest'],
+      preTest: JSON.parse(JSON.stringify(store.getters['UserStudy/preTest'])),
+      userTasks: JSON.parse(JSON.stringify(store.getters['UserStudy/tasks'])),
+      postTest: JSON.parse(JSON.stringify(store.getters['UserStudy/postTest'])),
       consent: consent.value,
     }
 


### PR DESCRIPTION
## Description
Fixes issue #1485 where pre-test and post-test variables are not initialized after pressing the calibration config confirmation button.

## Root Cause
1. Vue 3's reactivity system wraps reactive arrays/objects in Proxy objects. When these Proxy objects were directly dispatched to the Vuex store and saved to Firebase, they couldn't be properly serialized, causing data loss.

2. Missing Vuex namespace prefix in store dispatch/getter calls - actions were not being found in the UserStudy module.

3. Vuex store was not being cleared when switching between different tests, causing data from old tests to appear in new tests.

## Solution
1. Convert Vue Proxy objects to plain JavaScript objects using structuredClone() at two critical points:
   - When loading from database (deserialization)
   - When saving to database (serialization)

2. Add proper Vuex namespace prefix to all store dispatch/getter calls:
   - Use `store.dispatch('UserStudy/setPreTest', data)` instead of `store.dispatch('setPreTest', data)`
   - Use `store.getters['UserStudy/preTest']` instead of `store.getters.preTest`

## Changes Made
- Updated getTasks() to use structuredClone(tasksData)
- Updated getPreTest() to use structuredClone(preTestData)
- Updated getPostTest() to use structuredClone(postTestData)
- Updated save() function to use structuredClone() for testStructure serialization
- Fixed UserVariables emit dispatch to use 'UserStudy/setPreTest' and 'UserStudy/setPostTest' namespace

## BEFORE:

https://github.com/user-attachments/assets/bb58cf3d-acd2-4b4b-89ef-4c128746adb1

## AFTER:


https://github.com/user-attachments/assets/14b90fb3-3ebc-4613-b2f8-6f88824a8e0a


## Files Changed
- `src/ux/UserTest/views/EditTestView.vue`