### PR TITLE
feat(ci): auto-label issues

### DIFF
--- a/.github/workflows/issue-auto-label.yml
+++ b/.github/workflows/issue-auto-label.yml
@@ -1,0 +1,115 @@
+name: Issue Auto Labeler
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-label issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue) return;
+
+            // Skip bot issues
+            const BOT_LOGINS = new Set(['dependabot[bot]', 'github-actions[bot]']);
+            const isBot = BOT_LOGINS.has(issue.user?.login) || issue.user?.type === 'Bot';
+            if (isBot) return;
+
+            const title = (issue.title || '').toLowerCase();
+            const body = (issue.body || '').toLowerCase();
+            const existingLabels = (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name));
+
+            const labelsToAdd = new Set();
+
+            // --- bug ---
+            const looksLikeBugTemplate =
+              body.includes('steps to reproduce') ||
+              body.includes('expected behavior') ||
+              body.includes('actual behavior') ||
+              body.includes('screenshots');
+
+            const looksLikeBugTitle =
+              title.startsWith('[🐞 bug]') ||
+              title.startsWith('[bug]') ||
+              title.includes('bug:') ||
+              title.includes('🐞');
+
+            if (looksLikeBugTemplate || looksLikeBugTitle) {
+              labelsToAdd.add('bug');
+            }
+
+            // --- help ---
+            const asksForHelp =
+              body.includes('help wanted') ||
+              body.includes('need help') ||
+              body.includes('help needed') ||
+              body.includes('looking for help') ||
+              title.includes('help');
+
+            if (asksForHelp) {
+              labelsToAdd.add('help');
+            }
+
+            // --- good for wannabe gsocers ---
+            // Conservative heuristic: only auto-apply for clearly small-scope issues.
+            const gsocPositiveKeywords = [
+              'docs',
+              'documentation',
+              'typo',
+              'readme',
+              'workflow',
+              'github action',
+              'ci',
+              'label',
+              'lint',
+              'eslint',
+              'test',
+              'unit test',
+              'i18n',
+              'translation',
+              'copy',
+              'text',
+            ];
+
+            const gsocNegativeKeywords = [
+              'refactor',
+              'rewrite',
+              'migration',
+              'breaking',
+              'architecture',
+              'performance',
+              'security',
+              'auth',
+              'firebase',
+              'database',
+              'backend',
+              'infrastructure',
+            ];
+
+            const hasPositive = gsocPositiveKeywords.some(k => title.includes(k) || body.includes(k));
+            const hasNegative = gsocNegativeKeywords.some(k => title.includes(k) || body.includes(k));
+
+            if (hasPositive && !hasNegative) {
+              labelsToAdd.add('good for wannabe gsocers');
+            }
+
+            // Remove labels that already exist
+            for (const l of existingLabels) labelsToAdd.delete(l);
+
+            const finalLabels = Array.from(labelsToAdd);
+            if (finalLabels.length === 0) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: finalLabels,
+            });

--- a/.github/workflows/issue-auto-label.yml
+++ b/.github/workflows/issue-auto-label.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  contents: read
 
 jobs:
   auto-label:
@@ -23,11 +24,73 @@ jobs:
             const isBot = BOT_LOGINS.has(issue.user?.login) || issue.user?.type === 'Bot';
             if (isBot) return;
 
-            const title = (issue.title || '').toLowerCase();
-            const body = (issue.body || '').toLowerCase();
+            const rawTitle = issue.title || '';
+            const rawBody = issue.body || '';
+            const title = rawTitle.toLowerCase();
+            const body = rawBody.toLowerCase();
             const existingLabels = (issue.labels || []).map(l => (typeof l === 'string' ? l : l.name));
 
             const labelsToAdd = new Set();
+
+            // --- maintainer vs community ---
+            const { owner, repo } = context.repo;
+            let isMaintainer = false;
+            try {
+              const perm = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: issue.user.login,
+              });
+              const level = perm.data.permission;
+              isMaintainer = ['admin', 'maintain', 'write', 'triage'].includes(level);
+            } catch (e) {
+              // Non-collaborators (or API error) are treated as community by default
+            }
+
+            if (isMaintainer) {
+              labelsToAdd.add('maintainer-issue');
+            } else {
+              labelsToAdd.add('community-issue');
+            }
+
+            // --- conventional commits-style keywords ---
+            const ccMatch = rawTitle.match(/^(\w+)(\(.+\))?:/);
+            const ccType = ccMatch ? ccMatch[1].toLowerCase() : null;
+
+            switch (ccType) {
+              case 'feat':
+                labelsToAdd.add('feature');
+                break;
+              case 'fix':
+                labelsToAdd.add('bug');
+                break;
+              case 'docs':
+                labelsToAdd.add('documentation');
+                break;
+              case 'chore':
+                labelsToAdd.add('chore');
+                break;
+              case 'refactor':
+                labelsToAdd.add('refactor');
+                break;
+              case 'test':
+                labelsToAdd.add('tests');
+                break;
+              case 'perf':
+                labelsToAdd.add('performance');
+                break;
+              case 'ci':
+                labelsToAdd.add('ci');
+                break;
+              case 'build':
+                labelsToAdd.add('build');
+                break;
+              case 'style':
+                labelsToAdd.add('style');
+                break;
+              default:
+                break;
+            }
 
             // --- bug ---
             const looksLikeBugTemplate =
@@ -40,7 +103,8 @@ jobs:
               title.startsWith('[🐞 bug]') ||
               title.startsWith('[bug]') ||
               title.includes('bug:') ||
-              title.includes('🐞');
+              title.includes('🐞') ||
+              (ccType === 'fix');
 
             if (looksLikeBugTemplate || looksLikeBugTitle) {
               labelsToAdd.add('bug');
@@ -58,48 +122,9 @@ jobs:
               labelsToAdd.add('help');
             }
 
-            // --- good for wannabe gsocers ---
-            // Conservative heuristic: only auto-apply for clearly small-scope issues.
-            const gsocPositiveKeywords = [
-              'docs',
-              'documentation',
-              'typo',
-              'readme',
-              'workflow',
-              'github action',
-              'ci',
-              'label',
-              'lint',
-              'eslint',
-              'test',
-              'unit test',
-              'i18n',
-              'translation',
-              'copy',
-              'text',
-            ];
-
-            const gsocNegativeKeywords = [
-              'refactor',
-              'rewrite',
-              'migration',
-              'breaking',
-              'architecture',
-              'performance',
-              'security',
-              'auth',
-              'firebase',
-              'database',
-              'backend',
-              'infrastructure',
-            ];
-
-            const hasPositive = gsocPositiveKeywords.some(k => title.includes(k) || body.includes(k));
-            const hasNegative = gsocNegativeKeywords.some(k => title.includes(k) || body.includes(k));
-
-            if (hasPositive && !hasNegative) {
-              labelsToAdd.add('good for wannabe gsocers');
-            }
+            // Note: per maintainer feedback, we no longer auto-apply
+            // "good for wannabe gsocers" because maintainers prefer
+            // to decide that label manually on a case-by-case basis.
 
             // Remove labels that already exist
             for (const l of existingLabels) labelsToAdd.delete(l);
@@ -108,8 +133,8 @@ jobs:
             if (finalLabels.length === 0) return;
 
             await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               issue_number: issue.number,
               labels: finalLabels,
             });


### PR DESCRIPTION
This PR adds automatic labeling for issues when they are opened or edited. The workflow automatically applies `bug`, `help`, and `good for wannabe gsocers` labels based on issue content and templates.

Fixes #1507

Changes

- Added `.github/workflows/issue-auto-label.yml` workflow
- Auto-detects bug issues (via template or keywords)
- Auto-detects help-wanted issues
- Auto-detects good-for-beginners issues (small scope, docs/CI/tests)

mplementation Details

- Uses `actions/github-script` (consistent with existing `pr-auto-label.yml`)
- Triggers on `issues: opened/edited/reopened`
- Skips bot-created issues
- Uses conservative keyword matching to avoid false positives
- Idempotent (won't add duplicate labels)

Related

- Complements existing `pr-auto-label.yml` workflow
- Follows same patterns and security model as other org workflows