### PR TITLE
fix: normalize dates in daysLeft calculation

### DIFF
--- a/src/features/dashboard/components/ActiveStudies.vue
+++ b/src/features/dashboard/components/ActiveStudies.vue
@@ -76,8 +76,8 @@
                     study.status === 'active'
                       ? 'success'
                       : study.status === 'finished'
-                      ? 'warning'
-                      : 'info'
+                        ? 'warning'
+                        : 'info'
                   "
                   variant="tonal"
                   size="small"
@@ -244,6 +244,9 @@ const daysLeft = (date) => {
   const futureDate = new Date(date)
   const today = new Date()
 
+  futureDate.setHours(0, 0, 0, 0)
+  today.setHours(0, 0, 0, 0)
+
   const differenceInTime = futureDate.getTime() - today.getTime()
   const differenceInDays = differenceInTime / (1000 * 3600 * 24)
 
@@ -409,7 +412,9 @@ watch(
 <style scoped>
 .study-card {
   height: 100%;
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  transition:
+    transform 0.2s ease-in-out,
+    box-shadow 0.2s ease-in-out;
 }
 
 .study-card:hover {


### PR DESCRIPTION
### Description 📝
This PR fixes an issue where studies with an end date set to **today** were incorrectly marked as **“Expired 1 day ago”** on the dashboard.

The issue occurred because the `daysLeft` calculation used raw timestamps (including hours, minutes, and seconds), which led to incorrect results depending on the time of day and timezone.

#### Closes: #1512 

### What was changed ✅
- Normalized both the **end date** and **current date** to the start of the day (`00:00:00`) before calculating the difference.
- Ensured the calculation is based on **calendar days** rather than exact timestamps.

### Steps to Reproduce 🔄
1. Create or edit a study.
2. Set the study end date to today.
3. Open the dashboard.

### Expected Behavior 🤔
- The study should display **“Ends today”**.

### Actual Behavior 😱
- The study was displayed as **“Expired 1 day ago”**.

### Impact 🎯
- Prevents premature expiration messages.
- Ensures consistent behavior across different timezones and times of day.

### Screenshots/Recording

https://github.com/user-attachments/assets/7004e143-aaf1-43a7-8703-859b994083da


### Additional Information ℹ️
This change only affects date comparison logic and does not modify existing study data.