### PR TITLE
feat(user-test): add step-based PostTest question flow

### DIFF
--- a/src/ux/UserTest/components/steps/PostTestStep.vue
+++ b/src/ux/UserTest/components/steps/PostTestStep.vue
@@ -1,40 +1,40 @@
 <template>
-  <ShowInfo :title="testTitle + ' - ' + 'PosTest'">
+  <ShowInfo :title="testTitle + ' - ' + 'PostTest'">
     <template #content>
       <div class="test-content pa-4 rounded-xl">
-        <div
-          v-for="(item, i) in postTest"
-          :key="i"
-          class="mb-6"
-        >
-          <v-col
-            cols="12"
-            class="py-0"
-          >
-            <span class="text-subtitle-1 font-weight-bold text-secondary">{{ item.title }}</span>
-            <br>
-            <span
-              v-if="item.description"
-              class="text-body-2 text-grey-darken-1"
-            >{{ item.description
+        <!-- Step Indicator -->
+        <div class="text-center mb-4 text-grey">
+          Question {{ step + 1 }} / {{ postTest.length }}
+        </div>
+
+        <div class="mb-6">
+          <v-col cols="12" class="py-0">
+            <span class="text-subtitle-1 font-weight-bold text-secondary">{{
+              currentItem.title
             }}</span>
+            <br />
+            <span
+              v-if="currentItem.description"
+              class="text-body-2 text-grey-darken-1"
+              >{{ currentItem.description }}</span
+            >
             <v-text-field
-              v-if="item.textField"
-              v-model="localAnswers[i].answer"
-              :placeholder="item.title"
+              v-if="currentItem.textField"
+              v-model="localAnswers[step].answer"
+              :placeholder="'Type your answer here…'"
               variant="outlined"
               density="comfortable"
               class="mt-2"
-              @update:model-value="updateAnswer(i, $event)"
+              @update:model-value="updateAnswer(step, $event)"
             />
             <v-radio-group
-              v-if="item.selectionField"
-              v-model="localAnswers[i].answer"
+              v-if="currentItem.selectionField"
+              v-model="localAnswers[step].answer"
               class="mt-2"
-              @update:model-value="updateAnswer(i, $event)"
+              @update:model-value="updateAnswer(step, $event)"
             >
               <v-radio
-                v-for="(selection, j) in item.selectionFields"
+                v-for="(selection, j) in currentItem.selectionFields"
                 :key="j"
                 :label="selection"
                 :value="selection"
@@ -43,20 +43,17 @@
             </v-radio-group>
           </v-col>
         </div>
-        <v-row
-          justify="center"
-          class="mt-4"
-        >
-          <v-col
-            cols="12"
-            md="6"
-          >
-            <v-btn
-              block
-              color="primary"
-              variant="flat"
-              @click="$emit('done')"
-            >
+        <v-row justify="space-between" class="mt-4">
+          <v-col cols="auto">
+            <v-btn variant="outlined" :disabled="step === 0" @click="prev">
+              Previous
+            </v-btn>
+          </v-col>
+          <v-col cols="auto">
+            <v-btn v-if="!isLastStep" color="primary" @click="next">
+              Next
+            </v-btn>
+            <v-btn v-else color="primary" variant="flat" @click="$emit('done')">
               Done
             </v-btn>
           </v-col>
@@ -67,8 +64,8 @@
 </template>
 
 <script setup>
-import ShowInfo from '@/shared/components/ShowInfo.vue';
-import { ref, watch } from 'vue';
+import ShowInfo from '@/shared/components/ShowInfo.vue'
+import { ref, computed, watch } from 'vue'
 
 const props = defineProps({
   testTitle: String,
@@ -76,20 +73,36 @@ const props = defineProps({
   postTest: Array,
   postTestAnswer: Array,
   postTestCompleted: Boolean,
-});
+})
 
-const emit = defineEmits(['done', 'update:postTestAnswer']);
+const emit = defineEmits(['done', 'update:postTestAnswer'])
 
-const localAnswers = ref([...props.postTestAnswer]);
+const step = ref(0)
+const localAnswers = ref([...props.postTestAnswer])
+
+const currentItem = computed(() => props.postTest[step.value])
+const isLastStep = computed(() => step.value === props.postTest.length - 1)
+
+const next = () => {
+  if (step.value < props.postTest.length - 1) step.value++
+}
+
+const prev = () => {
+  if (step.value > 0) step.value--
+}
 
 const updateAnswer = (index, value) => {
-  localAnswers.value[index].answer = value;
-  emit('update:postTestAnswer', localAnswers.value);
-};
+  localAnswers.value[index].answer = value
+  emit('update:postTestAnswer', localAnswers.value)
+}
 
-watch(() => props.postTestAnswer, (newAnswers) => {
-  if (newAnswers) {
-    localAnswers.value = [...newAnswers];
-  }
-}, { deep: true, immediate: true });
+watch(
+  () => props.postTestAnswer,
+  (newAnswers) => {
+    if (newAnswers) {
+      localAnswers.value = [...newAnswers]
+    }
+  },
+  { deep: true, immediate: true },
+)
 </script>

--- a/src/ux/UserTest/components/steps/PostTestStep.vue
+++ b/src/ux/UserTest/components/steps/PostTestStep.vue
@@ -1,63 +1,109 @@
 <template>
   <ShowInfo :title="testTitle + ' - ' + 'PostTest'">
     <template #content>
-      <div class="test-content pa-4 rounded-xl">
-        <!-- Step Indicator -->
-        <div class="text-center mb-4 text-grey">
-          Question {{ step + 1 }} / {{ postTest.length }}
-        </div>
+      <div class="test-content pa-2 pa-sm-4">
+        <v-sheet rounded="xl" border class="pa-4 pa-sm-6">
+          <div class="d-flex align-center justify-space-between mb-4">
+            <v-chip
+              color="primary"
+              variant="tonal"
+              size="small"
+              class="font-weight-bold"
+            >
+              Question {{ step + 1 }}
+            </v-chip>
+            <span class="text-caption text-medium-emphasis"
+              >{{ postTest.length }} total</span
+            >
+          </div>
 
-        <div class="mb-6">
-          <v-col cols="12" class="py-0">
-            <span class="text-subtitle-1 font-weight-bold text-secondary">{{
-              currentItem.title
-            }}</span>
-            <br />
-            <span
+          <v-progress-linear
+            :model-value="progressPercentage"
+            color="primary"
+            height="8"
+            rounded
+            class="mb-7"
+          />
+
+          <div class="question-shell mx-auto mb-8">
+            <h2
+              class="text-h4 text-sm-h3 font-weight-bold text-secondary text-center mb-3"
+            >
+              {{ currentItem.title }}
+            </h2>
+            <p
               v-if="currentItem.description"
-              class="text-body-2 text-grey-darken-1"
-              >{{ currentItem.description }}</span
+              class="text-subtitle-1 text-center text-medium-emphasis mb-6"
             >
-            <v-text-field
-              v-if="currentItem.textField"
-              v-model="localAnswers[step].answer"
-              :placeholder="'Type your answer here…'"
-              variant="outlined"
-              density="comfortable"
-              class="mt-2"
-              @update:model-value="updateAnswer(step, $event)"
-            />
-            <v-radio-group
-              v-if="currentItem.selectionField"
-              v-model="localAnswers[step].answer"
-              class="mt-2"
-              @update:model-value="updateAnswer(step, $event)"
-            >
-              <v-radio
-                v-for="(selection, j) in currentItem.selectionFields"
-                :key="j"
-                :label="selection"
-                :value="selection"
-                density="compact"
+              {{ currentItem.description }}
+            </p>
+
+            <div v-if="currentItem.textField" class="answer-field-wrap mx-auto">
+              <v-text-field
+                v-model="localAnswers[step].answer"
+                :placeholder="'Type your answer here…'"
+                variant="outlined"
+                density="comfortable"
+                rounded="lg"
+                hide-details="auto"
+                class="answer-input"
+                @update:model-value="updateAnswer(step, $event)"
               />
-            </v-radio-group>
-          </v-col>
-        </div>
-        <v-row justify="space-between" class="mt-4">
-          <v-col cols="auto">
-            <v-btn variant="outlined" :disabled="step === 0" @click="prev">
-              Previous
-            </v-btn>
-          </v-col>
-          <v-col cols="auto">
-            <v-btn v-if="!isLastStep" color="primary" @click="next">
-              Next
-            </v-btn>
-            <v-btn v-else color="primary" variant="flat" @click="$emit('done')">
-              Done
-            </v-btn>
-          </v-col>
-        </v-row>
+            </div>
+            <div
+              v-if="currentItem.selectionField"
+              class="answer-field-wrap mx-auto"
+            >
+              <v-radio-group
+                v-model="localAnswers[step].answer"
+                hide-details="auto"
+                @update:model-value="updateAnswer(step, $event)"
+              >
+                <v-radio
+                  v-for="(selection, j) in currentItem.selectionFields"
+                  :key="j"
+                  :label="selection"
+                  :value="selection"
+                  density="comfortable"
+                  class="mb-1"
+                />
+              </v-radio-group>
+            </div>
+          </div>
+
+          <v-row justify="space-between" class="mt-2">
+            <v-col cols="auto">
+              <v-btn
+                rounded="pill"
+                variant="outlined"
+                :disabled="step === 0"
+                @click="prev"
+              >
+                Previous
+              </v-btn>
+            </v-col>
+            <v-col cols="auto">
+              <v-btn
+                v-if="!isLastStep"
+                rounded="pill"
+                color="primary"
+                variant="flat"
+                @click="next"
+              >
+                Next
+              </v-btn>
+              <v-btn
+                v-else
+                rounded="pill"
+                color="primary"
+                variant="flat"
+                @click="$emit('done')"
+              >
+                Done
+              </v-btn>
+            </v-col>
+          </v-row>
+        </v-sheet>
       </div>
     </template>
   </ShowInfo>
@@ -82,6 +128,10 @@ const localAnswers = ref([...props.postTestAnswer])
 
 const currentItem = computed(() => props.postTest[step.value])
 const isLastStep = computed(() => step.value === props.postTest.length - 1)
+const progressPercentage = computed(() => {
+  if (!props.postTest?.length) return 0
+  return ((step.value + 1) / props.postTest.length) * 100
+})
 
 const next = () => {
   if (step.value < props.postTest.length - 1) step.value++
@@ -106,3 +156,19 @@ watch(
   { deep: true, immediate: true },
 )
 </script>
+
+<style scoped>
+.question-shell {
+  max-width: 880px;
+}
+
+.answer-field-wrap {
+  width: 560px;
+  max-width: 100%;
+}
+
+.answer-input :deep(.v-field__input) {
+  font-size: 1.25rem;
+  text-align: center;
+}
+</style>

--- a/src/ux/UserTest/components/steps/PreTestStep.vue
+++ b/src/ux/UserTest/components/steps/PreTestStep.vue
@@ -2,42 +2,42 @@
   <ShowInfo :title="testTitle + ' - ' + 'PreTest'">
     <template #content>
       <div class="test-content pa-4 rounded-xl">
-        <div
-          v-for="(item, i) in preTest"
-          :key="i"
-          class="mb-6"
-        >
-          <v-col
-            cols="12"
-            class="py-0"
-          >
-            <span class="text-subtitle-1 font-weight-bold text-secondary">{{ item.title }}</span>
-            <br>
+        <!-- Step Indicator -->
+        <div class="text-center mb-4 text-grey">
+          Question {{ step + 1 }} / {{ preTest.length }}
+        </div>
+        <div class="mb-6">
+          <v-col cols="12" class="py-0">
+            <span class="text-subtitle-1 font-weight-bold text-secondary">{{
+              currentItem.title
+            }}</span>
+            <br />
             <span
-              v-if="item.description"
+              v-if="currentItem.description"
               class="text-body-2 text-grey-darken-1"
-            >{{ item.description }}</span>
+              >{{ currentItem.description }}</span
+            >
 
             <!-- text field -->
             <v-text-field
-              v-if="item.textField"
-              v-model="localAnswers[i].answer"
-              :placeholder="item.title"
+              v-if="currentItem.textField"
+              v-model="localAnswers[step].answer"
+              :placeholder="'Type your answer here…'"
               variant="outlined"
               density="comfortable"
               class="mt-2"
-              @update:model-value="updateAnswer(i, $event)"
+              @update:model-value="updateAnswer(step, $event)"
             />
 
             <!-- radio group -->
             <v-radio-group
-              v-if="item.selectionField"
-              v-model="localAnswers[i].answer"
+              v-if="currentItem.selectionField"
+              v-model="localAnswers[step].answer"
               class="mt-2"
-              @update:model-value="updateAnswer(i, $event)"
+              @update:model-value="updateAnswer(step, $event)"
             >
               <v-radio
-                v-for="(selection, j) in item.selectionFields"
+                v-for="(selection, j) in currentItem.selectionFields"
                 :key="j"
                 :label="selection"
                 :value="selection"
@@ -47,20 +47,18 @@
           </v-col>
         </div>
 
-        <v-row
-          justify="center"
-          class="mt-4"
-        >
-          <v-col
-            cols="12"
-            md="6"
-          >
-            <v-btn
-              block
-              color="primary"
-              variant="flat"
-              @click="$emit('done')"
-            >
+        <v-row class="mt-6" justify="space-between">
+          <v-col cols="auto">
+            <v-btn variant="outlined" :disabled="step === 0" @click="prev">
+              Previous
+            </v-btn>
+          </v-col>
+          <v-col cols="auto">
+            <v-btn v-if="!isLastStep" color="primary" @click="next">
+              Next
+            </v-btn>
+
+            <v-btn v-else color="primary" variant="flat" @click="$emit('done')">
               Done
             </v-btn>
           </v-col>
@@ -71,30 +69,47 @@
 </template>
 
 <script setup>
-import { ref, watch } from "vue";
-import ShowInfo from "@/shared/components/ShowInfo.vue";
+import { ref, computed, watch } from 'vue'
+import ShowInfo from '@/shared/components/ShowInfo.vue'
 
 const props = defineProps({
   testTitle: String,
   preTest: Array,
   preTestAnswer: Array,
   preTestCompleted: Boolean,
-});
+})
 
-const emit = defineEmits(["done", "update:preTestAnswer"]);
+const emit = defineEmits(['done', 'update:preTestAnswer'])
 
-const localAnswers = ref([...props.preTestAnswer]);
+const step = ref(0)
+const localAnswers = ref([...props.preTestAnswer])
+
+const currentItem = computed(() => props.preTest[step.value])
+const isLastStep = computed(() => step.value === props.preTest.length - 1)
+
+const next = () => {
+  if (step.value < props.preTest.length - 1) step.value++
+}
+
+const prev = () => {
+  if (step.value > 0) step.value--
+}
+
+const updateAnswer = (index, value) => {
+  localAnswers.value[index].answer = value
+  emit('update:preTestAnswer', localAnswers.value)
+}
 
 watch(
   () => props.preTestAnswer,
   (newVal) => {
-    localAnswers.value = [...newVal];
+    localAnswers.value = [...newVal]
   },
-  { deep: true }
-);
+  { deep: true },
+)
 
-function updateAnswer(index, value) {
-  localAnswers.value[index].answer = value;
-  emit("update:preTestAnswer", localAnswers.value);
-}
+// function updateAnswer(index, value) {
+//   localAnswers.value[index].answer = value;
+//   emit("update:preTestAnswer", localAnswers.value);
+// }
 </script>

--- a/src/ux/UserTest/components/steps/PreTestStep.vue
+++ b/src/ux/UserTest/components/steps/PreTestStep.vue
@@ -1,68 +1,111 @@
 <template>
   <ShowInfo :title="testTitle + ' - ' + 'PreTest'">
     <template #content>
-      <div class="test-content pa-4 rounded-xl">
-        <!-- Step Indicator -->
-        <div class="text-center mb-4 text-grey">
-          Question {{ step + 1 }} / {{ preTest.length }}
-        </div>
-        <div class="mb-6">
-          <v-col cols="12" class="py-0">
-            <span class="text-subtitle-1 font-weight-bold text-secondary">{{
-              currentItem.title
-            }}</span>
-            <br />
-            <span
+      <div class="test-content pa-2 pa-sm-4">
+        <v-sheet rounded="xl" border class="pa-4 pa-sm-6">
+          <div class="d-flex align-center justify-space-between mb-4">
+            <v-chip
+              color="primary"
+              variant="tonal"
+              size="small"
+              class="font-weight-bold"
+            >
+              Question {{ step + 1 }}
+            </v-chip>
+            <span class="text-caption text-medium-emphasis"
+              >{{ preTest.length }} total</span
+            >
+          </div>
+
+          <v-progress-linear
+            :model-value="progressPercentage"
+            color="primary"
+            height="8"
+            rounded
+            class="mb-7"
+          />
+
+          <div class="question-shell mx-auto mb-8">
+            <h2
+              class="text-h5 text-sm-h4 font-weight-bold text-secondary text-center mb-3"
+            >
+              {{ currentItem.title }}
+            </h2>
+            <p
               v-if="currentItem.description"
-              class="text-body-2 text-grey-darken-1"
-              >{{ currentItem.description }}</span
+              class="text-subtitle-1 text-center text-medium-emphasis mb-6"
             >
+              {{ currentItem.description }}
+            </p>
 
-            <!-- text field -->
-            <v-text-field
-              v-if="currentItem.textField"
-              v-model="localAnswers[step].answer"
-              :placeholder="'Type your answer here…'"
-              variant="outlined"
-              density="comfortable"
-              class="mt-2"
-              @update:model-value="updateAnswer(step, $event)"
-            />
-
-            <!-- radio group -->
-            <v-radio-group
-              v-if="currentItem.selectionField"
-              v-model="localAnswers[step].answer"
-              class="mt-2"
-              @update:model-value="updateAnswer(step, $event)"
-            >
-              <v-radio
-                v-for="(selection, j) in currentItem.selectionFields"
-                :key="j"
-                :label="selection"
-                :value="selection"
-                density="compact"
+            <div v-if="currentItem.textField" class="answer-field-wrap mx-auto">
+              <v-text-field
+                v-model="localAnswers[step].answer"
+                :placeholder="'Type your answer here…'"
+                variant="outlined"
+                density="comfortable"
+                rounded="lg"
+                hide-details="auto"
+                class="answer-input"
+                @update:model-value="updateAnswer(step, $event)"
               />
-            </v-radio-group>
-          </v-col>
-        </div>
+            </div>
 
-        <v-row class="mt-6" justify="space-between">
-          <v-col cols="auto">
-            <v-btn variant="outlined" :disabled="step === 0" @click="prev">
-              Previous
-            </v-btn>
-          </v-col>
-          <v-col cols="auto">
-            <v-btn v-if="!isLastStep" color="primary" @click="next">
-              Next
-            </v-btn>
+            <div
+              v-if="currentItem.selectionField"
+              class="answer-field-wrap mx-auto"
+            >
+              <v-radio-group
+                v-model="localAnswers[step].answer"
+                hide-details="auto"
+                @update:model-value="updateAnswer(step, $event)"
+              >
+                <v-radio
+                  v-for="(selection, j) in currentItem.selectionFields"
+                  :key="j"
+                  :label="selection"
+                  :value="selection"
+                  density="comfortable"
+                  class="mb-1"
+                />
+              </v-radio-group>
+            </div>
+          </div>
 
-            <v-btn v-else color="primary" variant="flat" @click="$emit('done')">
-              Done
-            </v-btn>
-          </v-col>
-        </v-row>
+          <v-row class="mt-2" justify="space-between">
+            <v-col cols="auto">
+              <v-btn
+                rounded="pill"
+                variant="outlined"
+                :disabled="step === 0"
+                @click="prev"
+              >
+                Previous
+              </v-btn>
+            </v-col>
+            <v-col cols="auto">
+              <v-btn
+                v-if="!isLastStep"
+                rounded="pill"
+                color="primary"
+                variant="flat"
+                @click="next"
+              >
+                Next
+              </v-btn>
+
+              <v-btn
+                v-else
+                rounded="pill"
+                color="primary"
+                variant="flat"
+                @click="$emit('done')"
+              >
+                Done
+              </v-btn>
+            </v-col>
+          </v-row>
+        </v-sheet>
       </div>
     </template>
   </ShowInfo>
@@ -86,6 +129,10 @@ const localAnswers = ref([...props.preTestAnswer])
 
 const currentItem = computed(() => props.preTest[step.value])
 const isLastStep = computed(() => step.value === props.preTest.length - 1)
+const progressPercentage = computed(() => {
+  if (!props.preTest?.length) return 0
+  return ((step.value + 1) / props.preTest.length) * 100
+})
 
 const next = () => {
   if (step.value < props.preTest.length - 1) step.value++
@@ -113,3 +160,19 @@ watch(
 //   emit("update:preTestAnswer", localAnswers.value);
 // }
 </script>
+
+<style scoped>
+.question-shell {
+  max-width: 880px;
+}
+
+.answer-field-wrap {
+  width: 560px;
+  max-width: 100%;
+}
+
+.answer-input :deep(.v-field__input) {
+  font-size: 1.25rem;
+  text-align: center;
+}
+</style>


### PR DESCRIPTION
### What was done
- Refactored **PreTest** and **PostTest** views to display one question at a time
- Added a step indicator (`Question X / Y`) to show progress clearly
- Introduced **Previous / Next** navigation for sequential answering
- Ensured button sizing remains responsive across laptop and desktop screens
- Reused existing answer data structures to avoid breaking changes

#### Closes: #1518 

### Why
Previously, all questions were rendered at once, which made the flow less focused and harder to follow.  
This change aligns both PreTest and PostTest experiences with the step-based UX discussed in **#1518**, improving readability, focus, and overall user engagement.

### UI behavior
- One question displayed per step
- Supports both text input and selection-based questions
- Navigation via **Previous / Next**
- Final step presents a clear **Done** action

### ScreenRcording

https://github.com/user-attachments/assets/235d9a17-e5e0-4b3c-8088-18d7d155c286
