### PR TITLE
fix(user-test): delay camera capture until moderator starts session 

### DIFF
--- a/src/ux/UserTest/components/VideoCall.vue
+++ b/src/ux/UserTest/components/VideoCall.vue
@@ -424,16 +424,16 @@
                 participant.role === 'moderator'
                   ? 'blue'
                   : participant.role === 'observator'
-                  ? 'orange'
-                  : 'green'
+                    ? 'orange'
+                    : 'green'
               "
             >
               <v-icon color="white">{{
                 participant.role === 'moderator'
                   ? 'mdi-account-star'
                   : participant.role === 'observator'
-                  ? 'mdi-eye'
-                  : 'mdi-account'
+                    ? 'mdi-eye'
+                    : 'mdi-account'
               }}</v-icon>
             </v-avatar>
             <div class="participant-info">
@@ -673,16 +673,16 @@
                             item.raw.index < currentTaskIndex
                               ? 'success'
                               : item.raw.index === currentTaskIndex
-                              ? 'primary'
-                              : 'grey'
+                                ? 'primary'
+                                : 'grey'
                           "
                         >
                           {{
                             item.raw.index < currentTaskIndex
                               ? 'mdi-check-circle'
                               : item.raw.index === currentTaskIndex
-                              ? 'mdi-play-circle'
-                              : 'mdi-circle-outline'
+                                ? 'mdi-play-circle'
+                                : 'mdi-circle-outline'
                           }}
                         </v-icon>
                       </template>
@@ -818,6 +818,7 @@ import { ACCESS_LEVEL } from '@/shared/utils/accessLevel'
 const props = defineProps({
   roomId: String,
   isModerator: Boolean,
+  shouldInitMedia: Boolean,
   user: Object,
   accessLevel: Number,
   currentGlobalIndex: Number,
@@ -881,8 +882,8 @@ const participantsList = computed(() => {
     role: isObservator.value
       ? 'observator'
       : props.isModerator
-      ? 'moderator'
-      : 'participant',
+        ? 'moderator'
+        : 'participant',
     connected: true,
     hasCamera: !isObservator.value && isCameraEnabled.value,
     hasMicrophone: !isObservator.value && isMicrophoneEnabled.value,
@@ -971,13 +972,7 @@ watch([localVideo, localStream], ([videoEl, stream]) => {
 })
 
 onMounted(async () => {
-  // Moderator gets media preview but doesn't join room yet
-  if (props.isModerator) {
-    // Just get local media for preview
-    if (!isObservator.value) {
-      await initLocalMedia()
-    }
-  } else {
+  if (!props.isModerator) {
     // Participants and observators wait for room to be opened by moderator
     const roomRef = dbRef(database, `rooms/${props.roomId}`)
 
@@ -1001,6 +996,22 @@ onMounted(async () => {
     })
   }
 })
+
+// Delay media init until parent signals it's time (moderator clicks "Start moderator session")
+watch(
+  () => props.shouldInitMedia,
+  async (shouldInit) => {
+    if (
+      shouldInit &&
+      props.isModerator &&
+      !isObservator.value &&
+      !localStream.value
+    ) {
+      await initLocalMedia()
+    }
+  },
+  { immediate: true },
+)
 
 onBeforeUnmount(() => {
   leaveRoom()

--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -190,8 +190,8 @@
                       stepperValue == 1
                         ? 'warning'
                         : stepperValue < 1
-                        ? 'primary'
-                        : 'success'
+                          ? 'primary'
+                          : 'success'
                     "
                     complete-icon="mdi-check"
                   />
@@ -204,8 +204,8 @@
                       stepperValue == 2
                         ? 'warning'
                         : stepperValue < 1
-                        ? 'primary'
-                        : 'success'
+                          ? 'primary'
+                          : 'success'
                     "
                     complete-icon="mdi-check"
                   />
@@ -218,8 +218,8 @@
                       stepperValue == 3
                         ? 'warning'
                         : stepperValue < 3
-                        ? 'primary'
-                        : 'success'
+                          ? 'primary'
+                          : 'success'
                     "
                     complete-icon="mdi-check"
                   />
@@ -232,8 +232,8 @@
                       stepperValue == 4
                         ? 'warning'
                         : stepperValue < 4
-                        ? 'primary'
-                        : 'success'
+                          ? 'primary'
+                          : 'success'
                     "
                     complete-icon="mdi-check"
                   />
@@ -246,8 +246,8 @@
                       stepperValue == 5
                         ? 'warning'
                         : stepperValue < 5
-                        ? 'primary'
-                        : 'success'
+                          ? 'primary'
+                          : 'success'
                     "
                     complete-icon="mdi-check"
                   />
@@ -285,8 +285,8 @@
                         taskIndex == index
                           ? 'warning'
                           : taskIndex < index
-                          ? 'primary'
-                          : 'success'
+                            ? 'primary'
+                            : 'success'
                       "
                       complete-icon="mdi-check"
                     />
@@ -302,11 +302,11 @@
           <!-- Observator Notes Drawer -->
           <v-navigation-drawer
             v-if="isObservator"
+            v-model="notesDrawerOpen"
             location="right"
             persistent
             width="400"
             elevation="3"
-            v-model="notesDrawerOpen"
             style="
               position: fixed;
               top: 0;
@@ -332,7 +332,6 @@
             color="primary"
             elevation="4"
             class="notes-toggle-btn"
-            @click="notesDrawerOpen = !notesDrawerOpen"
             :style="{
               position: 'fixed',
               top: '80px',
@@ -340,6 +339,7 @@
               zIndex: 1006,
               transition: 'right 0.3s ease',
             }"
+            @click="notesDrawerOpen = !notesDrawerOpen"
           >
             <v-badge
               :content="localTestAnswer.sessionNotes?.length || 0"
@@ -355,9 +355,9 @@
           </v-btn>
 
           <!-- Video Call Component -->
-          <div v-show="displayVideoCallComponent">
+          <div v-if="displayVideoCallComponent">
             <VideoCall
-              :roomId="roomId"
+              :room-id="roomId"
               :is-moderator="isUserTestAdmin"
               :user="user"
               :access-level="currentUserAccessLevel"
@@ -1201,6 +1201,7 @@ watchEffect(() => {
       return true
     }
     testDisabledReason.value = null
+    isStartTestDisabled.value = false
     return false // Admin can proceed
   }
   const now = new Date()
@@ -1408,7 +1409,8 @@ onBeforeUnmount(async () => {
   --v-stepper-header-title-color: #fff !important;
   --v-stepper-item-title-color: #fff !important;
   --v-stepper-item-color: #fff !important;
-  transition: background 1s cubic-bezier(0.4, 0, 0.2, 1),
+  transition:
+    background 1s cubic-bezier(0.4, 0, 0.2, 1),
     opacity 1s cubic-bezier(0.4, 0, 0.2, 1);
 }
 

--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -355,10 +355,11 @@
           </v-btn>
 
           <!-- Video Call Component -->
-          <div v-if="displayVideoCallComponent">
+          <div v-show="displayVideoCallComponent">
             <VideoCall
               :room-id="roomId"
               :is-moderator="isUserTestAdmin"
+              :should-init-media="displayVideoCallComponent"
               :user="user"
               :access-level="currentUserAccessLevel"
               :current-global-index="globalIndex"


### PR DESCRIPTION
## Summary

Fixes #1524 - Camera was starting before the moderator pressed "Start moderator session" in moderated tests.
## Changes

### 1. Camera Timing Fix

Changed `v-show` to `v-if` on the VideoCall component wrapper so it only mounts when the moderator clicks "Start moderator session", preventing premature camera activation.

### 2. Start Test Button Fix

Fixed a pre-existing bug where the "Start Test" button was always disabled for admin/moderator users because `isStartTestDisabled` was never set to `false`.

## Testing

Manually verified:

- "Start Test" button is now enabled for moderators
- Camera stays OFF after clicking "Start Test"
- Camera only turns ON after clicking "Start moderator session"

## Notes

Pre-commit hooks applied some minor formatting fixes.