### PR TITLE
feat(storage): add helper to backfill storage usage for older studies

### DIFF
--- a/src/features/auth/controllers/UserController.js
+++ b/src/features/auth/controllers/UserController.js
@@ -156,10 +156,7 @@ export default class UserController extends Controller {
       userToUpdate.notifications[notificationIndex].readAt = Date.now()
 
       // Save updated user data to Firestore
-      await this.update(
-        userToUpdate.id,
-        userToUpdate.toFirestore(),
-      )
+      await this.update(userToUpdate.id, userToUpdate.toFirestore())
       return userToUpdate
     } else {
       // Notification was not found in the array
@@ -181,10 +178,7 @@ export default class UserController extends Controller {
 
     if (!hasUnread) return userToUpdate
 
-    await this.update(
-      userToUpdate.id,
-      userToUpdate.toFirestore(),
-    )
+    await this.update(userToUpdate.id, userToUpdate.toFirestore())
     // Return the updated user object (in memory) so the store can commit it immediately
     return userToUpdate
   }
@@ -247,6 +241,68 @@ export default class UserController extends Controller {
       return super.update(COLLECTION, uid, { accessLevel })
     } catch (error) {
       throw error
+    }
+  }
+
+  /**
+   * Updates the storageUsageMB field for a specific user based on their current studies.
+   * @param {string} userId - The ID of the user to update.
+   */
+  async updateStorageUsage(userId) {
+    try {
+      const AnswerController = (
+        await import('@/shared/controllers/AnswerController')
+      ).default
+      const answerController = new AnswerController()
+
+      // 1. Fetch user with their studies (but 'myTests' only has test meta, not deep answers)
+      const userWithStudies = await this.getUserWithStudies(userId)
+
+      // 2. We must fetch the actual 'answers' document for each test in 'myTests'
+      // because the media URLs are stored in the 'answers' collection, not the 'tests' collection.
+      const myTests = userWithStudies.myTests || {}
+      const testIds = Object.keys(myTests)
+
+      await Promise.all(
+        testIds.map(async (testId) => {
+          const test = myTests[testId]
+          if (test.answersDocId) {
+            try {
+              // Fetch the answer document
+              // check if we have a direct way or need to use getAnswerById
+              const answerDoc = await answerController.getAnswerById(
+                test.answersDocId,
+              )
+
+              // Attach answers to the test object so calculator can see them
+              if (answerDoc && answerDoc.taskAnswers) {
+                // The answerController returns the model, which puts 'taskAnswers' into 'tasks' property usually or similar structure
+                // Let's check getAnswerById implementation: it calls instantiateStudyAnswerByType
+                // If it's a UserStudyEvaluatorAnswer, it maps 'tasks'
+                // We'll assign it to 'answers' property which the calculator expects
+                test.answers = Object.values(answerDoc.taskAnswers || {})
+              }
+            } catch (err) {
+              console.warn(`Could not fetch answers for test ${testId}`, err)
+            }
+          }
+        }),
+      )
+
+      // 3. Calculate storage usage using the helper
+      const { calculateUserStorageUsage } =
+        await import('@/shared/utils/storageUtils')
+      const totalStorageMB = calculateUserStorageUsage(userWithStudies)
+
+      // 4. Update the user document
+      await super.update(COLLECTION, userId, {
+        storageUsageMB: totalStorageMB,
+      })
+
+      return totalStorageMB
+    } catch (error) {
+      console.error('Error updating storage usage:', error)
+      throw new Error('Failed to update storage usage: ' + error.message)
     }
   }
 }

--- a/src/features/auth/controllers/UserController.js
+++ b/src/features/auth/controllers/UserController.js
@@ -275,7 +275,7 @@ export default class UserController extends Controller {
               )
 
               // Attach answers to the test object so calculator can see them
-              if (answerDoc && answerDoc.taskAnswers) {
+              if (answerDoc?.taskAnswers) {
                 // The answerController returns the model, which puts 'taskAnswers' into 'tasks' property usually or similar structure
                 // Let's check getAnswerById implementation: it calls instantiateStudyAnswerByType
                 // If it's a UserStudyEvaluatorAnswer, it maps 'tasks'

--- a/src/shared/utils/storageUtils.js
+++ b/src/shared/utils/storageUtils.js
@@ -1,0 +1,67 @@
+/**
+ * Calculate the total storage usage for a user based on their studies.
+ *
+ * @param {Object} user - The user object containing myTests and myAnswers.
+ * @returns {number} - The total storage usage in MB.
+ */
+export const calculateUserStorageUsage = (user) => {
+  let totalSizeMB = 0
+
+  // Constants for estimated file sizes in MB
+  const ESTIMATED_SIZES_MB = {
+    VIDEO: 50,
+    AUDIO: 10,
+    SCREEN: 100,
+    WEBCAM: 50,
+    RESPONSE: 0.01, // 10KB
+  }
+
+  // Iterate through user's answers (Completed studies)
+  const myAnswers = user.myAnswers || {}
+  Object.values(myAnswers).forEach((answer) => {
+    // Add base size for the response data itself
+    totalSizeMB += ESTIMATED_SIZES_MB.RESPONSE
+
+    const tasks = answer.tasks || {}
+    const taskList = Array.isArray(tasks) ? tasks : Object.values(tasks)
+
+    taskList.forEach((task) => {
+      if (task.videoRecordURL) totalSizeMB += ESTIMATED_SIZES_MB.VIDEO
+      if (task.audioRecordURL) totalSizeMB += ESTIMATED_SIZES_MB.AUDIO
+      if (task.screenRecordURL) totalSizeMB += ESTIMATED_SIZES_MB.SCREEN
+      if (task.webcamRecordURL) totalSizeMB += ESTIMATED_SIZES_MB.WEBCAM
+    })
+  })
+
+  // Iterate through user's tests (Created studies)
+  // We should also check for answers within the test if the user owns the test
+  // However, usually storage is charged to the owner of the test.
+  // The 'user.myTests' contains tests created by the user.
+  // We need to inspect the answers *within* these tests if they are embedded or referenced.
+  // Note: logic in StorageInfo.vue aggregates answers from tests.
+  // If the user's structure has full test objects with answers, we can calculate.
+  // If only IDs are stored, we might rely on what's passed in the 'user' object from UserController.getUserWithStudies()
+
+  const myTests = user.myTests || {}
+  Object.values(myTests).forEach((test) => {
+    const answers = test.answers || {}
+    const answerList = Array.isArray(answers) ? answers : Object.values(answers)
+
+    answerList.forEach((answer) => {
+      // Add base size for the response data
+      totalSizeMB += ESTIMATED_SIZES_MB.RESPONSE
+
+      const tasks = answer.tasks || {}
+      const taskList = Array.isArray(tasks) ? tasks : Object.values(tasks)
+
+      taskList.forEach((task) => {
+        if (task.videoRecordURL) totalSizeMB += ESTIMATED_SIZES_MB.VIDEO
+        if (task.audioRecordURL) totalSizeMB += ESTIMATED_SIZES_MB.AUDIO
+        if (task.screenRecordURL) totalSizeMB += ESTIMATED_SIZES_MB.SCREEN
+        if (task.webcamRecordURL) totalSizeMB += ESTIMATED_SIZES_MB.WEBCAM
+      })
+    })
+  })
+
+  return parseFloat(totalSizeMB.toFixed(2))
+}

--- a/src/shared/utils/storageUtils.js
+++ b/src/shared/utils/storageUtils.js
@@ -63,5 +63,5 @@ export const calculateUserStorageUsage = (user) => {
     })
   })
 
-  return parseFloat(totalSizeMB.toFixed(2))
+  return Number.parseFloat(totalSizeMB.toFixed(2))
 }

--- a/tests/unit/storageUtils.spec.js
+++ b/tests/unit/storageUtils.spec.js
@@ -12,13 +12,13 @@ describe('storageUtils.js', () => {
         myAnswers: {
           answer1: {
             tasks: [
-              { videoRecordURL: 'http://video' }, // 50MB
-              { audioRecordURL: 'http://audio' }, // 10MB
+              { videoRecordURL: 'https://video' }, // 50MB
+              { audioRecordURL: 'https://audio' }, // 10MB
             ],
           },
           answer2: {
             tasks: {
-              task1: { screenRecordURL: 'http://screen' }, // 100MB
+              task1: { screenRecordURL: 'https://screen' }, // 100MB
             },
           },
         },
@@ -38,7 +38,7 @@ describe('storageUtils.js', () => {
             answers: [
               {
                 tasks: [
-                  { webcamRecordURL: 'http://webcam' }, // 50MB
+                  { webcamRecordURL: 'https://webcam' }, // 50MB
                 ],
               },
             ],

--- a/tests/unit/storageUtils.spec.js
+++ b/tests/unit/storageUtils.spec.js
@@ -1,0 +1,59 @@
+import { calculateUserStorageUsage } from '@/shared/utils/storageUtils'
+
+describe('storageUtils.js', () => {
+  describe('calculateUserStorageUsage', () => {
+    it('should return 0 for a user with no answers or tests', () => {
+      const user = { myAnswers: {}, myTests: {} }
+      expect(calculateUserStorageUsage(user)).toBe(0)
+    })
+
+    it('should calculate storage correctly for answers with media', () => {
+      const user = {
+        myAnswers: {
+          answer1: {
+            tasks: [
+              { videoRecordURL: 'http://video' }, // 50MB
+              { audioRecordURL: 'http://audio' }, // 10MB
+            ],
+          },
+          answer2: {
+            tasks: {
+              task1: { screenRecordURL: 'http://screen' }, // 100MB
+            },
+          },
+        },
+        myTests: {},
+      }
+      // Response base: 0.01 * 2 = 0.02
+      // Media: 50 + 10 + 100 = 160
+      // Total: 160.02
+      expect(calculateUserStorageUsage(user)).toBe(160.02)
+    })
+
+    it('should calculate storage correctly for tests with answers', () => {
+      const user = {
+        myAnswers: {},
+        myTests: {
+          test1: {
+            answers: [
+              {
+                tasks: [
+                  { webcamRecordURL: 'http://webcam' }, // 50MB
+                ],
+              },
+            ],
+          },
+        },
+      }
+      // Response base: 0.01 * 1 = 0.01
+      // Media: 50
+      // Total: 50.01
+      expect(calculateUserStorageUsage(user)).toBe(50.01)
+    })
+
+    it('should handle missing properties gracefully', () => {
+      const user = {}
+      expect(calculateUserStorageUsage(user)).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
This PR adds a backend helper to calculate and backfill `storageUsageMB` for users with older studies where this field was not previously populated. This ensures storage quota tracking and dashboard values remain accurate and consistent.

Fixes #1522

## What’s changed
- Added a shared storage calculation utility that mirrors the estimation logic used in the frontend (`StorageInfo.vue`)
- Introduced a new `updateStorageUsage(userId)` method in `UserController`
- The controller:
  - Fetches the user and their tests
  - Explicitly resolves answer documents (since tests only store `answersDocId`)
  - Calculates total storage usage using estimated media sizes
  - Updates `storageUsageMB` in Firestore
- Added unit tests covering storage calculation edge cases

## Why this approach
- Keeps frontend and backend storage calculations consistent
- Avoids expensive file metadata lookups during bulk backfill
- Safely recalculates storage usage without modifying existing study data

## Testing
- Added unit tests for the storage calculation utility
- Verified correct handling of empty users, nested answers, and missing properties

## Follow-ups
The new helper can be invoked via a migration script, cloud function, or admin action to backfill storage usage for existing users.
