### PR TITLE
feat(storage): add helper to clean files from Firebase Storage

### DIFF
--- a/src/shared/utils/storageUtils.js
+++ b/src/shared/utils/storageUtils.js
@@ -1,0 +1,30 @@
+import { getStorage, ref, listAll, deleteObject } from 'firebase/storage'
+
+/**
+ * Recursively deletes all files and subfolders at the specified storage path.
+ * @param {string} path - The path to the folder to clean (e.g., 'users/123').
+ * @returns {Promise<void>}
+ */
+export async function cleanStorage(path) {
+  const storage = getStorage()
+  const listRef = ref(storage, path)
+
+  try {
+    const res = await listAll(listRef)
+
+    // Delete all files in this folder
+    const fileDeletionPromises = res.items.map((itemRef) =>
+      deleteObject(itemRef),
+    )
+    await Promise.all(fileDeletionPromises)
+
+    // Recursively clean subfolders
+    const folderCleaningPromises = res.prefixes.map((folderRef) =>
+      cleanStorage(folderRef.fullPath),
+    )
+    await Promise.all(folderCleaningPromises)
+  } catch (error) {
+    console.error(`Error cleaning storage at path ${path}:`, error)
+    throw error
+  }
+}

--- a/tests/unit/storageUtils.spec.js
+++ b/tests/unit/storageUtils.spec.js
@@ -1,0 +1,89 @@
+import { cleanStorage } from '@/shared/utils/storageUtils'
+import { getStorage, ref, listAll, deleteObject } from 'firebase/storage'
+
+// Mock firebase/storage
+jest.mock('firebase/storage', () => ({
+  getStorage: jest.fn(),
+  ref: jest.fn(),
+  listAll: jest.fn(),
+  deleteObject: jest.fn(),
+}))
+
+describe('storageUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getStorage.mockReturnValue({}) // Mock storage instance
+  })
+
+  it('should delete all files in a folder', async () => {
+    const path = 'some/path'
+    const mockItems = [{ name: 'file1' }, { name: 'file2' }]
+
+    ref.mockImplementation((storage, p) => ({ fullPath: p }))
+
+    listAll.mockResolvedValue({
+      items: mockItems,
+      prefixes: [],
+    })
+    deleteObject.mockResolvedValue(undefined)
+
+    await cleanStorage(path)
+
+    expect(getStorage).toHaveBeenCalled()
+    expect(ref).toHaveBeenCalledWith(expect.anything(), path)
+    expect(listAll).toHaveBeenCalledWith({ fullPath: path })
+    expect(deleteObject).toHaveBeenCalledTimes(2)
+    expect(deleteObject).toHaveBeenCalledWith(mockItems[0])
+    expect(deleteObject).toHaveBeenCalledWith(mockItems[1])
+  })
+
+  it('should recursively clean subfolders', async () => {
+    const rootPath = 'root'
+    const subfolderPath = 'root/sub'
+
+    ref.mockImplementation((storage, p) => ({ fullPath: p }))
+
+    // First call for root: 1 file, 1 subfolder
+    listAll.mockResolvedValueOnce({
+      items: [{ name: 'rootFile' }],
+      prefixes: [{ fullPath: subfolderPath }],
+    })
+
+    // Second call for subfolder: 1 file, 0 subfolders
+    listAll.mockResolvedValueOnce({
+      items: [{ name: 'subFile' }],
+      prefixes: [],
+    })
+
+    deleteObject.mockResolvedValue(undefined)
+
+    await cleanStorage(rootPath)
+
+    expect(listAll).toHaveBeenCalledTimes(2)
+    // First call checking root
+    expect(listAll).toHaveBeenCalledWith({ fullPath: rootPath })
+    // Second call checking subfolder
+    expect(listAll).toHaveBeenCalledWith({ fullPath: subfolderPath })
+
+    expect(deleteObject).toHaveBeenCalledTimes(2)
+  })
+
+  it('should handle errors gracefully', async () => {
+    const path = 'error/path'
+    const error = new Error('Storage error')
+
+    ref.mockImplementation((storage, p) => ({ fullPath: p }))
+    listAll.mockRejectedValue(error)
+
+    // Suppress console.error for this test as we expect it
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(cleanStorage(path)).rejects.toThrow('Storage error')
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      `Error cleaning storage at path ${path}:`,
+      error,
+    )
+    consoleSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
This PR introduces a reusable helper function to clean up files and folders from Firebase Storage. The helper is intended to support cleanup of unused or orphaned storage artifacts, such as files associated with deleted tests.

Fixes #1521

## What’s changed
- Added a new `cleanStorage` helper in `storageUtils.js`
- The helper:
  - Accepts a storage path (prefix)
  - Lists all files and subfolders using `listAll`
  - Deletes all files under the path
  - Recursively cleans subdirectories
- Added unit tests for the storage helper

## Testing
- Added unit tests covering:
  - Deletion of files in a directory
  - Recursive deletion of subdirectories
  - Error handling scenarios
- All tests pass:
