### PR TITLE
docs: document Cloud Functions dependency install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Follow these steps to set up the development environment and run the application
 npm install
 pip install
 ```
+```bash
+# Install Cloud Functions dependencies
+cd functions/
+npm install
+```
+
+
 
 Open Firebase / Firestore and start a project.
 


### PR DESCRIPTION
Fixes #1543

### What changed
- Documented the required `npm install` step inside the `functions/` directory in the README.

This helps new contributors run `firebase emulators:start` successfully after a clean setup.

### Question for maintainers
Would you prefer also adding a small helper script (e.g. `install:all` in `package.json` or a setup `.sh` file) to automate setup step(s) for contributors, or is documenting it in the README sufficient?
