### PR TITLE
feat: Open google form URL when task type is 'post-form' 

### DIFF
--- a/src/ux/UserTest/components/steps/TaskStep.vue
+++ b/src/ux/UserTest/components/steps/TaskStep.vue
@@ -763,7 +763,14 @@ function handleShowPostForm(userCompleted) {
   showPostForm.value.userCompleted = userCompleted
 
   if (props.task?.taskType === 'post-form' && props.task?.postForm) {
-    window.open(props.task.postForm, '_blank')
+    const link = props.task?.postForm
+    if (link) {
+      const url =
+        link.startsWith('http://') || link.startsWith('https://')
+          ? link
+          : `https://${link}`
+      window.open(url, '_blank')
+    }
   }
 
   // Show post-task form for all validated task types

--- a/src/ux/UserTest/components/steps/TaskStep.vue
+++ b/src/ux/UserTest/components/steps/TaskStep.vue
@@ -762,6 +762,10 @@ function handleShowPostForm(userCompleted) {
 
   showPostForm.value.userCompleted = userCompleted
 
+  if (props.task?.taskType === 'post-form' && props.task?.postForm) {
+    window.open(props.task.postForm, '_blank')
+  }
+
   // Show post-task form for all validated task types
   if (VALIDATION_REQUIRED_TYPES.has(props.task?.taskType)) {
     stage.value = 3


### PR DESCRIPTION
## Summary
Fix missing functionality where Google Form URLs were not being opened when participants completed tasks with 'post-form' type.

Fixes : #1556 

## Changes Made
- Add functionality to open external Google Form when task type is 'post-form'
- Modify handleShowPostForm function to handle 'post-form' type specifically
- Open postForm URL in new tab using window.open() when task completed

## Testing
- Verified postForm URL opens in new tab when completing 'post-form' tasks
- Confirmed existing behavior preserved for other task types
- Tested with various Google Form URLs

## Note
This PR addresses the core missing functionality. Future enhancements could include showing a notification popup when opening external forms, similar to the existing behavior for task links.

---

[Screencast from 2026-02-01 14-39-53.webm](https://github.com/user-attachments/assets/fb1c483d-0907-4431-8c40-6b8b407287b6)
