### PR TITLE
fix: sync transcription metadata after delete

### DIFF
--- a/src/shared/controllers/AnswerController.js
+++ b/src/shared/controllers/AnswerController.js
@@ -101,4 +101,20 @@ export default class AnswerController extends Controller {
     }
     return super.update(COLLECTION, answersDocId, update)
   }
+
+  async setTaskTranscriptionMeta({
+    answersDocId,
+    userDocId,
+    taskId,
+    latestTranscriptionDocId,
+    transcriptionsCount,
+  }) {
+    const base = `taskAnswers.${userDocId}.tasks.${taskId}`
+
+    const update = {
+      [`${base}.latestTranscriptionDocId`]: latestTranscriptionDocId,
+      [`${base}.transcriptionsCount`]: transcriptionsCount,
+    }
+    return super.update(COLLECTION, answersDocId, update)
+  }
 }

--- a/src/ux/UserTest/components/transcription/TranscriptionsPanel.vue
+++ b/src/ux/UserTest/components/transcription/TranscriptionsPanel.vue
@@ -195,19 +195,21 @@ async function confirmDelete() {
     // refetch to get the new list
     await fetchSelectedTaskTranscriptions()
 
-    // TODO: ADD THIS LATER
-    // // recompute meta from refreshed list
-    // const newCount = transcriptionsArray.value.length
-    // const newLatestId = transcriptionsArray.value[0]?.id ?? null // we already sort desc in controller
+    // refetch to get the new list
+    await fetchSelectedTaskTranscriptions()
 
-    // // update task meta on the Answer doc
-    // await answerController.setTaskTranscriptionMeta({
-    //   answersDocId: props.answersDocId,
-    //   userDocId: props.userDocId,
-    //   taskId: String(props.taskId),
-    //   latestTranscriptionDocId: newLatestId,
-    //   transcriptionsCount: newCount,
-    // })
+    // recompute meta from refreshed list
+    const newCount = transcriptionsArray.value.length
+    const newLatestId = transcriptionsArray.value[0]?.id ?? null // we already sort desc in controller
+
+    // update task meta on the Answer doc
+    await answerController.setTaskTranscriptionMeta({
+      answersDocId: props.answersDocId,
+      userDocId: props.userDocId,
+      taskId: String(props.taskId),
+      latestTranscriptionDocId: newLatestId,
+      transcriptionsCount: newCount,
+    })
   } catch {
   } finally {
     confirmOpen.value = false

--- a/tests/unit/AnswerController.spec.js
+++ b/tests/unit/AnswerController.spec.js
@@ -1,133 +1,181 @@
 jest.mock('firebase/firestore', () => ({
-    doc: jest.fn(),
-    updateDoc: jest.fn(),
-    collection: jest.fn(),
-    getDocs: jest.fn(),
-    getDoc: jest.fn(),
-    addDoc: jest.fn(),
-    deleteDoc: jest.fn(),
-    increment: jest.fn((val) => ({ _increment: val }))
+  doc: jest.fn(),
+  updateDoc: jest.fn(),
+  collection: jest.fn(),
+  getDocs: jest.fn(),
+  getDoc: jest.fn(),
+  addDoc: jest.fn(),
+  deleteDoc: jest.fn(),
+  increment: jest.fn((val) => ({ _increment: val })),
 }))
 
 jest.mock('@/app/plugins/firebase', () => ({
-    db: {}
+  db: {},
 }))
 
 jest.mock('../../src/features/auth/controllers/UserController', () => {
-    return jest.fn().mockImplementation(() => ({
-        getById: jest.fn(),
-        update: jest.fn()
-    }))
+  return jest.fn().mockImplementation(() => ({
+    getById: jest.fn(),
+    update: jest.fn(),
+  }))
 })
 
 jest.mock('@/shared/constants/methodDefinitions', () => ({
-    instantiateStudyAnswerByType: jest.fn((type, data) => data),
-    STUDY_TYPES: {
-        HEURISTIC: 'HEURISTIC',
-        USER: 'USER'
-    }
+  instantiateStudyAnswerByType: jest.fn((type, data) => data),
+  STUDY_TYPES: {
+    HEURISTIC: 'HEURISTIC',
+    USER: 'USER',
+  },
 }))
 
 jest.mock('@/ux/UserTest/models/UserStudyEvaluatorAnswer', () => {
-    return jest.fn().mockImplementation((data) => ({
-        ...data,
-        toFirestore: jest.fn().mockReturnValue(data)
-    }))
+  return jest.fn().mockImplementation((data) => ({
+    ...data,
+    toFirestore: jest.fn().mockReturnValue(data),
+  }))
 })
 
-const AnswerController = require('@/shared/controllers/AnswerController').default
+const AnswerController =
+  require('@/shared/controllers/AnswerController').default
 
 describe('AnswerController', () => {
-    let answerController
+  let answerController
 
-    beforeEach(() => {
-        jest.clearAllMocks()
-        answerController = new AnswerController()
+  beforeEach(() => {
+    jest.clearAllMocks()
+    answerController = new AnswerController()
+  })
+
+  describe('Structure', () => {
+    it('should have getAnswerById method', () => {
+      expect(typeof answerController.getAnswerById).toBe('function')
     })
 
-    describe('Structure', () => {
-        it('should have getAnswerById method', () => {
-            expect(typeof answerController.getAnswerById).toBe('function')
-        })
-
-        it('should have createAnswer method', () => {
-            expect(typeof answerController.createAnswer).toBe('function')
-        })
-
-        it('should have updateUserAnswer method', () => {
-            expect(typeof answerController.updateUserAnswer).toBe('function')
-        })
-
-        it('should have removeUserAnswer method', () => {
-            expect(typeof answerController.removeUserAnswer).toBe('function')
-        })
-
-        it('should have saveTestAnswer method', () => {
-            expect(typeof answerController.saveTestAnswer).toBe('function')
-        })
-
-        it('should have updateTaskAnswer method', () => {
-            expect(typeof answerController.updateTaskAnswer).toBe('function')
-        })
-
-        it('should have updateTaskTranscriptionMeta method', () => {
-            expect(typeof answerController.updateTaskTranscriptionMeta).toBe('function')
-        })
+    it('should have createAnswer method', () => {
+      expect(typeof answerController.createAnswer).toBe('function')
     })
 
-    describe('createAnswer', () => {
-        it('should call parent create with correct collection', async () => {
-            const mockPayload = {
-                type: 'HEURISTIC',
-                toFirestore: jest.fn().mockReturnValue({ type: 'HEURISTIC' })
-            }
-            const createSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(answerController)), 'create')
-                .mockResolvedValue({ id: 'new-answer-id' })
-
-            const result = await answerController.createAnswer(mockPayload)
-
-            expect(createSpy).toHaveBeenCalledWith('answers', { type: 'HEURISTIC' })
-            expect(result).toEqual({ id: 'new-answer-id' })
-
-            createSpy.mockRestore()
-        })
-
-        it('should throw error when create fails', async () => {
-            const mockError = new Error('Create failed')
-            const mockPayload = {
-                toFirestore: jest.fn().mockReturnValue({})
-            }
-            const createSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(answerController)), 'create')
-                .mockRejectedValue(mockError)
-
-            await expect(answerController.createAnswer(mockPayload)).rejects.toThrow(mockError)
-
-            createSpy.mockRestore()
-        })
+    it('should have updateUserAnswer method', () => {
+      expect(typeof answerController.updateUserAnswer).toBe('function')
     })
 
-    describe('updateTaskTranscriptionMeta', () => {
-        it('should call update with correct field paths', async () => {
-            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(answerController)), 'update')
-                .mockResolvedValue()
-
-            await answerController.updateTaskTranscriptionMeta({
-                answersDocId: 'answer-123',
-                userDocId: 'user-456',
-                taskId: 'task-1',
-                latestId: 'transcription-789',
-                inc: 1
-            })
-
-            expect(updateSpy).toHaveBeenCalledWith(
-                'answers',
-                'answer-123',
-                expect.objectContaining({
-                    'taskAnswers.user-456.tasks.task-1.latestTranscriptionDocId': 'transcription-789'
-                })
-            )
-
-            updateSpy.mockRestore()
-        })
+    it('should have removeUserAnswer method', () => {
+      expect(typeof answerController.removeUserAnswer).toBe('function')
     })
+
+    it('should have saveTestAnswer method', () => {
+      expect(typeof answerController.saveTestAnswer).toBe('function')
+    })
+
+    it('should have updateTaskAnswer method', () => {
+      expect(typeof answerController.updateTaskAnswer).toBe('function')
+    })
+
+    it('should have updateTaskTranscriptionMeta method', () => {
+      expect(typeof answerController.updateTaskTranscriptionMeta).toBe(
+        'function',
+      )
+    })
+  })
+
+  describe('createAnswer', () => {
+    it('should call parent create with correct collection', async () => {
+      const mockPayload = {
+        type: 'HEURISTIC',
+        toFirestore: jest.fn().mockReturnValue({ type: 'HEURISTIC' }),
+      }
+      const createSpy = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(answerController)),
+          'create',
+        )
+        .mockResolvedValue({ id: 'new-answer-id' })
+
+      const result = await answerController.createAnswer(mockPayload)
+
+      expect(createSpy).toHaveBeenCalledWith('answers', { type: 'HEURISTIC' })
+      expect(result).toEqual({ id: 'new-answer-id' })
+
+      createSpy.mockRestore()
+    })
+
+    it('should throw error when create fails', async () => {
+      const mockError = new Error('Create failed')
+      const mockPayload = {
+        toFirestore: jest.fn().mockReturnValue({}),
+      }
+      const createSpy = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(answerController)),
+          'create',
+        )
+        .mockRejectedValue(mockError)
+
+      await expect(answerController.createAnswer(mockPayload)).rejects.toThrow(
+        mockError,
+      )
+
+      createSpy.mockRestore()
+    })
+  })
+
+  describe('updateTaskTranscriptionMeta', () => {
+    it('should call update with correct field paths', async () => {
+      const updateSpy = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(answerController)),
+          'update',
+        )
+        .mockResolvedValue()
+
+      await answerController.updateTaskTranscriptionMeta({
+        answersDocId: 'answer-123',
+        userDocId: 'user-456',
+        taskId: 'task-1',
+        latestId: 'transcription-789',
+        inc: 1,
+      })
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        'answers',
+        'answer-123',
+        expect.objectContaining({
+          'taskAnswers.user-456.tasks.task-1.latestTranscriptionDocId':
+            'transcription-789',
+        }),
+      )
+
+      updateSpy.mockRestore()
+    })
+  })
+  describe('setTaskTranscriptionMeta', () => {
+    it('should call update with correct field paths', async () => {
+      const updateSpy = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(answerController)),
+          'update',
+        )
+        .mockResolvedValue()
+
+      await answerController.setTaskTranscriptionMeta({
+        answersDocId: 'answer-123',
+        userDocId: 'user-456',
+        taskId: 'task-1',
+        latestTranscriptionDocId: 'transcription-789',
+        transcriptionsCount: 5,
+      })
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        'answers',
+        'answer-123',
+        expect.objectContaining({
+          'taskAnswers.user-456.tasks.task-1.latestTranscriptionDocId':
+            'transcription-789',
+          'taskAnswers.user-456.tasks.task-1.transcriptionsCount': 5,
+        }),
+      )
+
+      updateSpy.mockRestore()
+    })
+  })
 })


### PR DESCRIPTION
# Fixes #1559

## Description

This PR fixes an issue where deleting a transcription did not correctly update the parent **Answer** document’s metadata.

Previously, the transcription was deleted successfully, but the associated metadata (`transcriptionsCount` and `latestTranscriptionDocId`) remained stale. This happened due to incomplete frontend deletion logic and the absence of a safe backend method to update metadata using absolute values.

---

## Changes

### Backend
- Added a new method `setTaskTranscriptionMeta` to `AnswerController`
- Allows setting **absolute values** for:
  - `transcriptionsCount`
  - `latestTranscriptionDocId`
- This approach is safer than increment/decrement logic, especially for delete operations

### Frontend
- Fixed and enabled the deletion logic in `TranscriptionsPanel.vue`
- After deleting a transcription:
  - The transcription list is refetched
  - Metadata is recalculated from the refreshed list
  - Updated values are synced back to the Answer document via the controller

---

## Why This Fix

- Prevents transcription metadata from becoming inconsistent after deletions
- Avoids fragile assumptions such as “count − 1”
- Correctly handles edge cases (e.g., deleting the last transcription)

---

## Verification

### Automated Tests
- Added a unit test for `setTaskTranscriptionMeta` in `tests/unit/AnswerController.spec.js`
- All related tests are passing

```bash
npm run test tests/unit/AnswerController.spec.js
```