### PR TITLE
feat: enable multiple test previews for admins and evaluators

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -296,8 +296,8 @@
                         taskIndex > idx
                           ? 'success'
                           : taskIndex === idx
-                          ? 'primary'
-                          : 'grey'
+                            ? 'primary'
+                            : 'grey'
                       "
                       complete-icon="mdi-check"
                     />
@@ -445,7 +445,7 @@
             v-if="
               globalIndex === (hasEyeTracking ? 7 : 6) &&
               localTestAnswer.postTestCompleted &&
-              !localTestAnswer.submitted
+              (!localTestAnswer.submitted || isUserTestAdmin)
             "
             :final-message="$t('finishTest.finalMessage')"
             :congratulations="test.testStructure.finalMessage"
@@ -585,7 +585,24 @@ const hasEyeTracking = computed(() =>
 )
 
 const isUserTestAdmin = computed(() => {
-  return test.value.testAdmin.userDocId === user.value?.id
+  // Check if user is the original test admin
+  if (test.value.testAdmin.userDocId === user.value?.id) {
+    return true
+  }
+
+  // Check if user is a cooperator with admin or evaluator access level
+  if (test.value.cooperators && Array.isArray(test.value.cooperators)) {
+    const userCooperator = test.value.cooperators.find(
+      (cooperator) =>
+        cooperator.userDocId === user.value?.id &&
+        (cooperator.accessLevel === 0 || cooperator.accessLevel === 1),
+    )
+    if (userCooperator) {
+      return true
+    }
+  }
+
+  return false
 })
 
 const isStartTestDisabled = computed(() => {
@@ -609,8 +626,8 @@ const isStartTestDisabled = computed(() => {
     if (endDate < currentDate) return true
   }
 
-  // Check if user has already submitted the test
-  if (localTestAnswer.submitted) return true
+  // Check if user has already submitted the test or user is admin
+  if (localTestAnswer.submitted && !isUserTestAdmin.value) return true
 
   return false
 })
@@ -1360,7 +1377,8 @@ onBeforeUnmount(() => {
   --v-stepper-header-title-color: #fff !important;
   --v-stepper-item-title-color: #fff !important;
   --v-stepper-item-color: #fff !important;
-  transition: background 1s cubic-bezier(0.4, 0, 0.2, 1),
+  transition:
+    background 1s cubic-bezier(0.4, 0, 0.2, 1),
     opacity 1s cubic-bezier(0.4, 0, 0.2, 1);
 }
 


### PR DESCRIPTION
### Summary
This PR resolves the issue where test administrators and evaluators couldn't preview tests multiple times due to completion restrictions. Previously, after one preview, users had to delete their own submissions to preview again, creating unnecessary friction.

Fixes #1560 

### Changes Made
- Updated the isUserTestAdmin computed property to recognize both original admins and cooperators with admin (0) or evaluator (1) access levels
- Modified test completion checks to bypass for authorized users during preview mode
- Adjusted the FinishStep condition to show for authorized users even if they've previously submitted
- Updated the start test disabled condition to allow previews for authorized users regardless of submission status

### Problem Solved
- Admins and evaluators can now preview tests multiple times without restrictions
- Eliminates the need to delete submissions just to preview again
- Improves UX for study creators and evaluators during the testing phase

### Videos

video demonstration showing the before and after behavior. The video illustrates how admins and evaluators can now seamlessly preview tests multiple times without encountering the previous completion restrictions.

- Admin(owner)

[Screencast from 2026-02-01 23-56-40.webm](https://github.com/user-attachments/assets/3ae6a92d-3d97-4995-b474-ae4ddb56d3fb)

- Admin (Cooperator)

[Screencast from 2026-02-01 23-59-12.webm](https://github.com/user-attachments/assets/e827167d-6f16-4b1e-9466-412d024d17e8)

- Guest (Cooperator) : Only 1 time

[Screencast from 2026-02-02 00-01-53.webm](https://github.com/user-attachments/assets/0a4c1071-3133-424a-8203-bcff11ba5ef3)

### Technical Details
The solution leverages the existing cooperator system where additional admins/evaluators are stored in the test.cooperators array with appropriate access levels (0 for admin, 1 for evaluator), rather than only checking against the original test.testAdmin.userDocId.