### PR TITLE
fix: remove video event listeners in SessionAnalyticsDialog on unmount

### DIFF
--- a/src/ux/UserTest/components/dialogs/SessionAnalyticsDialog.vue
+++ b/src/ux/UserTest/components/dialogs/SessionAnalyticsDialog.vue
@@ -198,6 +198,16 @@ function onTimeUpdate(event) {
   videoCurrentTime.value = video.currentTime
 }
 
+function onVideoPlay() {
+  isPlaying.value = true
+  updateLoop()
+}
+
+function onVideoPause() {
+  isPlaying.value = false
+  cancelAnimationFrame(rafId)
+}
+
 const togglePlay = () => {
   const video = mainVideo2.value
   if (!video) return
@@ -228,21 +238,19 @@ onMounted(() => {
   const video = mainVideo2.value
   if (!video) return
 
-  video.addEventListener('loadedmetadata', () => {
-    videoDuration.value = video.duration
-  })
-
-  video.addEventListener('play', () => {
-    isPlaying.value = true
-    updateLoop()
-  })
-
-  video.addEventListener('pause', () => {
-    isPlaying.value = false
-    cancelAnimationFrame(rafId)
-  })
+  video.addEventListener('loadedmetadata', onMetadataLoaded)
+  video.addEventListener('play', onVideoPlay)
+  video.addEventListener('pause', onVideoPause)
 })
-onBeforeUnmount(() => cancelAnimationFrame(rafId))
+onBeforeUnmount(() => {
+  const video = mainVideo2.value
+  if (video) {
+    video.removeEventListener('loadedmetadata', onMetadataLoaded)
+    video.removeEventListener('play', onVideoPlay)
+    video.removeEventListener('pause', onVideoPause)
+  }
+  cancelAnimationFrame(rafId)
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
# Fixes #1565 


## Description

The Task Analysis dialog was leaving native video event listeners attached to the screen video element after the dialog closed. Listeners for `loadedmetadata`, `play`, and `pause` were added in `onMounted` but never removed in `onBeforeUnmount`, which could lead to leaks and unexpected behavior when the dialog is opened and closed repeatedly.

## What changed

- **SessionAnalyticsDialog.vue**  
  - Reused the existing `onMetadataLoaded` handler for the `loadedmetadata` listener so it can be removed on unmount.  
  - Added named handlers `onVideoPlay` and `onVideoPause` (same behavior as before) and used them for the `play` and `pause` listeners.  
  - In `onBeforeUnmount`, the component now removes all three listeners from the video element (when it exists) using the same handler references, then calls `cancelAnimationFrame(rafId)` as before.

No template changes, no changes to other components or files. Behavior (timeline, play/pause, seeking) is unchanged.

## How to verify

1. **Behavior unchanged** — Open the Task Analysis dialog, play and pause the screen video, and use the timeline. Timeline and play state should behave as before.
2. **Cleanup on close** — Close the dialog (component unmounts). The three listeners are now removed in `onBeforeUnmount`, so no listeners are left attached. Optionally, in devtools you can inspect the video element before closing to confirm only the expected listeners, or open/close the dialog multiple times and confirm no errors or odd behavior.
