### PR TITLE
Fix: render task description HTML content properly in task preview

### DIFF
--- a/src/ux/UserTest/components/task-steps/TaskPreview.vue
+++ b/src/ux/UserTest/components/task-steps/TaskPreview.vue
@@ -22,11 +22,7 @@
                 <div class="text-body-2 text-grey-darken-1 mb-2">
                   {{ $t('CreateTask.preview.description') }}
                 </div>
-                <div class="description-content">
-                  {{
-                    (task && task.taskDescription) ||
-                    $t('CreateTask.preview.noDescription')
-                  }}
+                <div class="description-content" v-html="(task && task.taskDescription) || $t('CreateTask.preview.noDescription')">
                 </div>
               </div>
 


### PR DESCRIPTION
## Description
Fixed HTML rendering issue in the Task Preview component where task descriptions containing HTML markup (e.g., `<p>`, `<strong>`, etc.) were displaying as raw text instead of being rendered as HTML.

## Problem
When creating a task with formatted HTML content in the description field, the TaskPreview component was displaying the raw HTML tags instead of rendering them as formatted content. For example, `<p>yy</p>` would appear literally in the UI instead of being rendered as a paragraph.

## Solution
Changed the task description binding in `TaskPreview.vue` from string interpolation (`{{ }}`) to Vue's `v-html` directive to properly render HTML content.

### Changes
- **File:** `src/ux/UserTest/components/task-steps/TaskPreview.vue`
- **Change:** Updated task description rendering to use `v-html` directive instead of `{{ }}` interpolation
  - Before: `{{ (task && task.taskDescription) || $t('CreateTask.preview.noDescription') }}`
  - After: `v-html="(task && task.taskDescription) || $t('CreateTask.preview.noDescription')"`
 
## BEFORE:
<img width="1795" height="1083" alt="Screenshot 2026-02-02 at 1 55 58 PM" src="https://github.com/user-attachments/assets/2117be5f-9736-4fc5-a24f-c8651f57d291" />



## AFTER:
<img width="1800" height="1090" alt="Screenshot 2026-02-02 at 1 54 31 PM" src="https://github.com/user-attachments/assets/1580031d-e37a-4428-94e5-43af807cf10c" />

