### PR TITLE
feat: add camera/mic privacy controls in moderated test video call

### DIFF
--- a/src/ux/UserTest/components/VideoCall.vue
+++ b/src/ux/UserTest/components/VideoCall.vue
@@ -64,11 +64,26 @@
           >
             <div class="video-container">
               <video
+                v-if="isRemoteCameraEnabled(userId)"
                 :srcObject="stream"
                 autoplay
                 playsinline
                 class="video-element"
               ></video>
+
+              <!-- Camera disabled overlay for remote peer -->
+              <div v-if="!isRemoteCameraEnabled(userId)" class="camera-disabled-overlay">
+                <v-icon size="64" color="white" class="mb-2"
+                  >mdi-video-off</v-icon
+                >
+                <p class="text-white">Camera is off</p>
+              </div>
+
+              <!-- Microphone muted indicator for remote peer -->
+              <div v-if="!isRemoteMicrophoneEnabled(userId)" class="mic-muted-indicator">
+                <v-icon size="24" color="white">mdi-microphone-off</v-icon>
+              </div>
+
               <div class="video-label">{{ getPeerName(userId) }}</div>
             </div>
           </div>
@@ -1023,6 +1038,8 @@ const joinRoom = async () => {
     email: props.user.email,
     name: props.user.email?.split('@')[0], // Simple name
     joinedAt: Date.now(),
+    cameraEnabled: isCameraEnabled.value,
+    microphoneEnabled: isMicrophoneEnabled.value,
   })
   onDisconnect(myRef).remove() // Auto-remove on closing tab
 
@@ -1247,6 +1264,8 @@ function toggleCamera() {
   if (track) {
     track.enabled = !track.enabled
     isCameraEnabled.value = track.enabled
+    // Share camera state with other peers
+    updateParticipantStatus()
   }
 }
 
@@ -1256,7 +1275,34 @@ function toggleMicrophone() {
   if (track) {
     track.enabled = !track.enabled
     isMicrophoneEnabled.value = track.enabled
+    // Share mic state with other peers
+    updateParticipantStatus()
   }
+}
+
+async function updateParticipantStatus() {
+  if (!props.user?.id || !props.roomId) return
+  try {
+    const participantRef = dbRef(
+      database,
+      `calls/${props.roomId}/participants/${props.user.id}`,
+    )
+    await update(participantRef, {
+      cameraEnabled: isCameraEnabled.value,
+      microphoneEnabled: isMicrophoneEnabled.value,
+      updatedAt: Date.now(),
+    })
+  } catch (error) {
+    console.error('Error updating participant status:', error) // eslint-disable-line no-console
+  }
+}
+
+function isRemoteCameraEnabled(userId) {
+  return participants.value[userId]?.cameraEnabled !== false
+}
+
+function isRemoteMicrophoneEnabled(userId) {
+  return participants.value[userId]?.microphoneEnabled !== false
 }
 
 function toggleSidePanel() {


### PR DESCRIPTION
fixes #1528
### Description

Added real-time camera and microphone status sharing in moderated test video calls. Participants can now toggle their camera/mic on/off, and other participants see the status instantly via Firebase. When someone turns off their camera, their video disappears and shows "Camera is off" overlay. When mic is muted, a red indicator appears.

### Changes Made

#### 1. Enhanced Toggle Functions
- Modified `toggleCamera()` to call `updateParticipantStatus()` after toggling
- Modified `toggleMicrophone()` to call `updateParticipantStatus()` after toggling
- Now broadcasts status changes to Firebase

#### 2. New Function: updateParticipantStatus()
- Updates participant record in Firebase with current camera/mic state
- Called every time camera or mic is toggled
- Stores: `cameraEnabled`, `microphoneEnabled`, `updatedAt`
- Includes error handling with try-catch

#### 3. New Helper Functions
- `isRemoteCameraEnabled(userId)`: Checks if remote peer's camera is enabled
- `isRemoteMicrophoneEnabled(userId)`: Checks if remote peer's mic is enabled
- Used in template to conditionally show/hide video and indicators

#### 4. Updated Join Room Function
- Added `cameraEnabled` and `microphoneEnabled` to initial participant registration
- Other users know your status immediately when you join

#### 5. Updated Remote Video Template
- Video only displays if `isRemoteCameraEnabled(userId)` is true
- Shows "Camera is off" overlay when remote camera is disabled
- Shows red microphone-off indicator when remote mic is muted

## BEFORE:
<img width="1800" height="1088" alt="Screenshot 2026-02-02 at 5 02 43 PM" src="https://github.com/user-attachments/assets/d72d5e1c-90ac-4bf5-ba93-908e450559d7" />

#AFTER:
<img width="1800" height="1169" alt="Screenshot 2026-02-02 at 3 54 13 PM" src="https://github.com/user-attachments/assets/e261c956-5139-44ea-b19b-14d4f89d7ad7" />

