### PR TITLE
Fix Upcoming Webinar card layout to prevent CTA overlap

### DIFF
--- a/src/features/dashboard/components/UpcomingWebinar.vue
+++ b/src/features/dashboard/components/UpcomingWebinar.vue
@@ -29,8 +29,7 @@
       height="200"
       :src="officeHoursImage"
       cover
-    >
-    </v-img>
+    />
 
     <v-card-text class="pa-6">
       <!-- Webinar Title -->
@@ -44,7 +43,7 @@
       </p>
 
       <!-- Date and Duration Info -->
-      <v-row class="info-row mb-4" no-gutters>
+      <v-row class="info-row mb-2" no-gutters>
         <v-col cols="6" class="pr-2">
           <div class="info-item">
             <div class="info-icon-wrapper">
@@ -58,7 +57,8 @@
             </div>
           </div>
         </v-col>
-        <v-col cols="6" class="">
+
+        <v-col cols="6">
           <div class="info-item">
             <div class="info-icon-wrapper">
               <v-icon icon="mdi-clock-outline" size="24" color="primary" />
@@ -72,8 +72,10 @@
           </div>
         </v-col>
       </v-row>
+    </v-card-text>
 
-      <!-- Join Button -->
+    <!-- Join Button -->
+    <v-card-actions class="pa-6 pt-0">
       <v-btn
         :color="buttonConfig.color"
         variant="flat"
@@ -87,7 +89,7 @@
       >
         {{ buttonConfig.text }}
       </v-btn>
-    </v-card-text>
+    </v-card-actions>
   </v-card>
 </template>
 


### PR DESCRIPTION
fixed issue: #1577 

### PR Summary 

**What was wrong**

- CTA button was placed inside v-card-text
- On certain screen sizes and content lengths, the button overlapped webinar metadata

**What’s fixed**

- Moved CTA button to v-card-actions (Vuetify best practice)
- Ensures card height adjusts naturally and all content remains visible
- No design or logic changes

**Impact**

- Improved UI consistency
- Responsive-safe layout
- Better accessibility and UX

Before:
<img width="576" height="433" alt="image" src="https://github.com/user-attachments/assets/17cc0896-fabb-4260-b052-80eb3d106646" />
<img width="1292" height="961" alt="image" src="https://github.com/user-attachments/assets/915087a4-c291-4323-8019-737ba759411b" />

After:
<img width="1224" height="1227" alt="image" src="https://github.com/user-attachments/assets/d05c4e13-c71b-4996-af0f-7929f2240d4b" />
<img width="590" height="511" alt="image" src="https://github.com/user-attachments/assets/1102c6db-df0f-4cd3-8c32-efbd47f4fd2b" />