### PR TITLE
feat: responsive mobile tabs with dropdown for Edit Test page

### DIFF
--- a/src/ux/UserTest/views/EditTestView.vue
+++ b/src/ux/UserTest/views/EditTestView.vue
@@ -10,26 +10,62 @@
       <ButtonSave :visible="true" @click="save" />
 
       <div>
-        <v-tabs bg-color="transparent" color="#FCA326" class="pb-0 mb-0">
-          <v-tab @click="index = 0">
+        <!-- Desktop Tabs -->
+        <v-tabs
+          bg-color="transparent"
+          color="#FCA326"
+          class="pb-0 mb-0 desktop-tabs uppercase-tabs"
+        >
+          <v-tab @click="index = 0" class="uppercase-text">
             {{ $t('UserTestTable.titles.testConfiguration') }}
           </v-tab>
-          <v-tab @click="index = 1">
+          <v-tab @click="index = 1" class="uppercase-text">
             {{ $t('ModeratedTest.consentForm') }}
           </v-tab>
-          <v-tab @click="index = 2">
+          <v-tab @click="index = 2" class="uppercase-text">
             {{ $t('ModeratedTest.preTest') }}
           </v-tab>
-          <v-tab @click="index = 3">
+          <v-tab @click="index = 3" class="uppercase-text">
             {{ $t('ModeratedTest.tasks') }}
           </v-tab>
-          <v-tab @click="index = 4">
+          <v-tab @click="index = 4" class="uppercase-text">
             {{ $t('ModeratedTest.postTest') }}
           </v-tab>
-          <v-tab v-if="hasEyeTracking" @click="index = 5">
-            Eye Tracking Configurations
+          <v-tab v-if="hasEyeTracking" @click="index = 5" class="uppercase-text">
+            EYE TRACKING CONFIGURATIONS
           </v-tab>
         </v-tabs>
+
+        <!-- Mobile Dropdown -->
+        <div class="mobile-tabs-container">
+          <div 
+            class="mobile-tabs-header"
+            @click="showMobileDropdown = !showMobileDropdown"
+          >
+            <div class="mobile-tabs-selected uppercase-text">
+              {{ getCurrentTabName() }}
+            </div>
+            <v-icon :class="['mobile-tabs-chevron', { 'rotated': showMobileDropdown }]">
+              mdi-chevron-down
+            </v-icon>
+          </div>
+
+          <!-- Dropdown Menu -->
+          <div v-if="showMobileDropdown" class="mobile-tabs-dropdown">
+            <div 
+              v-for="(tab, i) in tabOptions" 
+              :key="i"
+              class="mobile-tabs-item uppercase-text"
+              :class="{ 'active': index === i }"
+              @click="selectTab(i)"
+            >
+              {{ tab }}
+              <v-icon v-if="index === i" class="mobile-tabs-check">
+                mdi-check
+              </v-icon>
+            </div>
+          </div>
+        </div>
 
         <v-col cols="12">
           <!-- TEST -->
@@ -107,6 +143,7 @@ const studyController = new StudyController()
 // Store
 const store = useStore()
 const { t } = useI18n()
+const route = useRoute()
 
 // Variables
 const change = ref(false)
@@ -114,8 +151,34 @@ const welcomeMessage = ref('')
 const finalMessage = ref('')
 const consent = ref('')
 const index = ref(0)
-const route = useRoute()
+const showMobileDropdown = ref(false)
 let unsubscribe = null
+
+// tab options for mobile dropdown
+const tabOptions = computed(() => {
+  const options = [
+    t('UserTestTable.titles.testConfiguration').toUpperCase(),
+    t('ModeratedTest.consentForm').toUpperCase(),
+    t('ModeratedTest.preTest').toUpperCase(),
+    t('ModeratedTest.tasks').toUpperCase(),
+    t('ModeratedTest.postTest').toUpperCase(),
+  ]
+  if (hasEyeTracking.value) {
+    options.push('EYE TRACKING CONFIGURATIONS')
+  }
+  return options
+})
+const getCurrentTabName = () => {
+  if (index.value >= 0 && index.value < tabOptions.value.length) {
+    return tabOptions.value[index.value]
+  }
+  return tabOptions.value[0]
+}
+const selectTab = (tabIndex) => {
+  index.value = tabIndex
+  showMobileDropdown.value = false 
+}
+
 // Computed
 const test = computed(() => store.getters.test)
 
@@ -235,5 +298,125 @@ onUnmounted(() => {
 .v-text-field--outlined :deep(fieldset) {
   border-radius: 25px;
   border: 1px solid #ffceb2;
+}
+
+.uppercase-tabs :deep(.v-tab) {
+  text-transform: uppercase !important;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+}
+
+.uppercase-text {
+  text-transform: uppercase !important;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+}
+
+.desktop-tabs {
+  display: block;
+}
+
+.mobile-tabs-container {
+  display: none;
+  margin-top: 16px;
+  position: relative;
+  z-index: 10;
+}
+
+.mobile-tabs-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border: 1px solid #9e9e9e;
+  border-radius: 4px;
+  background-color: white;
+  cursor: pointer;
+  user-select: none;
+  transition: border-color 0.2s;
+}
+
+.mobile-tabs-header:hover {
+  border-color: #FCA326;
+}
+
+.mobile-tabs-selected {
+  font-size: 16px;
+  color: #333;
+}
+
+.mobile-tabs-chevron {
+  color: #666;
+  transition: transform 0.3s ease;
+}
+
+.mobile-tabs-chevron.rotated {
+  transform: rotate(180deg);
+}
+
+.mobile-tabs-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 4px;
+  background-color: white;
+  border: 1px solid #9e9e9e;
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.mobile-tabs-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  font-size: 16px;
+  color: #333;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.mobile-tabs-item:last-child {
+  border-bottom: none;
+}
+
+.mobile-tabs-item:hover {
+  background-color: #f5f5f5;
+}
+
+.mobile-tabs-item.active {
+  color: #FCA326;
+  font-weight: 500;
+  background-color: #fff5e6;
+}
+
+.mobile-tabs-check {
+  color: #FCA326;
+  font-size: 20px;
+}
+
+@media (max-width: 960px) {
+  .desktop-tabs {
+    display: none !important; 
+  }
+  
+  .mobile-tabs-container {
+    display: block; 
+  }
+}
+
+@media (min-width: 960px) {
+  .desktop-tabs {
+    display: block !important; 
+  }
+  
+  .mobile-tabs-container {
+    display: none !important; 
+  }
 }
 </style>


### PR DESCRIPTION
fixed issue: #1579 

### PR Summary 

**Problem**: Mobile users cannot access all tabs (PRE-TEST, TASKS, POST-TEST) in Edit Test view due to horizontal overflow.

**Solution: Implement responsive tab system**:

- Desktop: Shows original horizontal tabs
- Mobile (<960px): Shows dropdown menu with all tab options
- Dropdown opens on click with checkmark for selected tab

Before:
<img width="738" height="1122" alt="image" src="https://github.com/user-attachments/assets/04659ab4-242a-4148-a142-d08863ec7775" />
<img width="615" height="1147" alt="image" src="https://github.com/user-attachments/assets/8f3678da-2235-49c8-adf2-3ccaddebc507" />


After Video Demo:
https://app.screencastify.com/watch/xCrjlcKL2oNJsHdBys1T?checkOrg=83ca94ef-d118-40f1-92bc-e4fc7e0304e7