### PR TITLE
feat(i18n): localize tags and dates across all supported locales

### DIFF
--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -1408,7 +1408,11 @@
       "SelfTest": {
         "title": "اختبار ذاتي",
         "type": "غير مشرف عليه",
-        "text": ["الإجابة في وقت فراغ", "تحليل متقدم للإجابات", "تخصيص المهمة"]
+        "text": [
+          "الإجابة في وقت فراغ",
+          "تحليل متقدم للإجابات",
+          "تخصيص المهمة"
+        ]
       },
       "LiveTest": {
         "title": "اختبار مباشر",
@@ -1803,6 +1807,37 @@
     "deleteOptionConfirm": {
       "title": "حذف الخيار",
       "message": "هل أنت متأكد أنك تريد حذف هذا الخيار؟ لا يمكن التراجع عن هذا الإجراء."
+    }
+  },
+  "tags": {
+    "active": "نشط",
+    "draft": "مسودة",
+    "completed": "مكتمل",
+    "archived": "مؤرشف",
+    "public": "عام",
+    "private": "خاص",
+    "fromTemplate": "من قالب",
+    "withCollaborators": "مع المتعاونين"
+  },
+  "methods": {
+    "categories": {
+      "test": "اختبار المستخدم",
+      "inquiry": "بحث المستخدم",
+      "inspection": "فحص الخبراء",
+      "accessibility": "إمكانية الوصول",
+      "other": "آخر"
+    },
+    "definitions": {
+      "HEURISTICS": "التقييم الاستكشافي",
+      "USER_MODERATED": "اختبار قابلية الاستخدام المدار",
+      "USER_UNMODERATED": "اختبار قابلية الاستخدام غير المدار",
+      "SURVEY": "استطلاع",
+      "INTERVIEW": "مقابلة",
+      "CARD_SORTING": "تصنيف البطاقات",
+      "COGNITIVE_WALKTHROUGH": "التنفيذ المعرفي",
+      "ACCESSIBILITY_MANUAL": "تقييم يدوي",
+      "ACCESSIBILITY_AUTOMATIC": "تقييم آلي",
+      "WCAG_AUDIT": "تدقيق WCAG"
     }
   }
 }

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -1809,5 +1809,36 @@
       "title": "Option löschen",
       "message": "Sind Sie sicher, dass Sie diese Option löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
     }
+  },
+  "tags": {
+    "active": "Aktiv",
+    "draft": "Entwurf",
+    "completed": "Abgeschlossen",
+    "archived": "Archiviert",
+    "public": "Öffentlich",
+    "private": "Privat",
+    "fromTemplate": "Aus Vorlage",
+    "withCollaborators": "Mit Mitwirkenden"
+  },
+  "methods": {
+    "categories": {
+      "test": "Benutzertests",
+      "inquiry": "Benutzerforschung",
+      "inspection": "Expertenprüfung",
+      "accessibility": "Barrierefreiheit",
+      "other": "Sonstiges"
+    },
+    "definitions": {
+      "HEURISTICS": "Heuristische Bewertung",
+      "USER_MODERATED": "Moderierter Usability-Test",
+      "USER_UNMODERATED": "Unmoderierter Usability-Test",
+      "SURVEY": "Umfrage",
+      "INTERVIEW": "Interview",
+      "CARD_SORTING": "Card Sorting",
+      "COGNITIVE_WALKTHROUGH": "Cognitive Walkthrough",
+      "ACCESSIBILITY_MANUAL": "Manuelle Bewertung",
+      "ACCESSIBILITY_AUTOMATIC": "Automatische Bewertung",
+      "WCAG_AUDIT": "WCAG-Audit"
+    }
   }
 }

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -1785,5 +1785,36 @@
       "title": "Delete Option",
       "message": "Are you sure you want to delete this option? This action cannot be undone."
     }
+  },
+  "tags": {
+    "active": "Active",
+    "draft": "Draft",
+    "completed": "Completed",
+    "archived": "Archived",
+    "public": "Public",
+    "private": "Private",
+    "fromTemplate": "From Template",
+    "withCollaborators": "With Collaborators"
+  },
+  "methods": {
+    "categories": {
+      "test": "User Testing",
+      "inquiry": "User Research",
+      "inspection": "Expert Inspection",
+      "accessibility": "Accessibility",
+      "other": "Other"
+    },
+    "definitions": {
+      "HEURISTICS": "Heuristic Evaluation",
+      "USER_MODERATED": "Moderated Usability Test",
+      "USER_UNMODERATED": "Unmoderated Usability Test",
+      "SURVEY": "Survey",
+      "INTERVIEW": "Interview",
+      "CARD_SORTING": "Card Sorting",
+      "COGNITIVE_WALKTHROUGH": "Cognitive Walkthrough",
+      "ACCESSIBILITY_MANUAL": "Manual Evaluation",
+      "ACCESSIBILITY_AUTOMATIC": "Automatic Evaluation",
+      "WCAG_AUDIT": "WCAG Audit"
+    }
   }
 }

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -1788,5 +1788,36 @@
       "title": "Eliminar Opción",
       "message": "¿Está seguro de que desea eliminar esta opción? Esta acción no se puede deshacer."
     }
+  },
+  "tags": {
+    "active": "Activo",
+    "draft": "Borrador",
+    "completed": "Completado",
+    "archived": "Archivado",
+    "public": "Público",
+    "private": "Privado",
+    "fromTemplate": "Desde plantilla",
+    "withCollaborators": "Con colaboradores"
+  },
+  "methods": {
+    "categories": {
+      "test": "Pruebas con Usuarios",
+      "inquiry": "Investigación de Usuarios",
+      "inspection": "Inspección de Expertos",
+      "accessibility": "Accesibilidad",
+      "other": "Otro"
+    },
+    "definitions": {
+      "HEURISTICS": "Evaluación Heurística",
+      "USER_MODERATED": "Prueba de Usabilidad Moderada",
+      "USER_UNMODERATED": "Prueba de Usabilidad No Moderada",
+      "SURVEY": "Encuesta",
+      "INTERVIEW": "Entrevista",
+      "CARD_SORTING": "Clasificación de Tarjetas",
+      "COGNITIVE_WALKTHROUGH": "Recorrido Cognitivo",
+      "ACCESSIBILITY_MANUAL": "Evaluación Manual",
+      "ACCESSIBILITY_AUTOMATIC": "Evaluación Automática",
+      "WCAG_AUDIT": "Auditoría WCAG"
+    }
   }
 }

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -284,8 +284,6 @@
     "back": "Retour",
     "deleteForever": "Supprimer définitivement",
     "superAdmin": "Super Admin",
-    "uploadProfilePicture": "Télécharger une photo de profil",
-    "removeProfilePicture": "Supprimer la photo de profil",
     "currentPassword": "Mot de passe actuel",
     "currentPasswordRequired": "Le mot de passe actuel est requis",
     "wrongCurrentPassword": "Le mot de passe actuel est incorrect",
@@ -1805,8 +1803,39 @@
       "message": "Êtes-vous sûr de vouloir supprimer cette variable ? Cette action ne peut pas être annulée."
     },
     "deleteOptionConfirm": {
-      "title": "Supprimer l'Option",
-      "message": "Êtes-vous sûr de vouloir supprimer cette option ? Cette action ne peut pas être annulée."
+      "title": "Supprimer l'option",
+      "message": "Êtes-vous sûr de vouloir supprimer cette option ? Cette action est irréversible."
+    }
+  },
+  "tags": {
+    "active": "Actif",
+    "draft": "Brouillon",
+    "completed": "Terminé",
+    "archived": "Archivé",
+    "public": "Public",
+    "private": "Privé",
+    "fromTemplate": "À partir d'un modèle",
+    "withCollaborators": "Avec des collaborateurs"
+  },
+  "methods": {
+    "categories": {
+      "test": "Tests utilisateur",
+      "inquiry": "Recherche utilisateur",
+      "inspection": "Inspection experte",
+      "accessibility": "Accessibilité",
+      "other": "Autre"
+    },
+    "definitions": {
+      "HEURISTICS": "Évaluation heuristique",
+      "USER_MODERATED": "Test d'utilisabilité modéré",
+      "USER_UNMODERATED": "Test d'utilisabilité non modéré",
+      "SURVEY": "Sondage",
+      "INTERVIEW": "Entretien",
+      "CARD_SORTING": "Tri par cartes",
+      "COGNITIVE_WALKTHROUGH": "Parcours cognitif",
+      "ACCESSIBILITY_MANUAL": "Évaluation manuelle",
+      "ACCESSIBILITY_AUTOMATIC": "Évaluation automatique",
+      "WCAG_AUDIT": "Audit WCAG"
     }
   }
 }

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -1782,8 +1782,39 @@
       "message": "क्या आप वाकई इस वेरिएबल को हटाना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती।"
     },
     "deleteOptionConfirm": {
-      "title": "विकल्प हटाएं",
+      "title": "कल्प हटाएं",
       "message": "क्या आप वाकई इस विकल्प को हटाना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती।"
+    }
+  },
+  "tags": {
+    "active": "सक्रिय",
+    "draft": "ड्राफ्ट",
+    "completed": "पूर्ण",
+    "archived": "अभिलेखागार",
+    "public": "सार्वजनिक",
+    "private": "निजी",
+    "fromTemplate": "टेम्पलेट से",
+    "withCollaborators": "सहयोगियों के साथ"
+  },
+  "methods": {
+    "categories": {
+      "test": "उपयोगकर्ता परीक्षण",
+      "inquiry": "उपयोगकर्ता अनुसंधान",
+      "inspection": "विशेषज्ञ निरीक्षण",
+      "accessibility": "पहुंच",
+      "other": "अन्य"
+    },
+    "definitions": {
+      "HEURISTICS": "हेयुरिस्टिक मूल्यांकन",
+      "USER_MODERATED": "मोडरेटेड उपयोगकर्ता परीक्षण",
+      "USER_UNMODERATED": "अनमोडरेटेड उपयोगकर्ता परीक्षण",
+      "SURVEY": "सर्वेक्षण",
+      "INTERVIEW": "साक्षात्कार",
+      "CARD_SORTING": "कार्ड सॉर्टिंग",
+      "COGNITIVE_WALKTHROUGH": "संज्ञानात्मक पूर्वाभ्यास",
+      "ACCESSIBILITY_MANUAL": "मैन्युअल मूल्यांकन",
+      "ACCESSIBILITY_AUTOMATIC": "स्वचालित मूल्यांकन",
+      "WCAG_AUDIT": "WCAG ऑडिट"
     }
   }
 }

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -1406,7 +1406,11 @@
       "SelfTest": {
         "title": "セルフテスト",
         "type": "非モデレート",
-        "text": ["自分の時間に回答", "高度な回答分析", "タスクのカスタマイズ"]
+        "text": [
+          "自分の時間に回答",
+          "高度な回答分析",
+          "タスクのカスタマイズ"
+        ]
       },
       "LiveTest": {
         "title": "ライブテスト",
@@ -1674,7 +1678,11 @@
       "blank": {
         "title": "空白の研究から開始",
         "description": "完全なカスタマイズでゼロから研究を作成します",
-        "features": ["完全なカスタマイズ", "ゼロから構築", "設定を完全に制御"]
+        "features": [
+          "完全なカスタマイズ",
+          "ゼロから構築",
+          "設定を完全に制御"
+        ]
       },
       "template": {
         "title": "テンプレートから作成",
@@ -1796,7 +1804,38 @@
     },
     "deleteOptionConfirm": {
       "title": "オプションを削除",
-      "message": "このオプションを削除してもよろしいですか？この操作は元に戻せません。"
+      "message": "このオプションを削除してもよろしいですか？この操作は取り消せません。"
+    }
+  },
+  "tags": {
+    "active": "アクティブ",
+    "draft": "下書き",
+    "completed": "完了",
+    "archived": "アーカイブ済み",
+    "public": "公開",
+    "private": "非公開",
+    "fromTemplate": "テンプレートから",
+    "withCollaborators": "共同作業者あり"
+  },
+  "methods": {
+    "categories": {
+      "test": "ユーザーテスト",
+      "inquiry": "ユーザー調査",
+      "inspection": "専門家評価",
+      "accessibility": "アクセシビリティ",
+      "other": "その他"
+    },
+    "definitions": {
+      "HEURISTICS": "ヒューリスティック評価",
+      "USER_MODERATED": "モデレートありのユーザビリティテスト",
+      "USER_UNMODERATED": "モデレートなしのユーザビリティテスト",
+      "SURVEY": "アンケート",
+      "INTERVIEW": "インタビュー",
+      "CARD_SORTING": "カードソーティング",
+      "COGNITIVE_WALKTHROUGH": "認知的ウォークスルー",
+      "ACCESSIBILITY_MANUAL": "マニュアル評価",
+      "ACCESSIBILITY_AUTOMATIC": "自動評価",
+      "WCAG_AUDIT": "WCAG監査"
     }
   }
 }

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -284,8 +284,6 @@
     "yourPassword": "Sua senha",
     "back": "Voltar",
     "deleteForever": "Excluir permanentemente",
-    "uploadProfilePicture": "Enviar foto de perfil",
-    "removeProfilePicture": "Remover foto de perfil",
     "currentPassword": "Senha atual",
     "currentPasswordRequired": "A senha atual é obrigatória",
     "wrongCurrentPassword": "A senha atual está incorreta",
@@ -1785,8 +1783,39 @@
       "message": "Tem certeza de que deseja excluir esta variável? Esta ação não pode ser desfeita."
     },
     "deleteOptionConfirm": {
-      "title": "Excluir Opção",
+      "title": "Excluir opção",
       "message": "Tem certeza de que deseja excluir esta opção? Esta ação não pode ser desfeita."
+    }
+  },
+  "tags": {
+    "active": "Ativo",
+    "draft": "Rascunho",
+    "completed": "Concluído",
+    "archived": "Arquivado",
+    "public": "Público",
+    "private": "Privado",
+    "fromTemplate": "A partir de modelo",
+    "withCollaborators": "Com colaboradores"
+  },
+  "methods": {
+    "categories": {
+      "test": "Testes de usuário",
+      "inquiry": "Pesquisa de usuário",
+      "inspection": "Inspeção de especialistas",
+      "accessibility": "Acessibilidade",
+      "other": "Outros"
+    },
+    "definitions": {
+      "HEURISTICS": "Avaliação Heurística",
+      "USER_MODERATED": "Teste de Usabilidade Moderado",
+      "USER_UNMODERATED": "Teste de Usabilidade Não Moderado",
+      "SURVEY": "Pesquisa",
+      "INTERVIEW": "Entrevista",
+      "CARD_SORTING": "Card Sorting",
+      "COGNITIVE_WALKTHROUGH": "Percurso Cognitivo",
+      "ACCESSIBILITY_MANUAL": "Avaliação Manual",
+      "ACCESSIBILITY_AUTOMATIC": "Avaliação Automática",
+      "WCAG_AUDIT": "Auditoria WCAG"
     }
   }
 }

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -284,8 +284,6 @@
     "back": "Назад",
     "deleteForever": "Удалить навсегда",
     "superAdmin": "Суперадмин",
-    "uploadProfilePicture": "Загрузить фото профиля",
-    "removeProfilePicture": "Удалить фото профиля",
     "currentPassword": "Текущий пароль",
     "currentPasswordRequired": "Требуется текущий пароль",
     "wrongCurrentPassword": "Текущий пароль неверен",
@@ -1807,6 +1805,37 @@
     "deleteOptionConfirm": {
       "title": "Удалить опцию",
       "message": "Вы уверены, что хотите удалить эту опцию? Это действие нельзя отменить."
+    }
+  },
+  "tags": {
+    "active": "Активный",
+    "draft": "Черновик",
+    "completed": "Завершено",
+    "archived": "Архивировано",
+    "public": "Публичный",
+    "private": "Приватный",
+    "fromTemplate": "Из шаблона",
+    "withCollaborators": "С соавторами"
+  },
+  "methods": {
+    "categories": {
+      "test": "Тестирование пользователей",
+      "inquiry": "Исследование пользователей",
+      "inspection": "Экспертная оценка",
+      "accessibility": "Доступность",
+      "other": "Другое"
+    },
+    "definitions": {
+      "HEURISTICS": "Эвристическая оценка",
+      "USER_MODERATED": "Модерируемое юзабилити-тестирование",
+      "USER_UNMODERATED": "Немодерируемое юзабилити-тестирование",
+      "SURVEY": "Опрос",
+      "INTERVIEW": "Интервью",
+      "CARD_SORTING": "Карточная сортировка",
+      "COGNITIVE_WALKTHROUGH": "Когнитивный проход",
+      "ACCESSIBILITY_MANUAL": "Ручная оценка",
+      "ACCESSIBILITY_AUTOMATIC": "Автоматическая оценка",
+      "WCAG_AUDIT": "Аудит WCAG"
     }
   }
 }

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -284,8 +284,6 @@
     "back": "返回",
     "deleteForever": "永久删除",
     "superAdmin": "超级管理员",
-    "uploadProfilePicture": "上传头像",
-    "removeProfilePicture": "删除头像",
     "currentPassword": "当前密码",
     "currentPasswordRequired": "当前密码为必填项",
     "wrongCurrentPassword": "当前密码错误",
@@ -1390,7 +1388,11 @@
     "test": "测试",
     "testType_1": {
       "testTitle": "可用性启发式",
-      "text": ["可用性百分比", "最终报告PDF", "邀请专家评估您的应用程序"]
+      "text": [
+        "可用性百分比",
+        "最终报告PDF",
+        "邀请专家评估您的应用程序"
+      ]
     },
     "testType_2": {
       "testTitle": "用户可用性",
@@ -1404,12 +1406,20 @@
       "SelfTest": {
         "title": "自主测试",
         "type": "无主持",
-        "text": ["在空闲时间回答", "增强的答案分析", "任务自定义"]
+        "text": [
+          "在空闲时间回答",
+          "增强的答案分析",
+          "任务自定义"
+        ]
       },
       "LiveTest": {
         "title": "实时测试",
         "type": "有主持",
-        "text": ["摄像头、音频和屏幕录制", "增强的答案分析", "有主持的实时测试"]
+        "text": [
+          "摄像头、音频和屏幕录制",
+          "增强的答案分析",
+          "有主持的实时测试"
+        ]
       }
     }
   },
@@ -1668,12 +1678,20 @@
       "blank": {
         "title": "从空白研究开始",
         "description": "从头开始创建研究，完全可定制",
-        "features": ["完全可定制", "从头构建", "对设置的完全控制"]
+        "features": [
+          "完全可定制",
+          "从头构建",
+          "对设置的完全控制"
+        ]
       },
       "template": {
         "title": "从模板创建",
         "description": "使用预构建的模板快速开始",
-        "features": ["快速设置", "预配置设置", "包含最佳实践"]
+        "features": [
+          "快速设置",
+          "预配置设置",
+          "包含最佳实践"
+        ]
       }
     },
     "details": {
@@ -1786,7 +1804,38 @@
     },
     "deleteOptionConfirm": {
       "title": "删除选项",
-      "message": "您确定要删除此选项吗？此操作无法撤消。"
+      "message": "您确定要删除此选项吗？此操作无法撤销。"
+    }
+  },
+  "tags": {
+    "active": "有效",
+    "draft": "草稿",
+    "completed": "已完成",
+    "archived": "已存档",
+    "public": "公开",
+    "private": "私人",
+    "fromTemplate": "从模板",
+    "withCollaborators": "与协作者"
+  },
+  "methods": {
+    "categories": {
+      "test": "用户测试",
+      "inquiry": "用户研究",
+      "inspection": "专家检查",
+      "accessibility": "无障碍",
+      "other": "其他"
+    },
+    "definitions": {
+      "HEURISTICS": "启发式评估",
+      "USER_MODERATED": "有主持人的可用性测试",
+      "USER_UNMODERATED": "无主持人的可用性测试",
+      "SURVEY": "调查",
+      "INTERVIEW": "访谈",
+      "CARD_SORTING": "卡片分类",
+      "COGNITIVE_WALKTHROUGH": "认知走查",
+      "ACCESSIBILITY_MANUAL": "手动评估",
+      "ACCESSIBILITY_AUTOMATIC": "自动评估",
+      "WCAG_AUDIT": "WCAG 审核"
     }
   }
 }

--- a/src/shared/composables/useItemFormatting.js
+++ b/src/shared/composables/useItemFormatting.js
@@ -6,7 +6,7 @@ import {
 } from '../constants/methodDefinitions'
 
 export function useItemFormatting(type) {
-  const { t } = useI18n()
+  const { t, ...i18n } = useI18n()
 
   const getItemTitle = (item) => {
     if (type.value === 'myTemplates' || type.value === 'publicTemplates')
@@ -36,10 +36,14 @@ export function useItemFormatting(type) {
   }
 
   const formatItemDate = (item) => {
-    if (type.value === 'myTemplates' || type.value === 'publicTemplates')
-      return formatDateLong(item.header.creationDate, 'es')
-    return formatDateLong(item.creationDate || item.updateDate, 'es')
+    const date =
+      type.value === 'myTemplates' || type.value === 'publicTemplates'
+        ? item.header?.creationDate
+        : item.creationDate || item.updateDate
+
+    return formatDateLong(date, i18n.locale.value)
   }
+
   const getTags = (item) => {
     const tags = []
 
@@ -47,7 +51,7 @@ export function useItemFormatting(type) {
     const definition = getMethodDefinition(item.testType, item.subType)
     if (definition) {
       tags.push({
-        label: definition.nameEn,
+        label: t(`methods.definitions.${definition.id}`),
         color: definition.color,
         icon: definition.icon,
       })
@@ -57,7 +61,7 @@ export function useItemFormatting(type) {
     const category = getMethodCategory(item)
     if (category) {
       tags.push({
-        label: category.nameEn,
+        label: t(`methods.categories.${category.id}`),
         color: category.color,
         icon: category.icon,
       })
@@ -65,9 +69,8 @@ export function useItemFormatting(type) {
 
     // status
     if (item.status) {
-      const status = item.status.charAt(0).toUpperCase() + item.status.slice(1)
       tags.push({
-        label: status,
+        label: t(`tags.${item.status}`),
         color:
           item.status === 'active'
             ? 'green'
@@ -86,7 +89,7 @@ export function useItemFormatting(type) {
     // visibility
     if (item.isPublic !== undefined) {
       tags.push({
-        label: item.isPublic ? 'Public' : 'Private',
+        label: item.isPublic ? t('tags.public') : t('tags.private'),
         color: item.isPublic ? 'green' : 'grey',
         icon: item.isPublic ? 'mdi-earth' : 'mdi-lock',
       })
@@ -95,7 +98,7 @@ export function useItemFormatting(type) {
     // if created from a template
     if (item.templateDoc) {
       tags.push({
-        label: 'From Template',
+        label: t('tags.fromTemplate'),
         color: '#9C27B0',
         icon: 'mdi-file-document-edit',
       })
@@ -104,7 +107,7 @@ export function useItemFormatting(type) {
     // has cooperators
     if (item.cooperators?.length > 0) {
       tags.push({
-        label: 'With Collaborators',
+        label: t('tags.withCollaborators'),
         color: '#ff6161ff',
         icon: 'mdi-account-multiple',
       })

--- a/src/shared/utils/dateUtils.js
+++ b/src/shared/utils/dateUtils.js
@@ -1,45 +1,21 @@
-const MONTHS_ES = {
-  0: 'January',
-  1: 'February',
-  2: 'March',
-  3: 'April',
-  4: 'May',
-  5: 'June',
-  6: 'July',
-  7: 'August',
-  8: 'September',
-  9: 'October',
-  10: 'November',
-  11: 'December',
-}
-
 /**
- * Formatea una fecha al formato "10 Enero 2024"
- * @param {string|Date} date - La fecha a formatear
- * @param {string} locale - El idioma ('es' para español, 'en' para inglés)
- * @returns {string} - Fecha formateada o '-' si no hay fecha
+ * Formatted date to long format (e.g., "10 January 2024")
+ * @param {string|Date} date - The date to format
+ * @param {string} locale - The language locale (e.g., 'es', 'en', 'zh')
+ * @returns {string} - Formatted date or '-' if invalid
  */
-export const formatDateLong = (date, locale = 'es') => {
+export const formatDateLong = (date, locale = 'en') => {
   if (!date) return '-'
 
   try {
     const d = new Date(date)
     if (isNaN(d.getTime())) return '-'
 
-    const day = d.getDate()
-    const month = d.getMonth()
-    const year = d.getFullYear()
-
-    if (locale === 'es') {
-      return `${day} ${MONTHS_ES[month]} ${year}`
-    } else {
-      // Inglés por defecto
-      return d.toLocaleDateString('en-US', {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-      })
-    }
+    return new Intl.DateTimeFormat(locale, {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    }).format(d)
   } catch (error) {
     console.warn('Error formatting date:', error)
     return '-'


### PR DESCRIPTION
fixes #1294

Summary of Changes
UI Fix: Resolved the layout overlap in the Monthly Office Hours card by refactoring it to use a stable flexbox layout.
Tag Localization: Replaced hardcoded English tags (e.g., "Active", "Public", "User Testing") with centralized translation keys across all 10 supported languages.
Date Localization: Updated the global date utility to use Intl.DateTimeFormat, ensuring dates like "2 February 2026" now format correctly according to the active language (e.g., Chinese, Arabic, Hindi).
Locale Cleanup: Fixed duplicate keys and formatting issues in several locale JSON files.

screenshots
before
<img width="3024" height="1148" alt="image" src="https://github.com/user-attachments/assets/855a1df2-9410-4342-b5af-8e386130621f" />
after
<img width="3024" height="1148" alt="image" src="https://github.com/user-attachments/assets/8926946c-e8c1-4069-bfed-3fe8ffbfa1e9" />
