### PR TITLE
fix: remove iframe event listeners in Answers.vue to prevent listener leak

### DIFF
--- a/src/shared/composables/useManagedListeners.js
+++ b/src/shared/composables/useManagedListeners.js
@@ -1,0 +1,56 @@
+/**
+ * Composable and factory for managed event listeners with optional cleanup callbacks.
+ * Ensures the same handler reference is used for add/remove so removeEventListener works.
+ * Use from Composition API via useManagedListeners(), or from Options API via createManagedListeners().
+ */
+
+/**
+ * Creates a managed listeners controller. Use this from Options API (e.g. in data() or created()).
+ * @returns {{ addListeners: (entries: Array<{target: EventTarget, event: string, handler: Function}>) => void, removeListeners: () => void, addCleanup: (fn: () => void) => void }}
+ */
+export function createManagedListeners() {
+  const entries = []
+  const cleanups = []
+
+  return {
+    addListeners(newEntries) {
+      if (!Array.isArray(newEntries)) return
+      for (const { target, event, handler } of newEntries) {
+        if (target && event && typeof handler === 'function') {
+          target.addEventListener(event, handler)
+          entries.push({ target, event, handler })
+        }
+      }
+    },
+    removeListeners() {
+      for (const { target, event, handler } of entries) {
+        try {
+          target.removeEventListener(event, handler)
+        } catch {
+          // target may already be detached
+        }
+      }
+      entries.length = 0
+      for (const fn of cleanups) {
+        try {
+          fn()
+        } catch (e) {
+          // eslint-disable-next-line no-console -- intentional for cleanup error reporting
+          console.warn('[useManagedListeners] cleanup error:', e)
+        }
+      }
+      cleanups.length = 0
+    },
+    addCleanup(fn) {
+      if (typeof fn === 'function') cleanups.push(fn)
+    },
+  }
+}
+
+/**
+ * Composable for managed event listeners. Use from Composition API (setup).
+ * @returns {{ addListeners: Function, removeListeners: Function, addCleanup: Function }}
+ */
+export function useManagedListeners() {
+  return createManagedListeners()
+}

--- a/src/ux/UserTest/components/dialogs/SessionAnalyticsDialog.vue
+++ b/src/ux/UserTest/components/dialogs/SessionAnalyticsDialog.vue
@@ -143,6 +143,7 @@
 
 <script setup>
 import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+import { useManagedListeners } from '@/shared/composables/useManagedListeners'
 import SessionTimeline from '../sessions/SessionTimeline.vue'
 import TranscriptWordCloud from '../sessions/TranscriptWordCloud.vue'
 import EyeTrackingStats from '../sessions/EyeTrackingStats.vue'
@@ -234,22 +235,21 @@ const onSeek = (time) => {
 
 const close = () => (open.value = false)
 
+const managedListeners = useManagedListeners()
+managedListeners.addCleanup(() => cancelAnimationFrame(rafId))
+
 onMounted(() => {
   const video = mainVideo2.value
   if (!video) return
 
-  video.addEventListener('loadedmetadata', onMetadataLoaded)
-  video.addEventListener('play', onVideoPlay)
-  video.addEventListener('pause', onVideoPause)
+  managedListeners.addListeners([
+    { target: video, event: 'loadedmetadata', handler: onMetadataLoaded },
+    { target: video, event: 'play', handler: onVideoPlay },
+    { target: video, event: 'pause', handler: onVideoPause },
+  ])
 })
 onBeforeUnmount(() => {
-  const video = mainVideo2.value
-  if (video) {
-    video.removeEventListener('loadedmetadata', onMetadataLoaded)
-    video.removeEventListener('play', onVideoPlay)
-    video.removeEventListener('pause', onVideoPause)
-  }
-  cancelAnimationFrame(rafId)
+  managedListeners.removeListeners()
 })
 </script>
 

--- a/src/ux/accessibility/view/automatic/Answers.vue
+++ b/src/ux/accessibility/view/automatic/Answers.vue
@@ -538,6 +538,7 @@
 <script>
 import { mapState, mapActions } from 'vuex'
 import PageWrapper from '@/shared/views/template/PageWrapper.vue'
+import { createManagedListeners } from '@/shared/composables/useManagedListeners'
 
 export default {
   name: 'ReportDetail',
@@ -554,6 +555,7 @@ export default {
       page: 1,
       itemsPerPage: 10,
       infiniteScrollCount: 20, // Number of issues to show initially in infinite scroll
+      iframeListeners: createManagedListeners(),
     }
   },
   computed: {
@@ -593,6 +595,9 @@ export default {
         }, 100)
       })
     })
+  },
+  beforeUnmount() {
+    this.iframeListeners.removeListeners()
   },
   methods: {
     ...mapActions('automaticReport', ['fetchReport']),
@@ -640,6 +645,26 @@ export default {
       this.selectedIssue = index
       this.scrollToIssue(index)
     },
+    _onIframeLoad() {
+      const frame = this.$refs.previewFrame
+      if (!frame?.contentWindow || !frame?.contentDocument) return
+      this.iframeListeners.addListeners([
+        {
+          target: frame.contentWindow,
+          event: 'click',
+          handler: this._onContentWindowClick,
+        },
+      ])
+    },
+    _onContentWindowClick(event) {
+      const issueMarker = event.target.closest('.a11y-issue-marker')
+      if (issueMarker) {
+        const issueId = issueMarker.getAttribute('data-issue-id')
+        const index = parseInt(issueId?.replace('issue-', '') ?? '', 10)
+        if (!Number.isFinite(index) || index < 0) return
+        this.selectIssue(index)
+      }
+    },
     renderModifiedHtml() {
       if (
         !this.$refs.previewFrame ||
@@ -649,21 +674,14 @@ export default {
         return
       }
       try {
+        this.iframeListeners.removeListeners()
         const frame = this.$refs.previewFrame
-        frame.addEventListener('load', () => {
-          if (!frame.contentWindow || !frame.contentDocument) {
-            return
-          }
-          frame.contentWindow.addEventListener('click', (event) => {
-            const issueMarker = event.target.closest('.a11y-issue-marker')
-            if (issueMarker) {
-              const issueId = issueMarker.getAttribute('data-issue-id')
-              const index = parseInt(issueId.replace('issue-', ''))
-              this.selectIssue(index)
-            }
-          })
-        })
-      } catch {}
+        this.iframeListeners.addListeners([
+          { target: frame, event: 'load', handler: this._onIframeLoad },
+        ])
+      } catch {
+        // Ignore DOM/ref errors when iframe is not ready
+      }
     },
     scrollToIssue(index) {
       if (


### PR DESCRIPTION
## Summary

Fixes #1589 

This PR fixes the iframe listener leak in Answers.vue  and incorporates the reviewer feedback (https://github.com/ruxailab/RUXAILAB/pull/1566#pullrequestreview-3746850832) from the previous Session Analytics Dialog listener-cleanup PR: it introduces a shared helper for add/remove listeners and keeps all cleanup (including `cancelAnimationFrame`) in a single block.

## Changes made

- Added a shared composable/helper (`useManagedListeners`) that supports `addListeners`, `removeListeners`, and optional `addCleanup`, so the same handler reference is used for add/remove and `removeEventListener` works correctly.
- Refactored **SessionAnalyticsDialog** to use this helper for the three video event listeners (loadedmetadata, play, pause) and to run `cancelAnimationFrame(rafId)` in the same cleanup path as listener removal.
- Fixed **Answers.vue** : introduced named handlers (`_onIframeLoad`, `_onContentWindowClick`), teardown at the start of `renderModifiedHtml()` and in `beforeUnmount()`, and use of the helper so iframe `load` and contentWindow `click` listeners are always removed and never accumulate.

I've also addressed the maintainer's suggestion from the previous PR (https://github.com/ruxailab/RUXAILAB/pull/1566#pullrequestreview-3746850832).

## Files modified

- **src/shared/composables/useManagedListeners.js** – New composable and `createManagedListeners()` factory for managed event listeners and optional cleanup.
- **src/ux/UserTest/components/dialogs/SessionAnalyticsDialog.vue** – Uses `useManagedListeners` for video listeners and registers `cancelAnimationFrame` via `addCleanup` so all cleanup runs together.
- **src/ux/accessibility/view/automatic/Answers.vue** – Uses `createManagedListeners()` for iframe/contentWindow listeners, named handlers, teardown in `renderModifiedHtml` and `beforeUnmount`; no template changes.

## Verification

- Confirmed listener teardown runs at the start of `renderModifiedHtml()` and in `beforeUnmount()` in Answers.vue so listeners do not accumulate on re-render or unmount.
- Confirmed SessionAnalyticsDialog uses one cleanup block (listeners + `cancelAnimationFrame`) in `onBeforeUnmount`.
- No template changes in Answers.vue; scope limited to Issue and the previous PR's feedback.

## Scope

- Issue  (Answers.vue iframe listeners) and reviewer feedback from the https://github.com/ruxailab/RUXAILAB/pull/1566
- No conversion of Answers.vue to Composition API.