### PR TITLE
docs: add SECURITY.md security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+Thank you for helping keep **UX Remote LAB** and its users safe!
+
+## Supported Versions
+
+We provide security updates for the **latest version only**. We encourage all users to keep their installations up to date.
+
+## Reporting a Vulnerability
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+### How to Report
+
+Use GitHub's **Private Vulnerability Reporting** feature:
+
+1. Go to the [Security tab](https://github.com/uramakilab/remote-usability-lab/security) of this repository
+2. Click **"Report a vulnerability"**
+3. Fill out the form with details about the vulnerability
+
+> [!NOTE]
+> If the "Report a vulnerability" button is not visible, private vulnerability reporting may need to be enabled by a maintainer.  
+> **Maintainers**: Enable this in Repository Settings → Security → Private vulnerability reporting.
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Any suggested fixes (optional)
+
+### What to Expect
+
+We will review your report and respond as soon as possible. The timeline for fixes depends on the severity and complexity of the issue.
+
+## Disclosure
+
+We follow coordinated disclosure practices. Once a fix is released, we will publish a security advisory crediting the reporter (unless they prefer to remain anonymous).
+
+---
+
+_Last updated: February 2026_


### PR DESCRIPTION
## Summary
 
### Fixes #1594

This PR adds a `SECURITY.md` file to define a clear security policy for the project.

GitHub currently shows a “No security policy” warning. This change addresses that by documenting how security vulnerabilities should be reported responsibly and privately.

---

## What’s included

- Added a `SECURITY.md` file at the repository root
- Documented the preferred process for reporting security vulnerabilities
- Encouraged use of GitHub’s Private Vulnerability Reporting feature
- Clarified that only the latest version receives security updates
- Added guidance for coordinated disclosure after fixes are released

---

## Why this change

- Provides a safe and private channel for reporting security issues
- Prevents accidental public disclosure via GitHub issues
- Improves project trust and maturity
- Removes GitHub’s “No security policy” warning

---

## Scope

- Documentation-only change
- No production code changes
- No CI or dependency changes

---

## Notes

- The policy is intentionally lightweight and non-prescriptive
- No response-time guarantees or strict requirements are enforced
- Can be expanded later based on maintainer feedback
