### PR TITLE
style(ui): unify heuristic creation flow and refine empty state design

### DIFF
--- a/src/ux/Heuristic/components/HeuristicsTable.vue
+++ b/src/ux/Heuristic/components/HeuristicsTable.vue
@@ -429,28 +429,19 @@
     <!-- Empty State for No Heuristics -->
     <v-row v-if="filteredHeuristics.length === 0">
       <v-col cols="12">
-        <v-card class="text-center pa-8 empty-heuristics" variant="outlined">
+        <v-card class="text-center py-16 empty-heuristics" variant="outlined">
           <v-icon
-            icon="mdi-file-remove"
+            icon="mdi-clipboard-text-outline"
             size="64"
-            color="primary"
+            color="grey-darken-1"
             class="mb-4"
           />
-          <h3 class="text-h5 text-ternary mb-2">
+          <h3 class="text-h5 font-weight-bold text-grey-darken-3 mb-2">
             {{ $t('HeuristicsTable.titles.noHeuristicsFound') }}
           </h3>
-          <p class="text-body-1 text-ternary empty-state-text">
+          <p class="text-body-1 text-grey-darken-1">
             {{ $t('HeuristicsTable.messages.noHeuristics') }}
           </p>
-          <v-btn
-            color="primary"
-            variant="outlined"
-            prepend-icon="mdi-plus"
-            :disabled="testAnswerDocLength > 0"
-            @click="dialogHeuris = true"
-          >
-            {{ $t('HeuristicsTable.titles.addNewHeuristic') }}
-          </v-btn>
         </v-card>
       </v-col>
     </v-row>


### PR DESCRIPTION
fixes #1597 
Changes

Unified CTA Placement
	•	The top-right “Add new heuristic” button is now the single primary entry point, consistent with other tabs.

Removed Duplicate CTA
	•	Removed the empty-state “Add new heuristic” button to eliminate competing primary actions and reduce visual clutter.

Enhanced Empty State UI
	•	Replaced the icon with mdi-clipboard-text-outline for clearer contextual meaning
	•	Updated typography with bolder headers and consistent grey-darken colors
	•	Increased vertical spacing (py-16) to achieve a more balanced, premium layout

Result
	•	Clear, predictable CTA placement
	•	Consistent interaction pattern across tabs
	•	Cleaner, calmer empty state aligned with the Options tab design
screenshots
before
<img width="1508" height="829" alt="image" src="https://github.com/user-attachments/assets/d804c642-6a4a-4805-bd75-22d095b6419c" />
after
<img width="3016" height="1658" alt="image" src="https://github.com/user-attachments/assets/652f943a-d076-4f69-b25e-6726fb7c6a0c" />
