### PR TITLE
fix: update Firestore security rules to require authentication

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,7 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write: if
-          request.time < timestamp.date(2025, 10, 18);
+      allow read, write: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
## Summary

### Fixes #1610 

### What was the issue?
- Firestore rules relied on a hardcoded timestamp (`2025-10-18`)
- Before expiry, the database was effectively public
- After expiry, all database access would fail
- This created both **security** and **availability** risks

### What was changed?
- Updated `firestore.rules` to enforce authentication-based access control
- Only authenticated users can now read and write data

```js
allow read, write: if request.auth != null;
```
### Why this approach?

- request.auth != null is the standard Firebase security baseline

- Prevents unauthorized access immediately

- Allows future extension with more granular, role-based rules if needed

### Impact

- Protects user data from unauthorized access

- Prevents accidental production outages due to expired rules

- Aligns with Firebase security best practices