### PR TITLE
fix: implement horizontal scrollable tabs for mobile accessibility

### DIFF
--- a/src/ux/UserTest/views/EditTestView.vue
+++ b/src/ux/UserTest/views/EditTestView.vue
@@ -10,24 +10,29 @@
       <ButtonSave :visible="true" @click="save" />
 
       <div>
-        <v-tabs bg-color="transparent" color="#FCA326" class="pb-0 mb-0">
-          <v-tab @click="index = 0">
+        <v-tabs 
+          bg-color="transparent" 
+          color="#FCA326" 
+          class="pb-0 mb-0 scrollable-tabs"
+          show-arrows
+        >
+          <v-tab @click="index = 0" class="uppercase-tab">
             {{ $t('UserTestTable.titles.testConfiguration') }}
           </v-tab>
-          <v-tab @click="index = 1">
+          <v-tab @click="index = 1" class="uppercase-tab">
             {{ $t('ModeratedTest.consentForm') }}
           </v-tab>
-          <v-tab @click="index = 2">
+          <v-tab @click="index = 2" class="uppercase-tab">
             {{ $t('ModeratedTest.preTest') }}
           </v-tab>
-          <v-tab @click="index = 3">
+          <v-tab @click="index = 3" class="uppercase-tab">
             {{ $t('ModeratedTest.tasks') }}
           </v-tab>
-          <v-tab @click="index = 4">
+          <v-tab @click="index = 4" class="uppercase-tab">
             {{ $t('ModeratedTest.postTest') }}
           </v-tab>
-          <v-tab v-if="hasEyeTracking" @click="index = 5">
-            Eye Tracking Configurations
+          <v-tab v-if="hasEyeTracking" @click="index = 5" class="uppercase-tab">
+            EYE TRACKING CONFIGURATIONS
           </v-tab>
         </v-tabs>
 
@@ -235,5 +240,47 @@ onUnmounted(() => {
 .v-text-field--outlined :deep(fieldset) {
   border-radius: 25px;
   border: 1px solid #ffceb2;
+}
+
+.scrollable-tabs {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+.scrollable-tabs :deep(.v-tabs-bar) {
+  min-width: max-content;
+}
+
+.scrollable-tabs :deep(.v-slide-group__content) {
+  flex-wrap: nowrap;
+}
+
+.uppercase-tab {
+  text-transform: uppercase !important;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  min-width: fit-content;
+}
+
+.scrollable-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.scrollable-tabs {
+  -ms-overflow-style: none; 
+  scrollbar-width: none; 
+}
+
+@media (max-width: 960px) {
+  .scrollable-tabs {
+    padding-bottom: 8px;
+  }
+  
+  .scrollable-tabs :deep(.v-tab) {
+    padding: 0 16px;
+    font-size: 14px;
+  }
 }
 </style>


### PR DESCRIPTION
fixed issue: #1579 

### PR Summary

**Problem**: Mobile users cannot access all tabs (PRE-TEST, TASKS, POST-TEST) in Edit Test view due to horizontal overflow.

**Solution**: Implement horizontal scrollable tab system:

- Horizontal scroll on mobile devices
- Navigation arrows appear when tabs overflow
- Touch-friendly scrolling with -webkit-overflow-scrolling: touch
- Hidden scrollbars for clean UI

### Files Changed:

- `EditTestView.vue` - Added scrollable tab functionality with CSS styles

### Key Changes:

- Added show-arrows prop to v-tabs component
- Implemented horizontal scrolling with overflow-x: auto
- Added touch scrolling support for mobile
- Hidden scrollbars while maintaining functionality
- Mobile-responsive padding and font adjustments

Before:
<img width="738" height="1122" alt="image" src="https://github.com/user-attachments/assets/04659ab4-242a-4148-a142-d08863ec7775" />
<img width="615" height="1147" alt="image" src="https://github.com/user-attachments/assets/8f3678da-2235-49c8-adf2-3ccaddebc507" />

After:
<img width="674" height="911" alt="image" src="https://github.com/user-attachments/assets/9911721d-8e4b-468d-83ef-f572562ae489" />
