### PR TITLE
style(lint): fix eslint warnings in src/features folder

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -237,7 +237,16 @@
       "viewEditProfile": "View and edit your profile information",
       "exploreCommunityStudies": "Explore studies shared by the RUXAI community",
       "browseCommunityTemplates": "Browse templates contributed by the RUXAI community"
-    }
+    },
+    "appName": "RUXAILAB",
+    "tagline": "UX Research Platform",
+    "appNavigation": "App Navigation",
+    "createNewStudy": "Create New Study",
+    "exitTest": "Exit Test",
+    "signOut": "Sign Out",
+    "previousStep": "Previous Step",
+    "nextStep": "Next Step",
+    "finishTest": "Finish Test"
   },
   "profile": {
     "title": "Profile",
@@ -480,8 +489,12 @@
       "today": "Today",
       "joinNow": "Join Now",
       "webinarEnded": "Webinar Ended",
-      "startingToday": "Starting Today"
+      "startingToday": "Starting Today",
+      "startSession": "Start Session"
     },
+    "studyType": "Study Type",
+    "noRecentActivity": "No recent activity",
+    "viewAllActivity": "View All Activity",
     "cards": {
       "recentActivity": "Recent Activity",
       "activities7Days": "Activities (7 days total)",

--- a/src/features/auth/composables/useProfile.js
+++ b/src/features/auth/composables/useProfile.js
@@ -104,7 +104,7 @@ export function useProfile() {
     return new Promise((resolve, reject) => {
       const reader = new FileReader()
       reader.onload = () => resolve(reader.result)
-      reader.onerror = (error) => reject(new Error('Failed to read file'))
+      reader.onerror = () => reject(new Error('Failed to read file'))
       reader.readAsDataURL(file)
     })
   }

--- a/src/features/dashboard/components/NextSession.vue
+++ b/src/features/dashboard/components/NextSession.vue
@@ -42,7 +42,7 @@
           />
           <div class="info-content">
             <div class="info-value">{{ getStudyType(nextSession) }}</div>
-            <div>Tipo de Estudio</div>
+            <div>{{ $t('Dashboard.studyType') }}</div>
           </div>
         </div>
         <div class="info-item">

--- a/src/features/dashboard/components/RecentActivityList.vue
+++ b/src/features/dashboard/components/RecentActivityList.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="recent-activity-list">
-    <div
-      v-if="activities.length === 0"
-      class="empty-state text-center py-4"
-    >
+    <div v-if="activities.length === 0" class="empty-state text-center py-4">
       <v-icon
         icon="mdi-history"
         size="48"
@@ -11,14 +8,11 @@
         class="mb-2"
       />
       <p class="text-body-2 text-grey-darken-1">
-        No recent activity
+        {{ $t('Dashboard.noRecentActivity') }}
       </p>
     </div>
 
-    <div
-      v-else
-      class="activity-timeline"
-    >
+    <div v-else class="activity-timeline">
       <div
         v-for="(activity, index) in activities"
         :key="activity.id"
@@ -26,28 +20,22 @@
         :class="{ 'mb-4': index !== activities.length - 1 }"
       >
         <div class="activity-indicator">
-          <div
-            class="activity-icon"
-            :class="`bg-${activity.color}`"
-          >
-            <v-icon
-              :icon="activity.icon"
-              size="16"
-              color="white"
-            />
+          <div class="activity-icon" :class="`bg-${activity.color}`">
+            <v-icon :icon="activity.icon" size="16" color="white" />
           </div>
-          <div
-            v-if="index !== activities.length - 1"
-            class="activity-line"
-          />
+          <div v-if="index !== activities.length - 1" class="activity-line" />
         </div>
 
         <div class="activity-content">
           <div class="activity-header">
-            <h4 class="text-subtitle-2 font-weight-medium text-grey-darken-4 mb-1">
+            <h4
+              class="text-subtitle-2 font-weight-medium text-grey-darken-4 mb-1"
+            >
               {{ activity.title }}
             </h4>
-            <span class="text-caption text-grey-darken-1">{{ activity.timestamp }}</span>
+            <span class="text-caption text-grey-darken-1">{{
+              activity.timestamp
+            }}</span>
           </div>
           <p class="text-body-2 text-grey-darken-2 mb-0">
             {{ activity.description }}
@@ -56,17 +44,14 @@
       </div>
     </div>
 
-    <div
-      v-if="activities.length > 0"
-      class="mt-4 text-center"
-    >
+    <div v-if="activities.length > 0" class="mt-4 text-center">
       <v-btn
         variant="text"
         color="primary"
         size="small"
         @click="$router.push('/admin?section=notifications')"
       >
-        View All Activity
+        {{ $t('Dashboard.viewAllActivity') }}
       </v-btn>
     </div>
   </div>
@@ -74,79 +59,79 @@
 
 <script setup>
 defineProps({
-    activities: {
-        type: Array,
-        default: () => []
-    }
+  activities: {
+    type: Array,
+    default: () => [],
+  },
 })
 </script>
 
 <style scoped>
 .recent-activity-list {
-    max-height: 400px;
-    overflow-y: auto;
+  max-height: 400px;
+  overflow-y: auto;
 }
 
 .activity-item {
-    display: flex;
-    align-items: flex-start;
-    position: relative;
+  display: flex;
+  align-items: flex-start;
+  position: relative;
 }
 
 .activity-indicator {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-right: 16px;
-    position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-right: 16px;
+  position: relative;
 }
 
 .activity-icon {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
 }
 
 .activity-line {
-    width: 2px;
-    height: 40px;
-    background-color: #e0e0e0;
-    margin-top: 4px;
+  width: 2px;
+  height: 40px;
+  background-color: #e0e0e0;
+  margin-top: 4px;
 }
 
 .activity-content {
-    flex: 1;
-    padding-top: 4px;
+  flex: 1;
+  padding-top: 4px;
 }
 
 .activity-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .bg-success {
-    background-color: rgb(var(--v-theme-success));
+  background-color: rgb(var(--v-theme-success));
 }
 
 .bg-info {
-    background-color: rgb(var(--v-theme-info));
+  background-color: rgb(var(--v-theme-info));
 }
 
 .bg-warning {
-    background-color: rgb(var(--v-theme-warning));
+  background-color: rgb(var(--v-theme-warning));
 }
 
 .bg-error {
-    background-color: rgb(var(--v-theme-error));
+  background-color: rgb(var(--v-theme-error));
 }
 
 .bg-primary {
-    background-color: rgb(var(--v-theme-primary));
+  background-color: rgb(var(--v-theme-primary));
 }
 </style>

--- a/src/features/dashboard/views/DashboardView.vue
+++ b/src/features/dashboard/views/DashboardView.vue
@@ -3,7 +3,7 @@
     <!-- Header with User Welcome -->
     <div class="dashboard-header mb-6">
       <h1 class="text-h4 font-weight-bold text-grey-darken-4 mb-2">
-        {{ $t('Dashboard.welcomeBack', { name: userDisplayName }) }} 👋
+        {{ $t('Dashboard.welcomeBack', { name: userDisplayName }) }}
       </h1>
       <p class="text-subtitle-1 text-grey-darken-1">
         {{ $t('Dashboard.subtitle') }}

--- a/src/features/navigation/components/MobileNavigationDrawer.vue
+++ b/src/features/navigation/components/MobileNavigationDrawer.vue
@@ -1,20 +1,38 @@
 <template>
-  <v-navigation-drawer v-model="isOpen" temporary location="left" width="300" elevation="4" class="mobile-drawer">
+  <v-navigation-drawer
+    v-model="isOpen"
+    temporary
+    location="left"
+    width="300"
+    elevation="4"
+    class="mobile-drawer"
+  >
     <!-- Header -->
     <div class="drawer-header pa-4">
       <div class="d-flex align-center justify-space-between">
         <div class="d-flex align-center">
-          <img src="@/assets/logo_full.png" alt="RUXAILAB" height="32" class="mr-3">
+          <img
+            src="@/assets/logo_full.png"
+            alt="RUXAILAB"
+            height="32"
+            class="mr-3"
+          />
           <div>
             <h4 class="text-primary font-weight-bold">
-              RUXAILAB
+              {{ $t('navigation.appName') }}
             </h4>
             <p class="text-caption text-medium-emphasis ma-0">
-              UX Research Platform
+              {{ $t('navigation.tagline') }}
             </p>
           </div>
         </div>
-        <v-btn icon="mdi-close" variant="text" size="small" color="primary" @click="closeDrawer" />
+        <v-btn
+          icon="mdi-close"
+          variant="text"
+          size="small"
+          color="primary"
+          @click="closeDrawer"
+        />
       </div>
     </div>
 
@@ -48,17 +66,30 @@
       <div v-if="isInTest" class="test-context pa-4">
         <div class="context-header mb-3">
           <v-icon :icon="testIcon" color="primary" size="20" class="mr-2" />
-          <span class="text-body-2 font-weight-bold text-primary">{{ testTitle }}</span>
+          <span class="text-body-2 font-weight-bold text-primary">{{
+            testTitle
+          }}</span>
         </div>
 
         <!-- Test Navigation Items -->
         <v-list class="test-nav-list" nav>
           <v-list-item
-v-for="item in filteredTestItems" :key="item.id" :title="item.title" :prepend-icon="item.icon"
-            :active="activeStep === item.id" :disabled="item.disabled" class="nav-item" rounded="lg"
-            @click="navigateToStep(item)">
+            v-for="item in filteredTestItems"
+            :key="item.id"
+            :title="item.title"
+            :prepend-icon="item.icon"
+            :active="activeStep === item.id"
+            :disabled="item.disabled"
+            class="nav-item"
+            rounded="lg"
+            @click="navigateToStep(item)"
+          >
             <template v-if="item.status" #append>
-              <v-icon :icon="getStatusIcon(item.status)" :color="getStatusColor(item.status)" size="16" />
+              <v-icon
+                :icon="getStatusIcon(item.status)"
+                :color="getStatusColor(item.status)"
+                size="16"
+              />
             </template>
           </v-list-item>
         </v-list>
@@ -68,22 +99,33 @@ v-for="item in filteredTestItems" :key="item.id" :title="item.title" :prepend-ic
       <div class="global-context pa-4">
         <div v-if="isInTest" class="context-header mb-3">
           <v-icon icon="mdi-apps" color="primary" size="20" class="mr-2" />
-          <span class="text-body-2 font-weight-bold text-primary">App Navigation</span>
+          <span class="text-body-2 font-weight-bold text-primary">{{
+            $t('navigation.appNavigation')
+          }}</span>
         </div>
 
         <v-list class="global-nav-list" nav>
           <template v-for="item in globalNavigationItems" :key="item.id">
             <!-- Section Headers -->
             <div v-if="item.type === 'header'" class="section-header">
-              <p class="text-caption text-medium-emphasis font-weight-bold px-2 py-1 ma-0">
+              <p
+                class="text-caption text-medium-emphasis font-weight-bold px-2 py-1 ma-0"
+              >
                 {{ item.title }}
               </p>
             </div>
 
             <!-- Navigation Items -->
             <v-list-item
-v-else :title="item.title" :subtitle="item.subtitle" :prepend-icon="item.icon"
-              :active="activeSection === item.id" class="nav-item" rounded="lg" @click="navigateToSection(item)">
+              v-else
+              :title="item.title"
+              :subtitle="item.subtitle"
+              :prepend-icon="item.icon"
+              :active="activeSection === item.id"
+              class="nav-item"
+              rounded="lg"
+              @click="navigateToSection(item)"
+            >
               <template v-if="item.badge" #append>
                 <v-chip :color="item.badge.color" size="x-small" variant="flat">
                   {{ item.badge.text }}
@@ -97,19 +139,41 @@ v-else :title="item.title" :subtitle="item.subtitle" :prepend-icon="item.icon"
       <!-- Action Buttons -->
       <div class="action-section pa-4 mt-auto">
         <v-btn
-v-if="!isInTest" color="primary" block size="large" prepend-icon="mdi-plus" rounded="lg"
-          class="create-button mb-3" @click="createStudy">
-          Create New Study
+          v-if="!isInTest"
+          color="primary"
+          block
+          size="large"
+          prepend-icon="mdi-plus"
+          rounded="lg"
+          class="create-button mb-3"
+          @click="createStudy"
+        >
+          {{ $t('navigation.createNewStudy') }}
         </v-btn>
 
         <v-btn
-v-if="isInTest" variant="outlined" color="primary" block prepend-icon="mdi-arrow-left" rounded="lg"
-          class="mb-3" @click="exitTest">
-          Exit Test
+          v-if="isInTest"
+          variant="outlined"
+          color="primary"
+          block
+          prepend-icon="mdi-arrow-left"
+          rounded="lg"
+          class="mb-3"
+          @click="exitTest"
+        >
+          {{ $t('navigation.exitTest') }}
         </v-btn>
 
-        <v-btn v-if="user" variant="text" color="error" block prepend-icon="mdi-logout" rounded="lg" @click="signOut">
-          Sign Out
+        <v-btn
+          v-if="user"
+          variant="text"
+          color="error"
+          block
+          prepend-icon="mdi-logout"
+          rounded="lg"
+          @click="signOut"
+        >
+          {{ $t('navigation.signOut') }}
         </v-btn>
       </div>
     </div>
@@ -117,43 +181,43 @@ v-if="isInTest" variant="outlined" color="primary" block prepend-icon="mdi-arrow
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed } from 'vue'
 
 // Props
 const props = defineProps({
   modelValue: {
     type: Boolean,
-    default: false
+    default: false,
   },
   user: {
     type: Object,
-    default: null
+    default: null,
   },
   userAccessLevel: {
     type: String,
-    default: 'basic'
+    default: 'basic',
   },
   activeSection: {
     type: String,
-    default: null
+    default: null,
   },
   activeStep: {
     type: String,
-    default: null
+    default: null,
   },
   isInTest: {
     type: Boolean,
-    default: false
+    default: false,
   },
   testType: {
     type: String,
-    default: null
+    default: null,
   },
   testTitle: {
     type: String,
-    default: 'Test'
-  }
-});
+    default: 'Test',
+  },
+})
 
 // Emits
 const emit = defineEmits([
@@ -163,14 +227,14 @@ const emit = defineEmits([
   'create-test',
   'exit-test',
   'sign-out',
-  'close'
-]);
+  'close',
+])
 
 // Computed
 const isOpen = computed({
   get: () => props.modelValue,
-  set: (value) => emit('update:modelValue', value)
-});
+  set: (value) => emit('update:modelValue', value),
+})
 
 const testIcon = computed(() => {
   const typeIcons = {
@@ -179,77 +243,77 @@ const testIcon = computed(() => {
     tree: 'mdi-file-tree',
     'card-sorting': 'mdi-card-multiple',
     'first-click': 'mdi-cursor-default-click',
-    'five-second': 'mdi-timer-5'
-  };
-  return typeIcons[props.testType] || 'mdi-test-tube';
-});
+    'five-second': 'mdi-timer-5',
+  }
+  return typeIcons[props.testType] || 'mdi-test-tube'
+})
 
 const filteredTestItems = computed(() => {
-  if (!props.isInTest || !props.testType) return [];
-  return getFilteredTestItems(props.testType, props.userAccessLevel);
-});
+  if (!props.isInTest || !props.testType) return []
+  return getFilteredTestItems(props.testType, props.userAccessLevel)
+})
 
 // Methods
 const closeDrawer = () => {
-  emit('close');
-  isOpen.value = false;
-};
+  emit('close')
+  isOpen.value = false
+}
 
 const navigateToSection = (item) => {
-  emit('navigate-section', item);
-  closeDrawer();
-};
+  emit('navigate-section', item)
+  closeDrawer()
+}
 
 const navigateToStep = (item) => {
   if (!item.disabled) {
-    emit('navigate-step', item);
-    closeDrawer();
+    emit('navigate-step', item)
+    closeDrawer()
   }
-};
+}
 
 const createStudy = () => {
-  emit('create-test');
-  closeDrawer();
-};
+  emit('create-test')
+  closeDrawer()
+}
 
 const exitTest = () => {
-  emit('exit-test');
-  closeDrawer();
-};
+  emit('exit-test')
+  closeDrawer()
+}
 
 const signOut = () => {
-  emit('sign-out');
-  closeDrawer();
-};
+  emit('sign-out')
+  closeDrawer()
+}
 
 const getAccessLevelText = (level) => {
   const levelTexts = {
     basic: 'Basic User',
     premium: 'Premium User',
-    admin: 'Administrator'
-  };
-  return levelTexts[level] || 'User';
-};
+    admin: 'Administrator',
+  }
+  return levelTexts[level] || 'User'
+}
 
 const getStatusIcon = (status) => {
   const statusIcons = {
     completed: 'mdi-check-circle',
     current: 'mdi-play-circle',
     pending: 'mdi-clock-outline',
-    error: 'mdi-alert-circle'
-  };
-  return statusIcons[status] || 'mdi-circle-outline';
-};
+    error: 'mdi-alert-circle',
+  }
+  return statusIcons[status] || 'mdi-circle-outline'
+}
 
 const getStatusColor = (status) => {
   const statusColors = {
     completed: 'success',
     current: 'primary',
     pending: 'grey',
-    error: 'error'
-  };
-  return statusColors[status] || 'grey';
-};
+    error: 'error',
+  }
+  return statusColors[status] || 'grey'
+}
 </script>
 
 <style scoped>
@@ -292,15 +356,15 @@ const getStatusColor = (status) => {
 .nav-item {
   transition: all 0.2s ease-in-out;
   margin-bottom: 4px;
-  color: var(--v-primary-base, #00213F) !important;
+  color: var(--v-primary-base, #00213f) !important;
 }
 
 .nav-item .v-list-item__prepend .v-icon {
-  color: var(--v-primary-base, #00213F) !important;
+  color: var(--v-primary-base, #00213f) !important;
 }
 
 .nav-item .v-list-item-title {
-  color: var(--v-primary-base, #00213F) !important;
+  color: var(--v-primary-base, #00213f) !important;
 }
 
 .nav-item.v-list-item--active {

--- a/src/features/navigation/components/TestNavigationDrawer.vue
+++ b/src/features/navigation/components/TestNavigationDrawer.vue
@@ -105,7 +105,7 @@
           prepend-icon="mdi-arrow-left"
           @click="goBack"
         >
-          Previous Step
+          {{ $t('navigation.previousStep') }}
         </v-btn>
 
         <v-btn
@@ -116,7 +116,7 @@
           append-icon="mdi-arrow-right"
           @click="goNext"
         >
-          Next Step
+          {{ $t('navigation.nextStep') }}
         </v-btn>
 
         <v-btn
@@ -126,7 +126,7 @@
           prepend-icon="mdi-check"
           @click="finishTest"
         >
-          Finish Test
+          {{ $t('navigation.finishTest') }}
         </v-btn>
       </div>
     </div>


### PR DESCRIPTION
Fixes #1626

### Summary

Resolved all 15 ESLint warnings reported when running `npx eslint src/features`.

### Changes made

**1. Unused variable fix**

- Removed unused `error` parameter in `useProfile.js` FileReader callback

**2. i18n fixes**

- Added 13 missing translation keys to `en.json` (e.g., `Dashboard.studyType`, `navigation.appName`, `navigation.signOut`, etc.)
- Replaced hardcoded Spanish text "Tipo de Estudio" with proper i18n call
- Replaced raw text strings in navigation components with `$t()` calls

### Verification

```bash
npx eslint src/features
# Returns 0 warnings ✓
```
