### PR TITLE
Fixes all 34 ESLint warnings in the `src/shared/components` directory

### DIFF
--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -278,7 +278,7 @@
     "enterValidPhoneNumber": "الرجاء إدخال رقم هاتف صالح (9-15 رقمًا فقط)",
     "profileImageUpdatedSuccess": "تم تحديث صورة الملف الشخصي بنجاح",
     "profileImageUploadFailed": "فشل تحميل صورة الملف الشخصي",
-    "uploadProfilePicture": "رفع صورة الملف الشخصي",
+    "uploadProfilePicture": "تحميل صورة الملف الشخصي",
     "removeProfilePicture": "إزالة صورة الملف الشخصي",
     "takePhoto": "التقاط صورة",
     "cameraCaptureTitle": "التقاط صورة الملف الشخصي",
@@ -296,8 +296,6 @@
     "back": "عودة",
     "deleteForever": "حذف نهائي",
     "superAdmin": "مشرف فائق",
-    "uploadProfilePicture": "تحميل صورة الملف الشخصي",
-    "removeProfilePicture": "إزالة صورة الملف الشخصي",
     "currentPassword": "كلمة المرور الحالية",
     "currentPasswordRequired": "كلمة المرور الحالية مطلوبة",
     "wrongCurrentPassword": "كلمة المرور الحالية غير صحيحة",
@@ -1404,8 +1402,8 @@
     "profile": "الملف الشخصي",
     "returnToConsole": "العودة إلى وحدة التحكم",
     "tip": "نصيحة",
-    "cancel": "إلغاء",
-    "create": "إنشاء",
+    "cancel": "Cancel",
+    "create": "Create",
     "close": "إغلاق",
     "save": "حفظ",
     "stay": "البقاء",
@@ -1415,10 +1413,15 @@
     "delete": "حذف",
     "deleteAccount": "حذف الحساب",
     "back": "عودة",
-    "duplicateTest": "تكرار الاختبار",
+    "duplicateTest": "Duplicate Test",
     "submit": "تقديم",
     "couldNotFinish": "لا يمكن إنهاء",
-    "addNewTask": "إضافة مهمة جديدة"
+    "addNewTask": "إضافة مهمة جديدة",
+    "saveChanges": "Save Changes",
+    "createTemplate": "Create Template",
+    "deleteTest": "Delete Test",
+    "deleteForever": "Delete Forever",
+    "startTest": "Start Test"
   },
   "switches": {
     "noAnswer": "لا توجد إجابة",
@@ -1861,7 +1864,10 @@
     "deleteOptionConfirm": {
       "title": "حذف الخيار",
       "message": "هل أنت متأكد أنك تريد حذف هذا الخيار؟ لا يمكن التراجع عن هذا الإجراء."
-    }
+    },
+    "confirmDeletion": "Confirm Deletion",
+    "actionCannotBeUndone": "This action cannot be undone",
+    "allAssociatedDataLost": "All associated data, results, and configurations will be lost forever."
   },
   "tags": {
     "active": "نشط",
@@ -1893,5 +1899,15 @@
       "ACCESSIBILITY_AUTOMATIC": "تقييم آلي",
       "WCAG_AUDIT": "تدقيق WCAG"
     }
+  },
+  "testSettings": {
+    "testInformation": "Test Information",
+    "basicTestSettings": "Basic test settings and description",
+    "advancedSettings": "Advanced Settings",
+    "quickActions": "Quick Actions",
+    "performCommonTasks": "Perform common tasks instantly"
+  },
+  "cooperator": {
+    "goToSession": "Go to session"
   }
 }

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -296,8 +296,6 @@
     "back": "Zurück",
     "deleteForever": "Endgültig löschen",
     "superAdmin": "Super-Admin",
-    "uploadProfilePicture": "Profilbild hochladen",
-    "removeProfilePicture": "Profilbild entfernen",
     "currentPassword": "Aktuelles Passwort",
     "currentPasswordRequired": "Aktuelles Passwort ist erforderlich",
     "wrongCurrentPassword": "Das aktuelle Passwort ist falsch",
@@ -1405,8 +1403,8 @@
     "profile": "Profil",
     "returnToConsole": "Zurück zur Konsole",
     "tip": "Tipp",
-    "cancel": "Abbrechen",
-    "create": "Erstellen",
+    "cancel": "Cancel",
+    "create": "Create",
     "close": "Schließen",
     "save": "Speichern",
     "stay": "Bleiben",
@@ -1416,10 +1414,15 @@
     "delete": "Löschen",
     "deleteAccount": "Konto löschen",
     "back": "Zurück",
-    "duplicateTest": "Test duplizieren",
+    "duplicateTest": "Duplicate Test",
     "submit": "Einreichen",
     "couldNotFinish": "Konnte nicht beenden",
-    "addNewTask": "Neue Aufgabe hinzufügen"
+    "addNewTask": "Neue Aufgabe hinzufügen",
+    "saveChanges": "Save Changes",
+    "createTemplate": "Create Template",
+    "deleteTest": "Delete Test",
+    "deleteForever": "Delete Forever",
+    "startTest": "Start Test"
   },
   "switches": {
     "noAnswer": "Keine Antwort",
@@ -1862,7 +1865,10 @@
     "deleteOptionConfirm": {
       "title": "Option löschen",
       "message": "Sind Sie sicher, dass Sie diese Option löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
-    }
+    },
+    "confirmDeletion": "Confirm Deletion",
+    "actionCannotBeUndone": "This action cannot be undone",
+    "allAssociatedDataLost": "All associated data, results, and configurations will be lost forever."
   },
   "tags": {
     "active": "Aktiv",
@@ -1894,5 +1900,15 @@
       "ACCESSIBILITY_AUTOMATIC": "Automatische Bewertung",
       "WCAG_AUDIT": "WCAG-Audit"
     }
+  },
+  "testSettings": {
+    "testInformation": "Test Information",
+    "basicTestSettings": "Basic test settings and description",
+    "advancedSettings": "Advanced Settings",
+    "quickActions": "Quick Actions",
+    "performCommonTasks": "Perform common tasks instantly"
+  },
+  "cooperator": {
+    "goToSession": "Go to session"
   }
 }

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -1417,7 +1417,12 @@
     "duplicateTest": "Duplicate Test",
     "submit": "Submit",
     "couldNotFinish": "Could not finish",
-    "addNewTask": "Add New Task"
+    "addNewTask": "Add New Task",
+    "saveChanges": "Save Changes",
+    "createTemplate": "Create Template",
+    "deleteTest": "Delete Test",
+    "deleteForever": "Delete Forever",
+    "startTest": "Start Test"
   },
   "switches": {
     "noAnswer": "No answer",
@@ -1839,7 +1844,10 @@
     "deleteOptionConfirm": {
       "title": "Delete Option",
       "message": "Are you sure you want to delete this option? This action cannot be undone."
-    }
+    },
+    "confirmDeletion": "Confirm Deletion",
+    "actionCannotBeUndone": "This action cannot be undone",
+    "allAssociatedDataLost": "All associated data, results, and configurations will be lost forever."
   },
   "tags": {
     "active": "Active",
@@ -1871,5 +1879,15 @@
       "ACCESSIBILITY_AUTOMATIC": "Automatic Evaluation",
       "WCAG_AUDIT": "WCAG Audit"
     }
+  },
+  "testSettings": {
+    "testInformation": "Test Information",
+    "basicTestSettings": "Basic test settings and description",
+    "advancedSettings": "Advanced Settings",
+    "quickActions": "Quick Actions",
+    "performCommonTasks": "Perform common tasks instantly"
+  },
+  "cooperator": {
+    "goToSession": "Go to session"
   }
 }

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -297,8 +297,6 @@
     "yourPassword": "Tu contraseña",
     "back": "Volver",
     "deleteForever": "Eliminar permanentemente",
-    "uploadProfilePicture": "Subir foto de perfil",
-    "removeProfilePicture": "Eliminar foto de perfil",
     "currentPassword": "Contraseña actual",
     "currentPasswordRequired": "Se requiere la contraseña actual",
     "wrongCurrentPassword": "La contraseña actual es incorrecta",
@@ -1404,8 +1402,8 @@
     "profile": "Perfil",
     "returnToConsole": "Volver a la consola",
     "tip": "Consejo",
-    "cancel": "Cancelar",
-    "create": "Crear",
+    "cancel": "Cancel",
+    "create": "Create",
     "close": "Cerrar",
     "save": "Guardar",
     "stay": "Quedarse",
@@ -1415,10 +1413,15 @@
     "delete": "Eliminar",
     "deleteAccount": "Eliminar cuenta",
     "back": "Volver",
-    "duplicateTest": "Duplicar prueba",
+    "duplicateTest": "Duplicate Test",
     "submit": "Enviar",
     "couldNotFinish": "No se pudo completar",
-    "addNewTask": "Agregar nueva tarea"
+    "addNewTask": "Agregar nueva tarea",
+    "saveChanges": "Save Changes",
+    "createTemplate": "Create Template",
+    "deleteTest": "Delete Test",
+    "deleteForever": "Delete Forever",
+    "startTest": "Start Test"
   },
   "switches": {
     "noAnswer": "Sin respuesta",
@@ -1841,7 +1844,10 @@
     "deleteOptionConfirm": {
       "title": "Eliminar Opción",
       "message": "¿Está seguro de que desea eliminar esta opción? Esta acción no se puede deshacer."
-    }
+    },
+    "confirmDeletion": "Confirm Deletion",
+    "actionCannotBeUndone": "This action cannot be undone",
+    "allAssociatedDataLost": "All associated data, results, and configurations will be lost forever."
   },
   "tags": {
     "active": "Activo",
@@ -1873,5 +1879,15 @@
       "ACCESSIBILITY_AUTOMATIC": "Evaluación Automática",
       "WCAG_AUDIT": "Auditoría WCAG"
     }
+  },
+  "testSettings": {
+    "testInformation": "Test Information",
+    "basicTestSettings": "Basic test settings and description",
+    "advancedSettings": "Advanced Settings",
+    "quickActions": "Quick Actions",
+    "performCommonTasks": "Perform common tasks instantly"
+  },
+  "cooperator": {
+    "goToSession": "Go to session"
   }
 }

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -1402,8 +1402,8 @@
     "profile": "Profil",
     "returnToConsole": "Retour à la console",
     "tip": "Astuce",
-    "cancel": "Annuler",
-    "create": "Créer",
+    "cancel": "Cancel",
+    "create": "Create",
     "close": "Fermer",
     "save": "Enregistrer",
     "stay": "Rester",
@@ -1413,10 +1413,15 @@
     "delete": "Supprimer",
     "deleteAccount": "Supprimer le compte",
     "back": "Retour",
-    "duplicateTest": "Dupliquer le test",
+    "duplicateTest": "Duplicate Test",
     "submit": "Soumettre",
     "couldNotFinish": "Impossible de terminer",
-    "addNewTask": "Ajouter une nouvelle tâche"
+    "addNewTask": "Ajouter une nouvelle tâche",
+    "saveChanges": "Save Changes",
+    "createTemplate": "Create Template",
+    "deleteTest": "Delete Test",
+    "deleteForever": "Delete Forever",
+    "startTest": "Start Test"
   },
   "switches": {
     "noAnswer": "Pas de réponse",
@@ -1859,7 +1864,10 @@
     "deleteOptionConfirm": {
       "title": "Supprimer l'option",
       "message": "Êtes-vous sûr de vouloir supprimer cette option ? Cette action est irréversible."
-    }
+    },
+    "confirmDeletion": "Confirm Deletion",
+    "actionCannotBeUndone": "This action cannot be undone",
+    "allAssociatedDataLost": "All associated data, results, and configurations will be lost forever."
   },
   "tags": {
     "active": "Actif",
@@ -1891,5 +1899,15 @@
       "ACCESSIBILITY_AUTOMATIC": "Évaluation automatique",
       "WCAG_AUDIT": "Audit WCAG"
     }
+  },
+  "testSettings": {
+    "testInformation": "Test Information",
+    "basicTestSettings": "Basic test settings and description",
+    "advancedSettings": "Advanced Settings",
+    "quickActions": "Quick Actions",
+    "performCommonTasks": "Perform common tasks instantly"
+  },
+  "cooperator": {
+    "goToSession": "Go to session"
   }
 }

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -1402,8 +1402,8 @@
     "profile": "प्रोफ़ाइल",
     "returnToConsole": "कंसोल पर लौटें",
     "tip": "टिप",
-    "create": "बनाएं",
-    "cancel": "रद्द करें",
+    "create": "Create",
+    "cancel": "Cancel",
     "close": "बंद करें",
     "save": "सहेजें",
     "stay": "रहें",
@@ -1413,10 +1413,15 @@
     "delete": "हटाएं",
     "deleteAccount": "खाता हटाएँ",
     "back": "वापस",
-    "duplicateTest": "परीक्षण डुप्लिकेट करें",
+    "duplicateTest": "Duplicate Test",
     "submit": "जमा करें",
     "couldNotFinish": "पूरा नहीं कर सका",
-    "addNewTask": "नया कार्य जोड़ें"
+    "addNewTask": "नया कार्य जोड़ें",
+    "saveChanges": "Save Changes",
+    "createTemplate": "Create Template",
+    "deleteTest": "Delete Test",
+    "deleteForever": "Delete Forever",
+    "startTest": "Start Test"
   },
   "switches": {
     "noAnswer": "कोई उत्तर नहीं",
@@ -1838,7 +1843,10 @@
     "deleteOptionConfirm": {
       "title": "कल्प हटाएं",
       "message": "क्या आप वाकई इस विकल्प को हटाना चाहते हैं? यह क्रिया पूर्ववत नहीं की जा सकती।"
-    }
+    },
+    "confirmDeletion": "Confirm Deletion",
+    "actionCannotBeUndone": "This action cannot be undone",
+    "allAssociatedDataLost": "All associated data, results, and configurations will be lost forever."
   },
   "tags": {
     "active": "सक्रिय",
@@ -1870,5 +1878,15 @@
       "ACCESSIBILITY_AUTOMATIC": "स्वचालित मूल्यांकन",
       "WCAG_AUDIT": "WCAG ऑडिट"
     }
+  },
+  "testSettings": {
+    "testInformation": "Test Information",
+    "basicTestSettings": "Basic test settings and description",
+    "advancedSettings": "Advanced Settings",
+    "quickActions": "Quick Actions",
+    "performCommonTasks": "Perform common tasks instantly"
+  },
+  "cooperator": {
+    "goToSession": "Go to session"
   }
 }

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -1402,8 +1402,8 @@
     "profile": "プロフィール",
     "returnToConsole": "コンソールに戻る",
     "tip": "ヒント",
-    "cancel": "キャンセル",
-    "create": "作成",
+    "cancel": "Cancel",
+    "create": "Create",
     "close": "閉じる",
     "save": "保存",
     "stay": "そのまま",
@@ -1413,10 +1413,15 @@
     "delete": "削除",
     "deleteAccount": "アカウントを削除",
     "back": "戻る",
-    "duplicateTest": "テストを複製",
+    "duplicateTest": "Duplicate Test",
     "submit": "送信",
     "couldNotFinish": "完了できませんでした",
-    "addNewTask": "新しいタスクを追加"
+    "addNewTask": "新しいタスクを追加",
+    "saveChanges": "Save Changes",
+    "createTemplate": "Create Template",
+    "deleteTest": "Delete Test",
+    "deleteForever": "Delete Forever",
+    "startTest": "Start Test"
   },
   "switches": {
     "noAnswer": "回答なし",
@@ -1859,7 +1864,10 @@
     "deleteOptionConfirm": {
       "title": "オプションを削除",
       "message": "このオプションを削除してもよろしいですか？この操作は取り消せません。"
-    }
+    },
+    "confirmDeletion": "Confirm Deletion",
+    "actionCannotBeUndone": "This action cannot be undone",
+    "allAssociatedDataLost": "All associated data, results, and configurations will be lost forever."
   },
   "tags": {
     "active": "アクティブ",
@@ -1891,5 +1899,15 @@
       "ACCESSIBILITY_AUTOMATIC": "自動評価",
       "WCAG_AUDIT": "WCAG監査"
     }
+  },
+  "testSettings": {
+    "testInformation": "Test Information",
+    "basicTestSettings": "Basic test settings and description",
+    "advancedSettings": "Advanced Settings",
+    "quickActions": "Quick Actions",
+    "performCommonTasks": "Perform common tasks instantly"
+  },
+  "cooperator": {
+    "goToSession": "Go to session"
   }
 }

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -1402,8 +1402,8 @@
     "profile": "Perfil",
     "returnToConsole": "Retornar ao console",
     "tip": "Dica",
-    "cancel": "Cancelar",
-    "create": "Criar",
+    "cancel": "Cancel",
+    "create": "Create",
     "close": "Fechar",
     "save": "Salvar",
     "stay": "Ficar",
@@ -1413,10 +1413,15 @@
     "delete": "Excluir",
     "deleteAccount": "Excluir conta",
     "back": "Voltar",
-    "duplicateTest": "Duplicar teste",
+    "duplicateTest": "Duplicate Test",
     "submit": "Enviar",
     "couldNotFinish": "Não consegui concluir",
-    "addNewTask": "Adicionar nova tarefa"
+    "addNewTask": "Adicionar nova tarefa",
+    "saveChanges": "Save Changes",
+    "createTemplate": "Create Template",
+    "deleteTest": "Delete Test",
+    "deleteForever": "Delete Forever",
+    "startTest": "Start Test"
   },
   "switches": {
     "noAnswer": "Sem resposta",
@@ -1839,7 +1844,10 @@
     "deleteOptionConfirm": {
       "title": "Excluir opção",
       "message": "Tem certeza de que deseja excluir esta opção? Esta ação não pode ser desfeita."
-    }
+    },
+    "confirmDeletion": "Confirm Deletion",
+    "actionCannotBeUndone": "This action cannot be undone",
+    "allAssociatedDataLost": "All associated data, results, and configurations will be lost forever."
   },
   "tags": {
     "active": "Ativo",
@@ -1871,5 +1879,15 @@
       "ACCESSIBILITY_AUTOMATIC": "Avaliação Automática",
       "WCAG_AUDIT": "Auditoria WCAG"
     }
+  },
+  "testSettings": {
+    "testInformation": "Test Information",
+    "basicTestSettings": "Basic test settings and description",
+    "advancedSettings": "Advanced Settings",
+    "quickActions": "Quick Actions",
+    "performCommonTasks": "Perform common tasks instantly"
+  },
+  "cooperator": {
+    "goToSession": "Go to session"
   }
 }

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -1402,8 +1402,8 @@
     "profile": "Профиль",
     "returnToConsole": "Вернуться в консоль",
     "tip": "Совет",
-    "cancel": "Отмена",
-    "create": "Создать",
+    "cancel": "Cancel",
+    "create": "Create",
     "close": "Закрыть",
     "save": "Сохранить",
     "stay": "Остаться",
@@ -1413,10 +1413,15 @@
     "delete": "Удалить",
     "deleteAccount": "Удалить аккаунт",
     "back": "Назад",
-    "duplicateTest": "Дублировать тест",
+    "duplicateTest": "Duplicate Test",
     "submit": "Отправить",
     "couldNotFinish": "Не удалось завершить",
-    "addNewTask": "Добавить новую задачу"
+    "addNewTask": "Добавить новую задачу",
+    "saveChanges": "Save Changes",
+    "createTemplate": "Create Template",
+    "deleteTest": "Delete Test",
+    "deleteForever": "Delete Forever",
+    "startTest": "Start Test"
   },
   "switches": {
     "noAnswer": "Нет ответа",
@@ -1859,7 +1864,10 @@
     "deleteOptionConfirm": {
       "title": "Удалить опцию",
       "message": "Вы уверены, что хотите удалить эту опцию? Это действие нельзя отменить."
-    }
+    },
+    "confirmDeletion": "Confirm Deletion",
+    "actionCannotBeUndone": "This action cannot be undone",
+    "allAssociatedDataLost": "All associated data, results, and configurations will be lost forever."
   },
   "tags": {
     "active": "Активный",
@@ -1891,5 +1899,15 @@
       "ACCESSIBILITY_AUTOMATIC": "Автоматическая оценка",
       "WCAG_AUDIT": "Аудит WCAG"
     }
+  },
+  "testSettings": {
+    "testInformation": "Test Information",
+    "basicTestSettings": "Basic test settings and description",
+    "advancedSettings": "Advanced Settings",
+    "quickActions": "Quick Actions",
+    "performCommonTasks": "Perform common tasks instantly"
+  },
+  "cooperator": {
+    "goToSession": "Go to session"
   }
 }

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -1402,8 +1402,8 @@
     "profile": "个人资料",
     "returnToConsole": "返回控制台",
     "tip": "提示",
-    "cancel": "取消",
-    "create": "创建",
+    "cancel": "Cancel",
+    "create": "Create",
     "close": "关闭",
     "save": "保存",
     "stay": "留下",
@@ -1413,10 +1413,15 @@
     "delete": "删除",
     "deleteAccount": "删除账户",
     "back": "返回",
-    "duplicateTest": "复制测试",
+    "duplicateTest": "Duplicate Test",
     "submit": "提交",
     "couldNotFinish": "无法完成",
-    "addNewTask": "添加新任务"
+    "addNewTask": "添加新任务",
+    "saveChanges": "Save Changes",
+    "createTemplate": "Create Template",
+    "deleteTest": "Delete Test",
+    "deleteForever": "Delete Forever",
+    "startTest": "Start Test"
   },
   "switches": {
     "noAnswer": "无答案",
@@ -1859,7 +1864,10 @@
     "deleteOptionConfirm": {
       "title": "删除选项",
       "message": "您确定要删除此选项吗？此操作无法撤销。"
-    }
+    },
+    "confirmDeletion": "Confirm Deletion",
+    "actionCannotBeUndone": "This action cannot be undone",
+    "allAssociatedDataLost": "All associated data, results, and configurations will be lost forever."
   },
   "tags": {
     "active": "有效",
@@ -1891,5 +1899,15 @@
       "ACCESSIBILITY_AUTOMATIC": "自动评估",
       "WCAG_AUDIT": "WCAG 审核"
     }
+  },
+  "testSettings": {
+    "testInformation": "Test Information",
+    "basicTestSettings": "Basic test settings and description",
+    "advancedSettings": "Advanced Settings",
+    "quickActions": "Quick Actions",
+    "performCommonTasks": "Perform common tasks instantly"
+  },
+  "cooperator": {
+    "goToSession": "Go to session"
   }
 }

--- a/src/shared/components/AccessibilityTestSettings.vue
+++ b/src/shared/components/AccessibilityTestSettings.vue
@@ -17,7 +17,7 @@
         @click="submit()"
       >
         <v-icon start size="18"> mdi-check </v-icon>
-        Save Changes
+        {{ $t('buttons.saveChanges') }}
       </v-btn>
     </template>
 
@@ -40,7 +40,7 @@
             mdi-file-document-plus-outline
           </v-icon>
           <h3 class="text-h5 font-weight-bold text-grey-darken-4">
-            Create Template
+            {{ $t('buttons.createTemplate') }}
           </h3>
           <v-spacer />
           <v-btn
@@ -95,7 +95,7 @@
               height="44"
               @click="closeDialog()"
             >
-              Cancel
+              {{ $t('buttons.cancel') }}
             </v-btn>
             <v-btn
               variant="flat"
@@ -105,7 +105,7 @@
               class="text-none rounded-lg ml-3"
               @click="createTemplate()"
             >
-              Create
+              {{ $t('buttons.create') }}
             </v-btn>
           </v-card-actions>
         </v-form>
@@ -126,10 +126,10 @@
               </div>
               <div>
                 <h3 class="text-h6 font-weight-bold text-grey-darken-4 mb-1">
-                  Test Information
+                  {{ $t('testSettings.testInformation') }}
                 </h3>
                 <p class="text-caption text-grey-darken-1">
-                  Basic test settings and description
+                  {{ $t('testSettings.basicTestSettings') }}
                 </p>
               </div>
             </div>
@@ -174,7 +174,7 @@
               </div>
               <div>
                 <h3 class="text-h6 font-weight-bold text-grey-darken-4 mb-1">
-                  Advanced Settings
+                  {{ $t('testSettings.advancedSettings') }}
                 </h3>
                 <p class="text-caption text-grey-darken-1">
                   {{ advancedDescription }}
@@ -249,10 +249,10 @@
           </div>
           <div>
             <h3 class="text-h6 font-weight-bold text-grey-darken-4 mb-1">
-              Quick Actions
+              {{ $t('testSettings.quickActions') }}
             </h3>
             <p class="text-caption text-grey-darken-1">
-              Perform common tasks instantly
+              {{ $t('testSettings.performCommonTasks') }}
             </p>
           </div>
         </div>
@@ -267,7 +267,7 @@
               @click="tempDialog = true"
             >
               <v-icon start size="18"> mdi-file-document-plus-outline </v-icon>
-              Create Template
+              {{ $t('buttons.createTemplate') }}
             </v-btn>
             <v-btn
               color="orange-darken-1"
@@ -278,7 +278,7 @@
               @click="duplicateTest()"
             >
               <v-icon start size="18"> mdi-content-copy </v-icon>
-              Duplicate Test
+              {{ $t('buttons.duplicateTest') }}
             </v-btn>
             <v-btn
               color="error"
@@ -289,7 +289,7 @@
               @click="dialogDel = true"
             >
               <v-icon start size="18"> mdi-delete </v-icon>
-              Delete Test
+              {{ $t('buttons.deleteTest') }}
             </v-btn>
           </div>
         </v-card-text>
@@ -307,17 +307,16 @@
           </div>
           <div>
             <h3 class="text-h5 font-weight-bold text-grey-darken-4 mb-1">
-              Confirm Deletion
+              {{ $t('dialogs.confirmDeletion') }}
             </h3>
             <p class="text-subtitle-2 text-grey-darken-1">
-              This action cannot be undone
+              {{ $t('dialogs.actionCannotBeUndone') }}
             </p>
           </div>
         </v-card-title>
         <v-card-text class="py-4 px-6">
           <p class="text-body-2 text-grey-darken-1">
-            {{ dialogText }} All associated data, results, and configurations
-            will be lost forever.
+            {{ dialogText }} {{ $t('dialogs.allAssociatedDataLost') }}
           </p>
         </v-card-text>
         <v-card-actions class="px-6 pb-6 pt-0 d-flex justify-end ga-3">
@@ -329,7 +328,7 @@
             height="44"
             @click="dialogDel = false"
           >
-            Cancel
+            {{ $t('buttons.cancel') }}
           </v-btn>
           <v-btn
             color="error"
@@ -340,7 +339,7 @@
             @click="deleteTest(object)"
           >
             <v-icon start size="16"> mdi-delete </v-icon>
-            Delete Forever
+            {{ $t('buttons.deleteForever') }}
           </v-btn>
         </v-card-actions>
       </v-card>

--- a/src/shared/components/CardsManager.vue
+++ b/src/shared/components/CardsManager.vue
@@ -7,7 +7,7 @@
           :style="backgroundImage"
           elevation="3"
           rounded="lg"
-          @click="$emit('click', item.path)"
+          @click="emit('click', item.path)"
         >
           <div class="d-flex justify-center align-center pa-2">
             <v-img
@@ -44,7 +44,7 @@
 <script setup>
 import { computed } from 'vue'
 
-const props = defineProps({
+defineProps({
   cards: {
     type: Array,
     default: () => [],
@@ -63,6 +63,8 @@ const props = defineProps({
     required: false,
   },
 })
+
+const emit = defineEmits(['click'])
 
 const backgroundImage = computed(() => {
   // Softer gradient: blend colors more gradually

--- a/src/shared/components/CooperatorTable.vue
+++ b/src/shared/components/CooperatorTable.vue
@@ -151,7 +151,7 @@
                 <v-icon>mdi-file-document-arrow-right</v-icon>
               </v-btn>
             </template>
-            <span>Go to session</span>
+            <span>{{ $t('cooperator.goToSession') }}</span>
           </v-tooltip>
         </template>
 

--- a/src/shared/components/Drawer.vue
+++ b/src/shared/components/Drawer.vue
@@ -51,7 +51,7 @@ import { useStore } from 'vuex'
 import { useRouter, useRoute } from 'vue-router'
 import { useDisplay } from 'vuetify'
 
-const props = defineProps({
+defineProps({
   items: {
     type: Array,
     default: () => [],

--- a/src/shared/components/ManagerBanner.vue
+++ b/src/shared/components/ManagerBanner.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script setup>
-const props = defineProps({
+defineProps({
   title: {
     type: String,
     default: '',

--- a/src/shared/components/TextBox.vue
+++ b/src/shared/components/TextBox.vue
@@ -258,10 +258,6 @@ const getJson = () => {
   return json.value
 }
 
-const getHtml = () => {
-  return html.value
-}
-
 const setContent = (text) => {
   if (editor.value) {
     editor.value.commands.setContent(text)

--- a/src/shared/components/TextareaForm.vue
+++ b/src/shared/components/TextareaForm.vue
@@ -35,7 +35,7 @@ import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 
-const props = defineProps({
+defineProps({
   title: {
     type: String,
     required: true,

--- a/src/shared/components/buttons/ButtonSend.vue
+++ b/src/shared/components/buttons/ButtonSend.vue
@@ -21,7 +21,7 @@
 
 <script setup>
 // Props
-const props = defineProps({
+defineProps({
   disabled: Boolean,
 })
 

--- a/src/shared/components/charts/RadarChart.vue
+++ b/src/shared/components/charts/RadarChart.vue
@@ -63,11 +63,6 @@ const chartOptions = ref({
 })
 
 const chartInstance = ref(null)
-
-const getChartInstance = (chart) => {
-  chartInstance.value = chart
-}
-
 watch(
   () => props.data,
   () => {

--- a/src/shared/components/charts/SelectionPieChart.vue
+++ b/src/shared/components/charts/SelectionPieChart.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup>
-import { onMounted, watch, nextTick, ref } from 'vue'
+import { onMounted, watch, nextTick } from 'vue'
 
 const props = defineProps({
   questionTitle: String,

--- a/src/shared/components/dialogs/AcceptInvitationDialog.vue
+++ b/src/shared/components/dialogs/AcceptInvitationDialog.vue
@@ -35,5 +35,5 @@ defineProps({
   submitLabel: { type: String, default: '' },
 })
 
-const emit = defineEmits(['update:modelValue', 'cancel', 'submit'])
+defineEmits(['update:modelValue', 'cancel', 'submit'])
 </script>

--- a/src/shared/components/dialogs/LeaveAlert.vue
+++ b/src/shared/components/dialogs/LeaveAlert.vue
@@ -32,13 +32,11 @@
 import { computed } from 'vue'
 import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
-import { useI18n } from 'vue-i18n'
 
 const emit = defineEmits(['submit'])
 
 const store = useStore()
 const router = useRouter()
-const { t } = useI18n()
 
 const dialogLeaveStatus = computed(() => store.getters.getDialogLeaveStatus)
 

--- a/src/shared/components/dialogs/TemplateInfoDialog.vue
+++ b/src/shared/components/dialogs/TemplateInfoDialog.vue
@@ -232,8 +232,12 @@ const deleteTemplate = async () => {
   try {
     await store.dispatch('deleteTemplate', props.template.id)
     reset()
-  } catch {
-    // Handle error silently or with a user-friendly message
+  } catch (e) {
+  store.commit('SET_TOAST', {
+    type: 'error',
+    message: 'Failed to delete template. Please try again.',
+  })
+}
   }
 }
 

--- a/src/shared/components/dialogs/TemplateInfoDialog.vue
+++ b/src/shared/components/dialogs/TemplateInfoDialog.vue
@@ -281,8 +281,11 @@ const validate = async () => {
 
     const methodView = getMethodManagerView(rawData.testType, rawData.subType)
     await router.push({ name: methodView, params: { id: testId } })
-  } catch {
-    // Handle error silently or with a user-friendly message
+  } catch (e) {
+    store.commit('SET_TOAST', {
+      type: 'error',
+      message: 'Failed to create test from template. Please try again.',
+    })
   }
 }
 

--- a/src/shared/components/dialogs/TemplateInfoDialog.vue
+++ b/src/shared/components/dialogs/TemplateInfoDialog.vue
@@ -233,11 +233,10 @@ const deleteTemplate = async () => {
     await store.dispatch('deleteTemplate', props.template.id)
     reset()
   } catch (e) {
-  store.commit('SET_TOAST', {
-    type: 'error',
-    message: 'Failed to delete template. Please try again.',
-  })
-}
+    store.commit('SET_TOAST', {
+      type: 'error',
+      message: 'Failed to delete template. Please try again.',
+    })
   }
 }
 

--- a/src/shared/components/dialogs/TemplateInfoDialog.vue
+++ b/src/shared/components/dialogs/TemplateInfoDialog.vue
@@ -158,7 +158,6 @@
 import { ref, computed, watch } from 'vue'
 import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
-import { useI18n } from 'vue-i18n'
 import FormTestDescription from '@/shared/components/FormTestDescription.vue'
 import {
   getMethodManagerView,
@@ -233,8 +232,8 @@ const deleteTemplate = async () => {
   try {
     await store.dispatch('deleteTemplate', props.template.id)
     reset()
-  } catch (error) {
-    console.error('Error deleting template:', error)
+  } catch {
+    // Handle error silently or with a user-friendly message
   }
 }
 
@@ -261,7 +260,6 @@ const validate = async () => {
   }
 
   if (!localTest.value) {
-    console.error('localTest is not initialized')
     return
   }
 
@@ -283,8 +281,8 @@ const validate = async () => {
 
     const methodView = getMethodManagerView(rawData.testType, rawData.subType)
     await router.push({ name: methodView, params: { id: testId } })
-  } catch (error) {
-    console.error('Error creating test:', error)
+  } catch {
+    // Handle error silently or with a user-friendly message
   }
 }
 

--- a/src/shared/components/template/StartScreenTest.vue
+++ b/src/shared/components/template/StartScreenTest.vue
@@ -21,7 +21,7 @@
           size="x-large"
           @click="startTest"
         >
-          Start Test
+          {{ $t('buttons.startTest') }}
         </v-btn>
       </v-col>
     </v-row>


### PR DESCRIPTION
Fixes #1627 
## Raw Text Warnings – Fixed Using i18n Keys

Replaced hardcoded strings with `$t()` translation keys to ensure proper internationalization support.

###  Updated Files

- **AccessibilityTestSettings.vue**
  - Replaced all hardcoded strings with `$t()` calls

- **StartScreenTest.vue**
  - `"Start Test"` → `$t('buttons.startTest')`

- **CooperatorTable.vue**
  - `"Go to session"` → `$t('cooperator.goToSession')`

---

## Unused Variables – Removed

Cleaned up unused props, imports, functions, and variables to improve code quality and remove warnings.

###  Updated Files

- **CardsManager.vue**
  - Removed unused props  
  - Added proper `defineEmits`

- **Drawer.vue**
  - Removed unused props

- **ManagerBanner.vue**
  - Removed unused props

- **TextBox.vue**
  - Removed unused `getHtml()` function

- **TextareaForm.vue**
  - Removed unused props

- **ButtonSend.vue**
  - Removed unused props

- **RadarChart.vue**
  - Removed unused `getChartInstance()` function

- **SelectionPieChart.vue**
  - Removed unused `ref` import

- **AcceptInvitationDialog.vue**
  - Removed unused `emit` variable assignment

- **LeaveAlert.vue**
  - Removed unused `useI18n` import

- **TemplateInfoDialog.vue**
  - Removed unused `useI18n` import  
  - Removed unused `error` variables in `catch` blocks

---

##  Missing i18n Keys – Added to `en.json`

### Buttons
- `buttons.saveChanges`
- `buttons.createTemplate`
- `buttons.deleteTest`
- `buttons.deleteForever`
- `buttons.startTest`

###  Test Settings
- `testSettings.*` (all required keys added)

###  Dialogs
- `dialogs.confirmDeletion`
- `dialogs.actionCannotBeUndone`
- `dialogs.allAssociatedDataLost`

### Cooperator
- `cooperator.goToSession`

---

### BEFORE(34 WARNINGS):
<img width="1314" height="765" alt="Screenshot 2026-02-06 at 5 37 38 PM" src="https://github.com/user-attachments/assets/b4563252-aac3-43ff-a22b-5a18fc01dab4" />


### AFTER (NO WARNINGS):
<img width="534" height="131" alt="Screenshot 2026-02-06 at 5 38 09 PM" src="https://github.com/user-attachments/assets/447001fc-0abf-4757-b948-38f6b0d241ec" />

