### PR TITLE
style(lint): fix lint for src/ux/CardSorting folder #1630

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -92,6 +92,7 @@
     "sentBy": "Sent by",
     "new": "NEW",
     "test": "a Study",
+    "of": "of",
     "actions": "Actions",
     "confirm_deletion": "Confirm Deletion",
     "action_cannot_be_undone": "This action cannot be undone",
@@ -1561,8 +1562,18 @@
     "createNewVariableTitle": "Create New Variable"
   },
   "CardSorting": {
-    "noCategory": "No category",
-    "noCards": "No cards found"
+    "noCategory": "No categories found",
+    "noCards": "No cards found",
+    "cards": "Cards",
+    "categories": "Categories",
+    "currentCards": "Current Cards",
+    "currentCategories": "Current Categories",
+    "addNewCard": "Add New Card",
+    "addNewCategory": "Add New Category",
+    "settings": "Settings",
+    "configureCards": "Configure how cards will be displayed",
+    "configureCategories": "Configure how categories will be displayed",
+    "newTask": "New task"
   },
   "analytics": {
     "searchByName": "Search by name",

--- a/src/ux/CardSorting/components/CardSortingTask.vue
+++ b/src/ux/CardSorting/components/CardSortingTask.vue
@@ -11,16 +11,31 @@
               <VCard class="card-category">
                 <VCardTitle class="d-flex justify-center align-center">
                   <VCol class="text-center">
-                    <p>{{ pendingAllocationCount }} of {{ props.test.testStructure.cardSorting.cards.length }} cards</p>
+                    <p>
+                      {{ pendingAllocationCount }} {{ $t('common.of') }}
+                      {{ props.test.testStructure.cardSorting.cards.length }}
+                      {{ $t('CardSorting.cards').toLowerCase() }}
+                    </p>
                     <v-progress-linear
-v-model="pendingAllocationCount" color="primary" height="12"
-                      :max="props.test.testStructure.cardSorting.cards.length" />
+                      v-model="pendingAllocationCount"
+                      color="primary"
+                      height="12"
+                      :max="props.test.testStructure.cardSorting.cards.length"
+                    />
                   </VCol>
                 </VCardTitle>
 
-                <Draggable :list="cards" item-key="title" class="list-group" group="cards">
+                <Draggable
+                  :list="cards"
+                  item-key="title"
+                  class="list-group"
+                  group="cards"
+                >
                   <template #item="{ element }">
-                    <CardSortingCard :element="element" :options="props.test.testStructure.cardSorting.options" />
+                    <CardSortingCard
+                      :element="element"
+                      :options="props.test.testStructure.cardSorting.options"
+                    />
                   </template>
                 </Draggable>
               </VCard>
@@ -28,23 +43,38 @@ v-model="pendingAllocationCount" color="primary" height="12"
 
             <!-- Categories -->
             <VCol
-v-for="(category, index) in categories" :key="index" :cols="12 / (categories.length + 1)"
-              class="mb-0 pb-0">
+              v-for="(category, index) in categories"
+              :key="index"
+              :cols="12 / (categories.length + 1)"
+              class="mb-0 pb-0"
+            >
               <VCard class="card-category category">
                 <VCardTitle class="d-flex justify-center align-center">
                   <VCol class="text-center">
                     <h3>{{ category.title }}</h3>
-                    <p v-if="category.description && props.test.testStructure.cardSorting.options.category_description">
-                      {{
-                        category.description }}</p>
+                    <p
+                      v-if="
+                        category.description &&
+                        props.test.testStructure.cardSorting.options
+                          .category_description
+                      "
+                    >
+                      {{ category.description }}
+                    </p>
                   </VCol>
                 </VCardTitle>
 
                 <Draggable
-:list="localTestAnswer.tasks[category.title]" item-key="title" class="list-group"
-                  group="cards">
+                  :list="localTestAnswer.tasks[category.title]"
+                  item-key="title"
+                  class="list-group"
+                  group="cards"
+                >
                   <template #item="{ element }">
-                    <CardSortingCard :element="element" :options="props.test.testStructure.cardSorting.options" />
+                    <CardSortingCard
+                      :element="element"
+                      :options="props.test.testStructure.cardSorting.options"
+                    />
                   </template>
                 </Draggable>
               </VCard>
@@ -66,15 +96,15 @@ import CardSortingCard from '../components/CardSortingCard.vue'
 const props = defineProps({
   test: {
     type: Object,
-    required: false
-  }
+    required: false,
+  },
 })
 
 // Variables
 const categories = ref([])
 const cards = ref([])
 const localTestAnswer = ref({
-  tasks: {}
+  tasks: {},
 })
 
 // Computed

--- a/src/ux/CardSorting/components/CardSortingTest.vue
+++ b/src/ux/CardSorting/components/CardSortingTest.vue
@@ -2,18 +2,31 @@
   <div>
     <VRow class="pa-0 ma-0" dense>
       <!-- Navigation Drawer -->
-      <v-navigation-drawer v-model="drawer" :rail="mini" permanent color="#3F3D56">
+      <v-navigation-drawer
+        v-model="drawer"
+        :rail="mini"
+        permanent
+        color="#3F3D56"
+      >
         <!-- Navigation Header -->
         <div v-if="!mini" class="header">
           <v-list-item>
             <v-row dense align="center" justify="space-around">
               <v-col class="pa-0 ma-0" cols="8">
-                <text-clamp class="titleText" :text="test.testTitle" :max-lines="2" />
+                <text-clamp
+                  class="titleText"
+                  :text="test.testTitle"
+                  :max-lines="2"
+                />
               </v-col>
               <v-col>
                 <v-progress-circular
-rotate="-90" :model-value="calculateProgress()" color="#fca326" :size="50"
-                  class="mt-2">
+                  rotate="-90"
+                  :model-value="calculateProgress()"
+                  color="#fca326"
+                  :size="50"
+                  class="mt-2"
+                >
                   {{ calculateProgress() }}%
                 </v-progress-circular>
               </v-col>
@@ -23,8 +36,11 @@ rotate="-90" :model-value="calculateProgress()" color="#fca326" :size="50"
 
         <!-- Navigation Body -->
         <v-list
-class="nav-list" density="compact" max-height="85%"
-          style="overflow-y: auto; overflow-x: hidden; padding-bottom: 100px">
+          class="nav-list"
+          density="compact"
+          max-height="85%"
+          style="overflow-y: auto; overflow-x: hidden; padding-bottom: 100px"
+        >
           <div v-for="item in items" :key="item.id">
             <!-- Pre Test -->
             <!-- <v-list-group v-if="item.id === 0"
@@ -184,40 +200,40 @@ class="nav-list" density="compact" max-height="85%"
 </template>
 
 <script setup>
-import { onMounted, reactive, ref } from 'vue';
-import { useStore } from 'vuex';
-import CardSortingTask from '../components/CardSortingTask.vue';
-import UserStudyEvaluatorAnswer from '@/ux/UserTest/models/UserStudyEvaluatorAnswer';
+import { onMounted, reactive, ref } from 'vue'
+import { useStore } from 'vuex'
+import CardSortingTask from '../components/CardSortingTask.vue'
+import UserStudyEvaluatorAnswer from '@/ux/UserTest/models/UserStudyEvaluatorAnswer'
 
 // Props
-const props = defineProps({
+defineProps({
   test: {
     type: Object,
-    required: true
+    required: true,
   },
 })
 
 // Stores
-const store = useStore();
+const store = useStore()
 
 // Variables
-const drawer = ref(true);
-const mini = ref(false);
+const drawer = ref(true)
+const mini = ref(false)
 
-const rightView = ref(null);
-const index = ref(1);
-const taskIndex = ref(null);
-const fullName = ref('');
-const items = ref([]);
+const rightView = ref(null)
+const index = ref(1)
+// const taskIndex = ref(null);
+// const fullName = ref('');
+const items = ref([])
 
-const localTestAnswer = reactive(new UserStudyEvaluatorAnswer());
+const localTestAnswer = reactive(new UserStudyEvaluatorAnswer())
 
 // Methods
-const completeStep = (id, type, userCompleted = true) => { }
+// const completeStep = (id, type, userCompleted = true) => { }
 
 const mappingSteps = async () => {
   try {
-    items.value = [];
+    items.value = []
 
     items.value.push({
       title: 'Tasks',
@@ -228,23 +244,25 @@ const mappingSteps = async () => {
         id: 0,
       },
       id: 1,
-    });
-
-  } catch (error) {
-    console.error('Error mapping steps:', error.message);
-    store.commit('SET_TOAST', { type: 'error', message: 'Failed to initialize test data. Please try again.' });
+    })
+  } catch {
+    // console.error('Error mapping steps:', error.message);
+    store.commit('SET_TOAST', {
+      type: 'error',
+      message: 'Failed to initialize test data. Please try again.',
+    })
   }
 }
 
-const isTaskDisabled = (taskIndex) => {
-  if (!Array.isArray(localTestAnswer.tasks)) return true;
-  for (let i = 0; i < taskIndex; i++) {
-    if (!localTestAnswer.tasks[i]?.completed) {
-      return true;
-    }
-  }
-  return false;
-};
+// const isTaskDisabled = (taskIndex) => {
+//   if (!Array.isArray(localTestAnswer.tasks)) return true;
+//   for (let i = 0; i < taskIndex; i++) {
+//     if (!localTestAnswer.tasks[i]?.completed) {
+//       return true;
+//     }
+//   }
+//   return false;
+// };
 
 const calculateProgress = () => {
   try {
@@ -259,7 +277,7 @@ const calculateProgress = () => {
     if (items.value[1]?.value && Array.isArray(localTestAnswer.tasks)) {
       for (let i = 0; i < items.value[1].value.length; i++) {
         if (localTestAnswer.tasks[i]?.completed) {
-          tasksCompleted++;
+          tasksCompleted++
         }
       }
       if (tasksCompleted === items.value[1].value.length) {
@@ -272,20 +290,20 @@ const calculateProgress = () => {
     const progressPercentage = (completedSteps / totalSteps) * 100
     localTestAnswer.progress = progressPercentage
     return progressPercentage
-  } catch (error) {
-    console.error('Error in calculateProgress:', error)
+  } catch {
+    // console.error('Error in calculateProgress:', error)
     return 0
   }
-};
+}
 
-const isPreTestTaskDisabled = (taskIndex) => {
-  if (taskIndex === 0) return localTestAnswer.consentCompleted && localTestAnswer.preTestCompleted && !localTestAnswer.submitted;
-  return !localTestAnswer.consentCompleted || (localTestAnswer.preTestCompleted && !localTestAnswer.submitted);
-};
+// const isPreTestTaskDisabled = (taskIndex) => {
+//   if (taskIndex === 0) return localTestAnswer.consentCompleted && localTestAnswer.preTestCompleted && !localTestAnswer.submitted;
+//   return !localTestAnswer.consentCompleted || (localTestAnswer.preTestCompleted && !localTestAnswer.submitted);
+// };
 
 // Lifecycle Hooks
 onMounted(async () => {
-  await mappingSteps();
+  await mappingSteps()
 })
 </script>
 

--- a/src/ux/CardSorting/components/CardsEditCardSorting.vue
+++ b/src/ux/CardSorting/components/CardsEditCardSorting.vue
@@ -6,14 +6,24 @@
         <v-card class="elevation-2 rounded-lg pa-6">
           <v-row aling="center" class="pa-4">
             <v-col cols="12" sm="6">
-              <v-card-title class="text-h5 font-weight-bold mb-4" :style="{ color: $vuetify.theme.current.colors['on-surface'] }">
-                {{ 'Current Cards' }}
+              <v-card-title
+                class="text-h5 font-weight-bold mb-4"
+                :style="{ color: $vuetify.theme.current.colors['on-surface'] }"
+              >
+                {{ $t('CardSorting.currentCards') }}
               </v-card-title>
             </v-col>
             <v-col cols="12" sm="6" class="text-right">
-              <v-btn color="primary" variant="flat" size="large" class="px-6 text-capitalize" rounded="lg" @click="dialog = true">
+              <v-btn
+                color="primary"
+                variant="flat"
+                size="large"
+                class="px-6 text-capitalize"
+                rounded="lg"
+                @click="dialog = true"
+              >
                 <v-icon start>mdi-plus-circle</v-icon>
-                Add New Card
+                {{ $t('CardSorting.addNewCard') }}
               </v-btn>
             </v-col>
           </v-row>
@@ -23,29 +33,48 @@
               :items="cards"
               :items-per-page="5"
               class="elevation-0 rounded-lg"
-              style="background: #FFFFFF; border: 1px solid #E5E7EB;"
-              :no-data-text="$t('noCards')"
+              style="background: #ffffff; border: 1px solid #e5e7eb"
+              :no-data-text="$t('CardSorting.noCards')"
             >
               <!-- DESCRIPTION -->
               <template #item.description="{ item }">
                 <v-icon :color="item.description ? 'success' : 'error'">
-                  {{ item.description ? 'mdi-checkbox-marked-circle-outline' : 'mdi-close-circle-outline' }}
+                  {{
+                    item.description
+                      ? 'mdi-checkbox-marked-circle-outline'
+                      : 'mdi-close-circle-outline'
+                  }}
                 </v-icon>
               </template>
 
               <!-- IMAGE -->
-               <template #item.image="{ item }">
+              <template #item.image="{ item }">
                 <v-icon :color="item.image ? 'success' : 'error'">
-                  {{ item.image ? 'mdi-checkbox-marked-circle-outline' : 'mdi-close-circle-outline' }}
+                  {{
+                    item.image
+                      ? 'mdi-checkbox-marked-circle-outline'
+                      : 'mdi-close-circle-outline'
+                  }}
                 </v-icon>
               </template>
 
               <!-- ACTIONS -->
               <template #item.actions="{ item }">
-                <v-btn icon variant="text" color="accent" class="mr-2" @click="editItem(item)">
+                <v-btn
+                  icon
+                  variant="text"
+                  color="accent"
+                  class="mr-2"
+                  @click="editItem(item)"
+                >
                   <v-icon>mdi-pencil</v-icon>
                 </v-btn>
-                <v-btn icon variant="text" color="error" @click="deleteItem(item)">
+                <v-btn
+                  icon
+                  variant="text"
+                  color="error"
+                  @click="deleteItem(item)"
+                >
                   <v-icon>mdi-trash-can-outline</v-icon>
                 </v-btn>
               </template>
@@ -59,10 +88,13 @@
         <v-card class="elevation-2 rounded-lg pa-6">
           <v-row align="center" class="pa-4">
             <v-col cols="12" sm="12">
-              <v-card-title class="text-h5 font-weight-bold mb-4" :style="{ color: $vuetify.theme.current.colors['on-surface'] }">
-                {{ 'Settings' }}
+              <v-card-title
+                class="text-h5 font-weight-bold mb-4"
+                :style="{ color: $vuetify.theme.current.colors['on-surface'] }"
+              >
+                {{ $t('CardSorting.settings') }}
               </v-card-title>
-              Configure how cards will be displayed
+              {{ $t('CardSorting.configureCards') }}
             </v-col>
           </v-row>
           <v-card-text>
@@ -80,22 +112,27 @@
         </v-card>
       </v-col>
     </v-row>
-    <CardSortingForm v-model:dialog="dialog" :value="card" :options="options" @save="save" />
+    <CardSortingForm
+      v-model:dialog="dialog"
+      :value="card"
+      :options="options"
+      @save="save"
+    />
   </v-container>
 </template>
 
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import CardSortingForm from '../components/dialogs/CardSortingForm.vue'
-import { useStore } from 'vuex';
-import { CardSortingStudyOptions } from '../models/CardSortingStudyOptions';
-import { CardSortingStudyCard } from '../models/CardSortingStudyCard';
+import { useStore } from 'vuex'
+import { CardSortingStudyOptions } from '../models/CardSortingStudyOptions'
+import { CardSortingStudyCard } from '../models/CardSortingStudyCard'
 
 // Emits
 const emit = defineEmits(['change', 'cards', 'options'])
 
 // Store
-const store = useStore();
+const store = useStore()
 
 // Computeds
 const test = computed(() => store.getters.test)
@@ -107,10 +144,27 @@ const card = ref(new CardSortingStudyCard())
 const dialog = ref(false)
 const options = ref(new CardSortingStudyOptions())
 const headers = ref([
-  { title: 'Name', align: 'start', sortable: false, value: 'title', width: '10%' },
-  { title: 'Description', value: 'description', sortable: false, align: 'center' },
+  {
+    title: 'Name',
+    align: 'start',
+    sortable: false,
+    value: 'title',
+    width: '10%',
+  },
+  {
+    title: 'Description',
+    value: 'description',
+    sortable: false,
+    align: 'center',
+  },
   { title: 'Image', value: 'image', sortable: false, align: 'center' },
-  { title: 'Actions', value: 'actions', sortable: false, align: 'center', width: '150px' },
+  {
+    title: 'Actions',
+    value: 'actions',
+    sortable: false,
+    align: 'center',
+    width: '150px',
+  },
 ])
 
 // Methods
@@ -149,11 +203,13 @@ const deleteItem = (item) => {
 const getCards = () => {
   if (!test.value.testStructure.cardSorting) return
 
-  test.value.testStructure.cardSorting.cards.map(card => {
+  test.value.testStructure.cardSorting.cards.map((card) => {
     cards.value.push(new CardSortingStudyCard(card))
   })
 
-  options.value = new CardSortingStudyOptions(test.value.testStructure.cardSorting.options)
+  options.value = new CardSortingStudyOptions(
+    test.value.testStructure.cardSorting.options,
+  )
   onChange()
 }
 

--- a/src/ux/CardSorting/components/CategoriesEditCardSorting.vue
+++ b/src/ux/CardSorting/components/CategoriesEditCardSorting.vue
@@ -1,32 +1,19 @@
 <template>
-  <v-container
-    fluid
-    class="pa-0"
-  >
+  <v-container fluid class="pa-0">
     <v-row class="ma-0">
       <!-- Categories -->
       <v-col cols="9">
         <v-card class="elevation-2 rounded-lg pa-6">
-          <v-row
-            aling="center"
-            class="pa-4"
-          >
-            <v-col
-              cols="12"
-              sm="6"
-            >
+          <v-row aling="center" class="pa-4">
+            <v-col cols="12" sm="6">
               <v-card-title
                 class="text-h5 font-weight-bold mb-4"
                 :style="{ color: $vuetify.theme.current.colors['on-surface'] }"
               >
-                {{ 'Current Categories' }}
+                {{ $t('CardSorting.currentCategories') }}
               </v-card-title>
             </v-col>
-            <v-col
-              cols="12"
-              sm="6"
-              class="text-right"
-            >
+            <v-col cols="12" sm="6" class="text-right">
               <v-btn
                 color="primary"
                 variant="flat"
@@ -35,10 +22,8 @@
                 rounded="lg"
                 @click="dialog = true"
               >
-                <v-icon start>
-                  mdi-plus-circle
-                </v-icon>
-                Add New Task
+                <v-icon start> mdi-plus-circle </v-icon>
+                {{ $t('CardSorting.addNewCategory') }}
               </v-btn>
             </v-col>
           </v-row>
@@ -48,23 +33,30 @@
               :items="categories"
               :items-per-page="5"
               class="elevation-0 rounded-lg"
-              style="background: #FFFFFF; border: 1px solid #E5E7EB;"
+              style="background: #ffffff; border: 1px solid #e5e7eb"
               :no-data-text="$t('CardSorting.noCategory')"
             >
               <!-- DESCRIPTION -->
               <template #item.description="{ item }">
                 <v-icon :color="item.description ? 'success' : 'error'">
-                  {{ item.description ? 'mdi-checkbox-marked-circle-outline' : 'mdi-close-circle-outline' }}
+                  {{
+                    item.description
+                      ? 'mdi-checkbox-marked-circle-outline'
+                      : 'mdi-close-circle-outline'
+                  }}
                 </v-icon>
               </template>
 
               <!-- IMAGE -->
               <template #item.image="{ item }">
                 <v-icon :color="item.image ? 'success' : 'error'">
-                  {{ item.image ? 'mdi-checkbox-marked-circle-outline' : 'mdi-close-circle-outline' }}
+                  {{
+                    item.image
+                      ? 'mdi-checkbox-marked-circle-outline'
+                      : 'mdi-close-circle-outline'
+                  }}
                 </v-icon>
               </template>
-
 
               <!-- ACTIONS -->
               <template #item.actions="{ item }">
@@ -94,21 +86,15 @@
       <!-- Settings -->
       <v-col cols="3">
         <v-card class="elevation-2 rounded-lg pa-6">
-          <v-row
-            align="center"
-            class="pa-4"
-          >
-            <v-col
-              cols="12"
-              sm="12"
-            >
+          <v-row align="center" class="pa-4">
+            <v-col cols="12" sm="12">
               <v-card-title
                 class="text-h5 font-weight-bold mb-4"
                 :style="{ color: $vuetify.theme.current.colors['on-surface'] }"
               >
-                {{ 'Settings' }}
+                {{ $t('CardSorting.settings') }}
               </v-card-title>
-              Configure how categories will be displayed
+              {{ $t('CardSorting.configureCategories') }}
             </v-col>
           </v-row>
           <v-card-text>
@@ -136,20 +122,20 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue';
-import { useStore } from 'vuex';
-import { CardSortingStudyCategory } from '../models/CardSortingStudyCategory';
-import { CardSortingStudyOptions } from '../models/CardSortingStudyOptions';
-import CardSortingForm from './dialogs/CardSortingForm.vue';
+import { computed, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import { CardSortingStudyCategory } from '../models/CardSortingStudyCategory'
+import { CardSortingStudyOptions } from '../models/CardSortingStudyOptions'
+import CardSortingForm from './dialogs/CardSortingForm.vue'
 
 // Emits
 const emit = defineEmits(['change', 'categories', 'options'])
 
 // Store
-const store = useStore();
+const store = useStore()
 
 // Computeds
-const test = computed(() => store.getters.test);
+const test = computed(() => store.getters.test)
 
 // Variables
 const categories = ref([])
@@ -158,10 +144,27 @@ const dialog = ref(false)
 const category = ref(new CardSortingStudyCategory())
 const options = ref(new CardSortingStudyOptions())
 const headers = ref([
-  { title: 'Name', align: 'start', sortable: false, value: 'title', width: '10%' },
-  { title: 'Description', value: 'description', sortable: false, align: 'center' },
+  {
+    title: 'Name',
+    align: 'start',
+    sortable: false,
+    value: 'title',
+    width: '10%',
+  },
+  {
+    title: 'Description',
+    value: 'description',
+    sortable: false,
+    align: 'center',
+  },
   { title: 'Image', value: 'image', sortable: false, align: 'center' },
-  { title: 'Actions', value: 'actions', sortable: false, align: 'center', width: '150px' },
+  {
+    title: 'Actions',
+    value: 'actions',
+    sortable: false,
+    align: 'center',
+    width: '150px',
+  },
 ])
 
 const onChange = () => {
@@ -172,7 +175,7 @@ const onChange = () => {
 
 const editItem = (item) => {
   editedIndex.value = categories.value.indexOf(item)
-  category.value = new CardSortingStudyCategory({...item})
+  category.value = new CardSortingStudyCategory({ ...item })
   dialog.value = true
 }
 
@@ -198,11 +201,13 @@ const save = (newCategoryRaw) => {
 const getCards = () => {
   if (!test.value.testStructure.cardSorting) return
 
-  test.value.testStructure.cardSorting.categories.map(cat => {
+  test.value.testStructure.cardSorting.categories.map((cat) => {
     categories.value.push(new CardSortingStudyCategory(cat))
   })
 
-  options.value = new CardSortingStudyOptions(test.value.testStructure.cardSorting.options)
+  options.value = new CardSortingStudyOptions(
+    test.value.testStructure.cardSorting.options,
+  )
   onChange()
 }
 

--- a/src/ux/CardSorting/components/dialogs/CardSortingForm.vue
+++ b/src/ux/CardSorting/components/dialogs/CardSortingForm.vue
@@ -1,8 +1,13 @@
 <template>
-  <v-dialog :model-value="dialog" width="70%" persistent @update:model-value="$emit('update:dialog', $event)">
+  <v-dialog
+    :model-value="dialog"
+    width="70%"
+    persistent
+    @update:model-value="$emit('update:dialog', $event)"
+  >
     <v-card class="dataCard">
       <p class="subtitleView ma-3 pt-3 mb-0 pa-2">
-        New task
+        {{ $t('CardSorting.newTask') }}
       </p>
       <v-divider />
       <v-card-text>
@@ -10,9 +15,18 @@
           <VRow justify="space-around">
             <VCol class="mt-4" cols="5">
               <v-text-field
-v-model="localTask.title" :label="$t('common.name')" :rules="requiredRule"
-                variant="outlined" density="compact" />
-              <quill-editor v-if="options.category_description || options.card_description" v-model:value="localTask.description" class="mb-5" style="height: 40%;" />
+                v-model="localTask.title"
+                :label="$t('common.name')"
+                :rules="requiredRule"
+                variant="outlined"
+                density="compact"
+              />
+              <quill-editor
+                v-if="options.category_description || options.card_description"
+                v-model:value="localTask.description"
+                class="mb-5"
+                style="height: 40%"
+              />
             </VCol>
 
             <!-- <VCol class="mt-4" cols="5" v-if="options.category_description">
@@ -24,7 +38,14 @@ v-model="localTask.title" :label="$t('common.name')" :rules="requiredRule"
       <v-divider />
       <v-card-actions>
         <v-spacer />
-        <v-btn color="red-lighten-1" variant="text" @click="$emit('update:dialog', false); reset()">
+        <v-btn
+          color="red-lighten-1"
+          variant="text"
+          @click="
+            $emit('update:dialog', false)
+            reset()
+          "
+        >
           {{ $t('buttons.cancel') }}
         </v-btn>
         <v-btn class="text-white bg-orange" @click="submit">
@@ -36,23 +57,23 @@ v-model="localTask.title" :label="$t('common.name')" :rules="requiredRule"
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, watch } from 'vue'
 
 // Props
 const props = defineProps({
   dialog: Boolean,
   task: {
     type: Object,
-    default: () => ({})
+    default: () => ({}),
   },
   options: {
     type: Object,
-    default: () => ({})
-  }
-});
+    default: () => ({}),
+  },
+})
 
 // Emits
-const emit = defineEmits(['update:dialog', 'save']);
+const emit = defineEmits(['update:dialog', 'save'])
 
 // Variables
 const form = ref(null)
@@ -71,18 +92,21 @@ const submit = async () => {
 }
 
 const reset = () => {
-  form.value?.reset();
+  form.value?.reset()
 }
 
-watch(() => props.task, (newTask) => {
-  if (newTask && Object.keys(newTask).length > 0) {
-    localTask.value = { ...newTask }
-  } else {
-    localTask.value = {}
-  }
-}, { immediate: true, deep: true })
+watch(
+  () => props.task,
+  (newTask) => {
+    if (newTask && Object.keys(newTask).length > 0) {
+      localTask.value = { ...newTask }
+    } else {
+      localTask.value = {}
+    }
+  },
+  { immediate: true, deep: true },
+)
 </script>
-
 
 <style scoped>
 .subtitleView {

--- a/src/ux/CardSorting/stores/CardStudy.js
+++ b/src/ux/CardSorting/stores/CardStudy.js
@@ -30,21 +30,21 @@ export default {
     setTasks({ commit }, payload) {
       try {
         commit('SET_TASKS', payload)
-      } catch (e) {
+      } catch {
         commit('setError', true)
       }
     },
     setPostTest({ commit }, payload) {
       try {
         commit('SET_POST_TEST', payload)
-      } catch (e) {
+      } catch {
         commit('setError', true)
       }
     },
     setPreTest({ commit }, payload) {
       try {
         commit('SET_PRE_TEST', payload)
-      } catch (e) {
+      } catch {
         commit('setError', true)
       }
     },

--- a/src/ux/CardSorting/views/EditTestView.vue
+++ b/src/ux/CardSorting/views/EditTestView.vue
@@ -1,28 +1,18 @@
 <template>
-  <PageWrapper
-    title="Edit Test"
-    :side-gap="true"
-  >
+  <PageWrapper :title="$t('HeuristicsEditTest.pageTitle')" :side-gap="true">
     <template #subtitle>
       <p class="text-body-1 text-grey-darken-1">
-        Customize the settings and preferences of your test
+        {{ $t('HeuristicsEditTest.pageSubtitle') }}
       </p>
     </template>
 
     <v-container>
-      <ButtonSave
-        :visible="change"
-        @click="save"
-      />
+      <ButtonSave :visible="change" @click="save" />
 
       <div>
-        <VTabs
-          bg-color="transparent"
-          color="#FCA326"
-          class="pb-0 mb-0"
-        >
+        <VTabs bg-color="transparent" color="#FCA326" class="pb-0 mb-0">
           <VTab @click="index = 0">
-            {{ 'Test' }}
+            {{ $t('common.test') }}
           </VTab>
           <VTab @click="index = 1">
             {{ $t('ModeratedTest.consentForm') }}
@@ -31,10 +21,10 @@
             {{ $t('ModeratedTest.preTest') }}
           </VTab>
           <VTab @click="index = 3">
-            {{ 'Categories' }}
+            {{ $t('CardSorting.categories') }}
           </VTab>
           <VTab @click="index = 4">
-            {{ 'Cards' }}
+            {{ $t('CardSorting.cards') }}
           </VTab>
           <VTab @click="index = 5">
             {{ $t('ModeratedTest.postTest') }}
@@ -47,29 +37,32 @@
             <TestConfigForm
               :welcome="welcomeMessage"
               :final-message="finalMessage"
-              @update:welcome-message="welcomeMessage = $event; change = true"
-              @update:final-message="finalMessage = $event; change = true"
+              @update:welcome-message="
+                welcomeMessage = $event
+                change = true
+              "
+              @update:final-message="
+                finalMessage = $event
+                change = true
+              "
             />
           </div>
 
           <!-- CONSENT FORM -->
-          <div
-            v-if="index === 1"
-            rounded="xxl"
-          >
+          <div v-if="index === 1" rounded="xxl">
             <TextareaForm
               v-model="consent"
               :title="$t('ModeratedTest.consentForm')"
               :subtitle="$t('ModeratedTest.consentFormSubtitle')"
-              @update:value="consent = $event; change = true"
+              @update:value="
+                consent = $event
+                change = true
+              "
             />
           </div>
 
           <!-- PRE-TEST -->
-          <v-card
-            v-if="index === 2"
-            rounded="xxl"
-          >
+          <v-card v-if="index === 2" rounded="xxl">
             <UserVariables
               type="pre-test"
               @change="change = true"
@@ -78,10 +71,7 @@
           </v-card>
 
           <!-- CATEGORIES -->
-          <div
-            v-if="index === 3"
-            rounded="xxl"
-          >
+          <div v-if="index === 3" rounded="xxl">
             <CategoriesEditCardSorting
               @change="change = true"
               @categories="categories = $event"
@@ -90,10 +80,7 @@
           </div>
 
           <!-- CARDS -->
-          <div
-            v-if="index === 4"
-            rounded="xxl"
-          >
+          <div v-if="index === 4" rounded="xxl">
             <CardsEditCardSorting
               @change="change = true"
               @cards="cards = $event"
@@ -102,10 +89,7 @@
           </div>
 
           <!-- POS-TEST -->
-          <v-card
-            v-if="index === 5"
-            rounded="xxl"
-          >
+          <v-card v-if="index === 5" rounded="xxl">
             <UserVariables
               type="post-test"
               @change="change = true"
@@ -119,23 +103,23 @@
 </template>
 
 <script setup>
-import ButtonSave from '@/shared/components/buttons/ButtonSave.vue';
-import TextareaForm from '@/shared/components/TextareaForm.vue';
-import UserVariables from '@/shared/components/UserVariables.vue';
-import CardsEditCardSorting from '../components/CardsEditCardSorting.vue';
-import CategoriesEditCardSorting from '../components/CategoriesEditCardSorting.vue';
-import PageWrapper from '@/shared/views/template/PageWrapper.vue';
-import { computed, onMounted, ref } from 'vue';
-import { useStore } from 'vuex';
-import { instantiateStudyByType } from '@/shared/constants/methodDefinitions';
-import TestConfigForm from '@/shared/components/TestConfigForm.vue';
-import { CardSortingStudyCategory } from '../models/CardSortingStudyCategory';
-import { CardSortingStudyCard } from '../models/CardSortingStudyCard';
-import { CardSortingStudyOptions } from '../models/CardSortingStudyOptions';
+import ButtonSave from '@/shared/components/buttons/ButtonSave.vue'
+import TextareaForm from '@/shared/components/TextareaForm.vue'
+import UserVariables from '@/shared/components/UserVariables.vue'
+import CardsEditCardSorting from '../components/CardsEditCardSorting.vue'
+import CategoriesEditCardSorting from '../components/CategoriesEditCardSorting.vue'
+import PageWrapper from '@/shared/views/template/PageWrapper.vue'
+import { computed, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import { instantiateStudyByType } from '@/shared/constants/methodDefinitions'
+import TestConfigForm from '@/shared/components/TestConfigForm.vue'
+import { CardSortingStudyCategory } from '../models/CardSortingStudyCategory'
+import { CardSortingStudyCard } from '../models/CardSortingStudyCard'
+import { CardSortingStudyOptions } from '../models/CardSortingStudyOptions'
 
 // Variables
-const index = ref(0);
-const change = ref(false);
+const index = ref(0)
+const change = ref(false)
 const welcomeMessage = ref('')
 const finalMessage = ref('')
 const consent = ref('')
@@ -145,7 +129,7 @@ const optionsCategories = ref({})
 const optionsCards = ref({})
 
 // Stores
-const store = useStore();
+const store = useStore()
 
 // Computed
 const test = computed(() => store.getters.test)
@@ -164,14 +148,14 @@ const submit = async () => {
     postTest: store.getters.postTest,
     consent: consent.value,
     cardSorting: {
-      categories: categories.value.map(category => category.toJson()),
-      cards: cards.value.map(card => card.toJson()),
+      categories: categories.value.map((category) => category.toJson()),
+      cards: cards.value.map((card) => card.toJson()),
       options: {
         card_description: optionsCards.value.card_description,
         card_image: optionsCards.value.card_image,
         category_description: optionsCategories.value.category_description,
         category_image: optionsCategories.value.category_image,
-      }
+      },
     },
   }
 
@@ -195,7 +179,7 @@ const getConsent = () => {
 const getCategories = () => {
   if (!test.value.testStructure.cardSorting) return
 
-  test.value.testStructure.cardSorting.categories.map(cat => {
+  test.value.testStructure.cardSorting.categories.map((cat) => {
     categories.value.push(new CardSortingStudyCategory(cat))
   })
 }
@@ -203,15 +187,19 @@ const getCategories = () => {
 const getCards = () => {
   if (!test.value.testStructure.cardSorting) return
 
-  test.value.testStructure.cardSorting.cards.map(card => {
+  test.value.testStructure.cardSorting.cards.map((card) => {
     cards.value.push(new CardSortingStudyCard(card))
   })
 }
 
 const getOptions = () => {
   if (!test.value.testStructure.cardSorting) return
-  optionsCategories.value = new CardSortingStudyOptions(test.value.testStructure.cardSorting.options)
-  optionsCards.value = new CardSortingStudyOptions(test.value.testStructure.cardSorting.options)
+  optionsCategories.value = new CardSortingStudyOptions(
+    test.value.testStructure.cardSorting.options,
+  )
+  optionsCards.value = new CardSortingStudyOptions(
+    test.value.testStructure.cardSorting.options,
+  )
 }
 
 const getPreTest = () => {

--- a/src/ux/CardSorting/views/ManagerView.vue
+++ b/src/ux/CardSorting/views/ManagerView.vue
@@ -22,7 +22,7 @@ import {
 // Stores
 const store = useStore()
 const route = useRoute()
-const router = useRouter()
+// const router = useRouter()
 
 // Computed
 const user = computed(() => store.getters.user)


### PR DESCRIPTION
# Description
This PR addresses multiple linting issues in the `src/ux/CardSorting` directory to improve code quality and maintainability.

## Changes
- **Internationalization**: Replaced hardcoded text with translation keys in [EditTestView.vue](cci:7://file:///Users/sarthakbasu/Desktop/GSoC/UrmakiLabs/RUXAILAB/src/ux/CardSorting/views/EditTestView.vue:0:0-0:0), [CardsEditCardSorting.vue](cci:7://file:///Users/sarthakbasu/Desktop/GSoC/UrmakiLabs/RUXAILAB/src/ux/CardSorting/components/CardsEditCardSorting.vue:0:0-0:0), [CategoriesEditCardSorting.vue](cci:7://file:///Users/sarthakbasu/Desktop/GSoC/UrmakiLabs/RUXAILAB/src/ux/CardSorting/components/CategoriesEditCardSorting.vue:0:0-0:0), [CardSortingForm.vue](cci:7://file:///Users/sarthakbasu/Desktop/GSoC/UrmakiLabs/RUXAILAB/src/ux/CardSorting/components/dialogs/CardSortingForm.vue:0:0-0:0), and [CardSortingTask.vue](cci:7://file:///Users/sarthakbasu/Desktop/GSoC/UrmakiLabs/RUXAILAB/src/ux/CardSorting/components/CardSortingTask.vue:0:0-0:0).
- **Unused Code**: Removed unused variables (`props`, `router`, `taskIndex`, `fullName`, error parameters) across multiple files.
- **Console Logs**: Commented out debugging `console` statements from production code in [CardSortingTest.vue](cci:7://file:///Users/sarthakbasu/Desktop/GSoC/UrmakiLabs/RUXAILAB/src/ux/CardSorting/components/CardSortingTest.vue:0:0-0:0).
- **Translation Keys**: Added new `CardSorting` section to [en.json](cci:7://file:///Users/sarthakbasu/Desktop/GSoC/UrmakiLabs/RUXAILAB/src/app/plugins/locales/en.json:0:0-0:0) with keys for cards, categories, settings, and UI text.

## Verification
- Run `npx eslint src/ux/CardSorting` to verify that there are **0 warnings**.
- Verified no merge conflicts with `upstream/develop`.

## Screenshots
<img width="1512" height="982" alt="linting_card_sorting" src="https://github.com/user-attachments/assets/c10d3dc1-64ba-4eb7-8367-0bed77f3e36a" />

Closes #1630