### PR TITLE
fix: bind tempform ref used in createTemplate validation

### DIFF
--- a/src/shared/components/AccessibilityTestSettings.vue
+++ b/src/shared/components/AccessibilityTestSettings.vue
@@ -395,6 +395,7 @@ const {
   loading,
   loadingPage,
   tempDialog,
+  tempform,
   statusOptions,
   titleRequired,
   localChanges,


### PR DESCRIPTION
fixes #1656 
This PR fixes an incorrect tempform ref binding used in createTemplate() validation.
Previously, tempform.value.validate() could be called without a guaranteed form instance, risking unsafe access.
The ref is now correctly bound, ensuring validation runs only when the v-form is available and preventing silent runtime errors.