### PR TITLE
fix(settings): bind form refs correctly in AccessibilityTestSettings

### DIFF
--- a/src/shared/components/AccessibilityTestSettings.vue
+++ b/src/shared/components/AccessibilityTestSettings.vue
@@ -395,6 +395,8 @@ const {
   loading,
   loadingPage,
   tempDialog,
+  form1,
+  tempform,
   statusOptions,
   titleRequired,
   localChanges,


### PR DESCRIPTION
## Summary
Fixes runtime error "Cannot read properties of null (reading 'validate')" when saving test settings or creating templates.

## Changes
- Destructured `tempform` and `form1` from `useAccessibilityTestSettings` composable so template refs are properly bound.

Closes #1656