### PR TITLE
Fix: Admin redirected to test steps on refresh and after step completion in moderated sessions

### DIFF
--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -643,7 +643,8 @@ const { t } = useI18n()
 // Data variables
 
 onBeforeUnmount(() => {
-  if (moderatorDisconnectTimeout.value) clearTimeout(moderatorDisconnectTimeout.value)
+  if (moderatorDisconnectTimeout.value)
+    clearTimeout(moderatorDisconnectTimeout.value)
 })
 
 const testDisabledReason = ref(null)
@@ -785,6 +786,10 @@ watch(
 // Methods
 const proceedToNextStep = async () => {
   if (!isUserTestAdmin.value) return
+
+  // Increment globalIndex before updating Firebase
+  globalIndex.value = globalIndex.value + 1
+
   const roomRef = dbRef(database, `rooms/${roomId.value}`)
   await update(roomRef, {
     globalIndex: globalIndex.value,
@@ -958,6 +963,9 @@ const startTest = async () => {
       if (data.showVideoCall !== undefined) {
         displayVideoCallComponent.value = data.showVideoCall
       }
+    } else {
+      // Admin always stays in video call during session
+      displayVideoCallComponent.value = true
     }
   })
 
@@ -996,7 +1004,8 @@ const handleModeratorStatusChange = (connected) => {
 
   if (!connected) {
     // Moderator disconnected — start 5-min timeout
-    if (moderatorDisconnectTimeout.value) clearTimeout(moderatorDisconnectTimeout.value)
+    if (moderatorDisconnectTimeout.value)
+      clearTimeout(moderatorDisconnectTimeout.value)
     moderatorDisconnectTimeout.value = setTimeout(() => {
       moderatorInactive.value = true
     }, MODERATOR_DISCONNECT_TIMEOUT_MS)


### PR DESCRIPTION
Admin was being redirected to test steps during refresh. Fixed Firebase listener to keep admin always in video call during active session.

**Changes:**
- Added condition in Firebase listener to ensure `displayVideoCallComponent = true` for admin throughout session
- Admin never sees test step components (ConsentStep, PreTestStep, TaskStep, etc.)

**File Modified:**
- `src/ux/UserTest/views/ModeratedTestView.vue` 


## BEFORE:

https://github.com/user-attachments/assets/356be7fb-8aee-4b41-9cfd-f948d973706e




## AFTER:

https://github.com/user-attachments/assets/637f2632-7c50-4f2c-ac95-023e934b6c61



