### PR TITLE
Fix test link redirect for unauthenticated users

### DIFF
--- a/src/features/auth/views/SignInView.vue
+++ b/src/features/auth/views/SignInView.vue
@@ -108,7 +108,7 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import GoogleSignInButton from '@/features/auth/components/GoogleSignInButton'
 import { createEmailRules } from '@/shared/utils/validators'
@@ -116,6 +116,7 @@ import { createEmailRules } from '@/shared/utils/validators'
 const { t } = useI18n()
 const store = useStore()
 const router = useRouter()
+const route = useRoute()
 
 const form = ref(null)
 const showPassword = ref(false)
@@ -123,6 +124,7 @@ const email = ref('')
 const password = ref('')
 const rememberMe = ref(false)
 const loadingType = ref('')
+const redirectUrl = ref(route.query.redirect || '/admin')
 
 const loading = computed(() => store.getters.loading)
 
@@ -146,7 +148,7 @@ const onSignIn = async () => {
       password: password.value,
       rememberMe: rememberMe.value,
     })
-    await router.push('/admin')
+    await router.push(decodeURIComponent(redirectUrl.value))
   } catch (error) {
     return error
   } finally {
@@ -160,7 +162,7 @@ const toggleShowPassword = () => {
 }
 
 const redirectToSignup = () => {
-  router.push('/signup')
+  router.push(`/signup?redirect=${encodeURIComponent(redirectUrl.value)}`)
 }
 
 const redirectToForgotPassword = () => {
@@ -173,7 +175,8 @@ const onGoogleSignInStart = () => {
 }
 
 const onGoogleSignInSuccess = async () => {
-  if (store.getters.user) router.push('/admin')
+  if (store.getters.user) 
+    await router.push(decodeURIComponent(redirectUrl.value))
   store.commit('setLoading', false)
 }
 

--- a/src/features/auth/views/SignUpView.vue
+++ b/src/features/auth/views/SignUpView.vue
@@ -96,7 +96,7 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Snackbar from '@/shared/components/Snackbar'
 import Loading from '../../../shared/components/Loading.vue'
@@ -117,7 +117,9 @@ const loading = computed(() => store.getters.loading)
 
 const store = useStore()
 const router = useRouter()
+const route = useRoute()
 const { t } = useI18n()
+const redirectUrl = ref(route.query.redirect || '/admin')
 
 const emailRules = createEmailRules(t)
 
@@ -143,7 +145,7 @@ const onSignUp = async () => {
         email: email.value,
         password: password.value,
       })
-      await router.push('/admin')
+      await router.push(decodeURIComponent(redirectUrl.value))
     } catch (error) {
       return error
     } finally {
@@ -153,7 +155,7 @@ const onSignUp = async () => {
 }
 
 const redirectToSignin = () => {
-  router.push('/signin')
+  router.push(`/signin?redirect=${encodeURIComponent(redirectUrl.value)}`)
 }
 
 const onGoogleSignInStart = () => {
@@ -162,7 +164,7 @@ const onGoogleSignInStart = () => {
 }
 
 const onGoogleSignInSuccess = async () => {
-  await router.push('/admin')
+  await router.push(decodeURIComponent(redirectUrl.value))
   store.commit('setLoading', false)
 }
 const onGoogleSignInError = (error) => {

--- a/src/views/public/TestView.vue
+++ b/src/views/public/TestView.vue
@@ -25,6 +25,7 @@
 <script setup>
 import { ref, computed, onBeforeMount } from 'vue'
 import { useStore } from 'vuex'
+import { useRouter, useRoute } from 'vue-router'
 import UserTestView from '@/ux/UserTest/views/UserTestView.vue'
 import ModeratedTestView from '../../ux/UserTest/views/ModeratedTestView.vue'
 import HeuristicTestView from '../../ux/Heuristic/views/HeuristicTestView.vue'
@@ -39,11 +40,25 @@ const props = defineProps({
 })
 
 const store = useStore()
+const route = useRoute()
+const router = useRouter()
 
 const test = computed(() => store.getters.test)
+const user = computed(() => store.getters.user)
 const moderatedTestViewRef = ref(null)
 
+const checkAuthAndRedirect = ()=> {
+  if(!user.value && !props.token){
+    const returnUrl = route.fullPath
+    router.push(`/signin?redirect=${encodeURIComponent(returnUrl)}`)
+    return false
+  }
+  return true
+}
+
 onBeforeMount(async () => {
+  // check if user is authenticated or not if not redirect to signin page with return url
+  if(!checkAuthAndRedirect()) return
   await store.dispatch('getStudy', { id: props.id })
   await store.dispatch('getCurrentTestAnswerDoc')
 })


### PR DESCRIPTION
issue fixed: #1677 

### Problem

When an unauthenticated user copies and pastes a test URL in a new tab/browser, they see a blank page instead of being redirected to signin.

### PR Summary

Implemented a complete redirect flow that:

- Checks authentication in TestView.vue before loading any test data
- Redirects unauthenticated users to signin with the test URL as a redirect parameter
- Preserves the redirect parameter throughout the entire auth flow (signin ↔ signup)
- Redirects users back to their original test after successful authentication

**Changes**:

- `TestView.vue`: Added auth check in onBeforeMount that redirects to signin if no user
- `SigninView.vue`: Added redirect parameter handling and passes it to signup page
- `SignupView.vue`: Added redirect parameter handling and passes it back to signin

Video Demo Before:
https://app.screencastify.com/watch/8nDCJhJ8vQOcNEF4RxSL?checkOrg=83ca94ef-d118-40f1-92bc-e4fc7e0304e7

Video Demo After:
https://app.screencastify.com/watch/rWWvD11P0dwxwsVQhgCv?checkOrg=83ca94ef-d118-40f1-92bc-e4fc7e0304e7

attaching image just to prevent github action close pr
<img width="2475" height="973" alt="image" src="https://github.com/user-attachments/assets/7c6fdfba-b398-4617-9ad8-3737868ec3d5" />
