### PR TITLE
fix(StudyController): move removeNotificationsForTest outside loop to…

### DIFF
--- a/src/controllers/StudyController.js
+++ b/src/controllers/StudyController.js
@@ -59,10 +59,10 @@ export default class StudyController extends Controller {
           promises.push(
             userController.removeTestFromUser(cooperator.userDocId, payload.id),
           )
-          promises.push(
-            userController.removeNotificationsForTest(payload.id, cooperators),
-          )
         }
+        promises.push(
+          userController.removeNotificationsForTest(payload.id, cooperators),
+        )
         await Promise.all(promises)
       }
       await super.update('users', payload.testAdmin.userDocId, payload.auxUser)


### PR DESCRIPTION
## Description
Moves the `userController.removeNotificationsForTest` call outside the cooperators loop in [deleteStudy](cci:1://file://wsl.localhost/Ubuntu/home/abhay/RUXAILAB/src/shared/views/SettingsView.vue:624:0-639:1).

Previously, this function was called for every cooperator, leading to O(N²) database operations and potential race conditions due to simultaneous `Promise.all` execution.

## Changes
- Extracted [removeNotificationsForTest](cci:1://file://wsl.localhost/Ubuntu/home/abhay/RUXAILAB/src/features/auth/controllers/UserController.js:191:2-221:3) from the `for` loop in [src/controllers/StudyController.js](cci:7://file://wsl.localhost/Ubuntu/home/abhay/RUXAILAB/src/controllers/StudyController.js:0:0-0:0).
- Ensured it is only called once per study deletion.

## Impact
- **Performance:** Reduces database operations from O(N²) to O(N).
- **Stability:** Eliminates race conditions and "Write Contention" errors during notification removal.

## Verification
- Verified that `removeNotificationsForTest` is called exactly once after the loop completes.

## Screenshot
<img width="1098" height="426" alt="image" src="https://github.com/user-attachments/assets/820f5594-34bb-401e-8f7e-a751791aa55f" />


closes #1686 