### PR TITLE
Title: fix: remove memory leak from uncleared change-section event listener in AdminView

### DIFF
--- a/src/features/navigation/views/AdminView.vue
+++ b/src/features/navigation/views/AdminView.vue
@@ -305,14 +305,13 @@ onMounted(async () => {
   window.addEventListener('toggle-dashboard-drawer', handleToggleDrawer)
 
   // Change section event listener
-  globalThis.addEventListener('change-section', (event) => {
-    activeSection.value = event.detail
-  })
+  window.addEventListener('change-section', handleChangeSection)
 })
 
 onUnmounted(() => {
   if (unsubscribeTests) unsubscribeTests()
   window.removeEventListener('toggle-dashboard-drawer', handleToggleDrawer)
+  window.removeEventListener('change-section', handleChangeSection)
 })
 
 /**
@@ -320,6 +319,10 @@ onUnmounted(() => {
  */
 const handleToggleDrawer = () => {
   drawerOpen.value = !drawerOpen.value
+}
+
+const handleChangeSection = (event) => {
+  activeSection.value = event.detail
 }
 
 // Reacts to route query changes for section/subsection


### PR DESCRIPTION
## Summary
The change-section event listener in AdminView.vue was added in onMounted but never removed in onUnmounted, causing a memory leak.

## Problem
The listener was registered as an anonymous inline function, making it impossible to remove with removeEventListener
Each time AdminView was mounted/unmounted, a new orphaned listener accumulated on the global object
Over repeated navigations, this caused duplicate event handlers firing multiple times and increased memory usage
Changes
* Extracted the anonymous handler into a named handleChangeSection function
* Added window.removeEventListener('change-section', handleChangeSection) in onUnmounted
* Changed globalThis to window for consistency with the existing toggle-dashboard-drawer listener

## Files changed
* src/features/navigation/views/AdminView.vue

## Test plan
- [ ] Navigate to the admin dashboard and verify sections still change correctly
- [ ] Navigate away from and back to the admin page multiple times — confirm no duplicate listener behavior
- [ ] Check browser DevTools (Event Listeners tab) to verify only one `change-section` listener exists while on the page, and zero after navigating away

