### PR TITLE
feat: integrate Codecov for test coverage reporting (#1696)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,18 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Test
-        run: npm test
+      - name: Test with Coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          flags: unittests
+          name: jest-coverage
+          fail_ci_if_error: false
 
       - name: Comment to PR
         if: failure() && github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ ui-debug.log
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/coverage/
 
 # Ignore the playwright test screenshots and video
 /playwright/output

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 <div align="center">
   <h1>Welcome to UX Remote LAB</h1>
+  <p>
+    <a href="https://codecov.io/gh/ruxailab/RUXAILAB">
+      <img src="https://codecov.io/gh/ruxailab/RUXAILAB/branch/develop/graph/badge.svg" alt="codecov" />
+    </a>
+  </p>
   <p><strong>UX Remote LAB</strong> is a user-friendly platform for usability testing and heuristic evaluation. Designed and provided by UX Remote LAB, it is a web application developed to assist project creators in gathering valuable insights from their users.</p>
 </div>
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: 60%
+        threshold: 5%
+        informational: true
+    patch:
+      default:
+        target: 70%
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,4 +9,7 @@ module.exports = {
   setupFilesAfterEnv: ['./tests/mocks/firebase.js'],
   resetMocks: true,
   clearMocks: true,
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'clover'],
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
     "doc": "jsdoc -c conf.json",
     "test": "vue-cli-service test:unit",
+    "test:coverage": "vue-cli-service test:unit --coverage",
     "build-dev": "vue-cli-service build --mode development",
     "build-prod": "vue-cli-service build --mode production",
     "cypress:open": "cypress open",


### PR DESCRIPTION
fixes #1696 
This PR integrates Codecov to enable automated test coverage reporting for the repository.

### Changes
- Enable Jest coverage reporting (text, lcov, clover)
- Add `test:coverage` npm script
- Add `codecov.yml` with informational coverage thresholds
- Update CI workflow to generate and upload coverage reports
- Add Codecov badge to README
- Exclude `coverage/` from version control

### Verification
- All tests pass with coverage enabled (93/93)
- Coverage report generated successfully (`coverage/lcov.info`)
- CI uploads coverage reports using `codecov/codecov-action`

### Maintainer Note
⚠️ One-time setup required:
Please add a `CODECOV_TOKEN` in  
**Settings → Secrets → Actions**  
(Token available from https://app.codecov.io after linking the repository)

Without the token, the upload step will safely skip without failing CI.

This PR does not modify existing tests—only reporting and CI integration.