### PR TITLE
docs: fixed format and test script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ Then create a Pull Request on GitHub:
 We use **Prettier** for code formatting. Configuration is in `.prettierrc`.
 
 ```bash
-# Format all files
+# Format source files
 npm run format
 
 # Check formatting
@@ -227,23 +227,23 @@ src/
 
 ```bash
 # Run all tests
-npm run test:unit
+npm run test
 
 # Run tests in watch mode
-npm run test:unit:watch
+npm run test -- --watch
 
 # Run with coverage
-npm run test:unit:coverage
+npm run test -- --coverage
 ```
 
 ### End-to-End Tests (Playwright)
 
 ```bash
 # Run E2E tests
-npm run test:e2e
+npm run test-playwright
 
 # Run in headed mode (see browser)
-npm run test:e2e:headed
+npm run test-playwright -- --headed
 ```
 
 ### Writing Tests

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "serve": "vue-cli-service serve",
     "lint": "eslint src --ext .js,.vue",
     "lint:fix": "eslint src --ext .js,.vue --fix",
+    "format": "prettier --write \"src/**/*.{js,vue}\"",
+    "format:check": "prettier --check \"src/**/*.{js,vue}\"",
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
     "doc": "jsdoc -c conf.json",
     "test": "vue-cli-service test:unit",


### PR DESCRIPTION
Fixes: #1700 

1. Added format and format:check in package.json on src files with .vue and .js 
Looking at lint-staged which runs prettier --write only on [*.{js,vue}] and the pre-commit hook runs npx lint-staged and .prettierignore explicitly ignores dist and node_modules and src/node_modules. So kept formatting only for Vue/JS under src. 
Before:
<img width="527" height="136" alt="image" src="https://github.com/user-attachments/assets/20a8b78e-b9a0-4d01-af12-3379998199b6" />

After:
<img width="907" height="885" alt="image" src="https://github.com/user-attachments/assets/4278c173-251a-4c0f-87f0-9d31b2043033" />

2. Updated formatting and test commands for unit, end to end and formatting in CONTRIBUTING.md


Ran all codes in CONTRIBUTING.md after change. No Missing Script error occured so all commands are in package.json