### PR TITLE
fix: pass coordinates to drawPrecisionPoints

### DIFF
--- a/src/ux/UserTest/components/answers/EyeTrackingOverlay.vue
+++ b/src/ux/UserTest/components/answers/EyeTrackingOverlay.vue
@@ -36,7 +36,6 @@ function drawFreeEye(cx, cy) {
 }
 
 function drawPrecisionPoints(cx, cy) {
-  console.log("Precision draw called with:", cx, cy)
   ctx.lineWidth = 2
   ctx.strokeStyle = 'rgba(0, 200, 255, 0.6)'
   ctx.beginPath()

--- a/src/ux/UserTest/components/answers/EyeTrackingOverlay.vue
+++ b/src/ux/UserTest/components/answers/EyeTrackingOverlay.vue
@@ -36,6 +36,7 @@ function drawFreeEye(cx, cy) {
 }
 
 function drawPrecisionPoints(cx, cy) {
+  console.log("Precision draw called with:", cx, cy)
   ctx.lineWidth = 2
   ctx.strokeStyle = 'rgba(0, 200, 255, 0.6)'
   ctx.beginPath()
@@ -103,7 +104,7 @@ function animateSmooth(timestamp) {
   ctx.clearRect(0, 0, canvas.value.width, canvas.value.height)
 
   if (props.viewMode === 'free') drawFreeEye(cx, cy)
-  else if (props.viewMode === 'precision') drawPrecisionPoints()
+  else if (props.viewMode === 'precision') drawPrecisionPoints(cx, cy)
   else if (props.viewMode === 'heatmap') {
     heatmapData.push({ x: cx, y: cy })
     drawHeatmap()


### PR DESCRIPTION
## Description
This PR fixes an issue where precision points were not being rendered correctly in the overlay.

The problem occurred because the `drawPrecisionPoints` function was not receiving the correct coordinate values from the backend data. As a result, the points either appeared in incorrect positions or were not drawn as expected.

This change ensures that:
- Correct coordinates are passed to `drawPrecisionPoints`
- Precision points are rendered accurately on the overlay
- The visualization aligns properly with the recorded interaction data

#### Fixes #1711 

## Root Cause
The coordinate data returned from the backend was available, but it was not being forwarded properly to the function responsible for drawing precision points.

## Fix
- Passed the correct coordinate values to `drawPrecisionPoints`
- Ensured the overlay rendering logic uses the updated coordinates

## Testing
- Ran the application locally
- Verified that precision points now appear in the correct position
- Confirmed that previously affected cases now render correctly


https://github.com/user-attachments/assets/05132669-ee96-4b78-9092-42cadde8d92f



## Related Area
Analytics / Heatmap Overlay