### PR TITLE
docs: update README Get Support link to GitHub Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ UX Remote LAB provides a collaborative environment for creators to share their p
 - [Request a Feature 🚀](https://github.com/uramakilab/remote-usability-lab/issues/new)
 - [Ask a Question 🤗](https://github.com/uramakilab/remote-usability-lab/discussions)
 
-For commercial support, academic collaborations, and answers to common questions, please use [Get Support]() to contact us.
+For commercial support, academic collaborations, and answers to common questions, please use [Get Support](https://github.com/uramakilab/remote-usability-lab/discussions) to contact us.
+
 
 ### Development Environment
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ UX Remote LAB provides a collaborative environment for creators to share their p
 - [Request a Feature 🚀](https://github.com/uramakilab/remote-usability-lab/issues/new)
 - [Ask a Question 🤗](https://github.com/uramakilab/remote-usability-lab/discussions)
 
-For commercial support, academic collaborations, and answers to common questions, please use [Get Support](https://github.com/uramakilab/remote-usability-lab/discussions) to contact us.
+For commercial support, academic collaborations, and answers to common questions, please use [Get Support](https://discord.gg/MFWNpwTq9q) to contact us.
 
 
 ### Development Environment


### PR DESCRIPTION
## 📄 Fix broken "Get Support" link in README

### Summary
This PR fixes a broken **Get Support** link in `README.md`.  
It’s a simple documentation fix that updates the empty link and redirects users to the project’s **GitHub Discussions** page, providing a clear and accessible place for support and community questions.

### What Changed
<img width="1343" height="433" alt="Screenshot 2026-02-21 001922" src="https://github.com/user-attachments/assets/ba7722de-ef59-4b16-93cb-d0a04ae051f3" />

 - After Change
<img width="1378" height="108" alt="Screenshot 2026-02-21 002144" src="https://github.com/user-attachments/assets/951825e1-0d89-450a-87a3-ce4f0be6a56a" />

  closes #1715 


