### PR TITLE
Fix : Enforce Descending Sort Order for Transcription Runs

### DIFF
--- a/src/ai/transcriptions/TranscriptionController.js
+++ b/src/ai/transcriptions/TranscriptionController.js
@@ -142,10 +142,26 @@ export default class TranscriptionController extends Controller {
 
         if (result.docs.length === 0) return null;
 
-        return result.docs.map(doc => Transcription.toTranscription({
+        const transcriptions = result.docs.map(doc => Transcription.toTranscription({
             id: doc.id, // Include the document ID here
             ...doc.data()
         }));
+
+        const toMillis = (ts) => {
+            if (!ts) return 0;
+            if (typeof ts.toMillis === 'function') return ts.toMillis();
+            if (typeof ts.toDate === 'function') return ts.toDate().getTime();
+            if (typeof ts.seconds === 'number') {
+                return ts.seconds * 1000 + Math.floor((ts.nanoseconds || 0) / 1e6);
+            }
+            if (ts instanceof Date) return ts.getTime();
+            const d = new Date(ts);
+            const ms = d.getTime();
+            return Number.isNaN(ms) ? 0 : ms;
+        };
+
+        transcriptions.sort((a, b) => toMillis(b.createdAt) - toMillis(a.createdAt));
+        return transcriptions;
     }
 
 


### PR DESCRIPTION
fixes #1719 

### Summary

Ensures transcription runs are returned in descending order (`createdAt`) from the controller to satisfy UI assumptions and prevent data inconsistency in exports and deletions.


### The Problem

The UI components (`TranscriptionsPanel.vue` and `ExportPanel.vue`) assume that the `runs` array is pre-sorted by date, specifically using `runs[0]` to identify the "latest" transcription.

However, `TranscriptionController.js` used a Firestore query without an explicit `orderBy` clause. This resulted in non-deterministic ordering, leading to:

* **Incorrect Exports:** The "Latest Run" export occasionally selected older transcriptions.
* **Metadata Corruption:** The `latestTranscriptionDocId` was frequently mapped to the wrong record during deletion flows.

### The Fix

Updated `TranscriptionController.js` to explicitly sort the results before returning them to the frontend.

* **Logic:** Once documents are mapped to `Transcription` instances, they are sorted by `createdAt` in descending order.
* **Robustness:** The sorting logic handles multiple timestamp formats (Firestore `Timestamp`, `{seconds, nanoseconds}`, `Date` objects, and ISO strings) to ensure reliability across different environments.

### Impact

* **Reliability:** "Latest run" exports now consistently pick the most recent data.
* **Integrity:** `latestTranscriptionDocId` updates now accurately reflect the true latest run after a deletion.
* **Consistency:** Eliminates the "magic assumption" in the UI by providing a guaranteed data structure from the backend.


### FLow Diagram
<img width="621" height="465" alt="image" src="https://github.com/user-attachments/assets/0721a3a1-9afe-46eb-a72f-a5529b544959" />
