### PR TITLE
fix: include NONE in author_association check for welcome workflow

### DIFF
--- a/.github/workflows/first-time-contributor-welcome.yml
+++ b/.github/workflows/first-time-contributor-welcome.yml
@@ -26,7 +26,7 @@ jobs:
 
             // Only welcome first-time contributors
             const assoc = pr.author_association;
-            const isFirstTimer = assoc === 'FIRST_TIMER' || assoc === 'FIRST_TIME_CONTRIBUTOR';
+            const isFirstTimer = ['NONE', 'FIRST_TIMER', 'FIRST_TIME_CONTRIBUTOR'].includes(assoc);
             if (!isFirstTimer) return;
 
             const marker = '<!-- ruxailab:first-time-welcome -->';


### PR DESCRIPTION
## Description
The `first-time-contributor-welcome.yml` workflow was not posting welcome messages for new contributors.

## Root Cause
The workflow only checked for `FIRST_TIMER` and `FIRST_TIME_CONTRIBUTOR` author associations. However, GitHub returns `NONE` for most first-time external contributors who have no prior association with the repository, causing the check to silently skip them.

## Fix
Added `NONE` to the `author_association` check so the welcome message triggers correctly for all first-time contributors.

```diff
- const isFirstTimer = assoc === 'FIRST_TIMER' || assoc === 'FIRST_TIME_CONTRIBUTOR';
+ const isFirstTimer = ['NONE', 'FIRST_TIMER', 'FIRST_TIME_CONTRIBUTOR'].includes(assoc);
```

Bot PRs and duplicate comments are still handled by existing guards.

## Screenshot
<img width="1395" height="4680" alt="github com_ruxailab_RUXAILAB_pull_1726Asus_Zenbook_Fold" src="https://github.com/user-attachments/assets/c29dfb50-2e17-42fd-8907-29fd8d330f69" />

Closes #1727