### PR TITLE
fix: navbar submenu extra space removed

### DIFF
--- a/src/features/navigation/components/DashboardSidebar.vue
+++ b/src/features/navigation/components/DashboardSidebar.vue
@@ -26,7 +26,7 @@
             :title="$t(child.title)"
             :prepend-icon="child.icon"
             :active="activeSection === item.id && activeSubSection === child.id"
-            class="subsection-item ml-4 mb-1"
+            class="subsection-item mb-1"
             rounded="lg"
             @click="selectNavigation(item.id, child.id)"
           />
@@ -191,6 +191,11 @@ const selectNavigation = (sectionId, childId = null) => {
   transform: scale(1.1);
 }
 
+/* Control Vuetify's built-in group indent at the correct parent scope */
+.v-list-group :deep(.v-list-group__items) {
+  --indent-padding: 8px !important;
+}
+
 .subsection-item {
   font-size: 0.9rem;
   padding: 0;
@@ -202,8 +207,13 @@ const selectNavigation = (sectionId, childId = null) => {
   opacity: 1;
 }
 
+/* Tighten the gap between the icon and the label */
+.subsection-item :deep(.v-list-item__prepend) {
+  margin-inline-end: 6px !important;
+}
+
 .subsection-item .v-list-item__prepend .v-icon {
   font-size: 18px;
-  margin-right: 12px;
+  margin-right: 6px;
 }
 </style>


### PR DESCRIPTION
fixes #1725

## What this PR does
Fixes the extra indentation/spacing in the navbar submenu by cleaning up the root cause rather than patching symptoms.

**(from issue #1725):** 
<img width="430" height="407" alt="image" src="https://github.com/user-attachments/assets/3420e779-3391-4e49-89c8-95bc918d6584" />

## Changes
- **Remove** `ml-4` utility class from the subsection `v-list-item` — spacing was being controlled in two places (template class + CSS), which is fragile and redundant
- **Move** `--indent-padding` to `.v-list-group :deep(.v-list-group__items)` — the correct parent scope where Vuetify internally reads this CSS variable
- **Add** `.subsection-item :deep(.v-list-item__prepend)` override to tighten the icon-label gap
- **Reduce** icon `margin-right` from `12px` → `6px` for consistent, compact spacing

## Why this improves on #1726
PR #1726 sets `--indent-padding` on `.subsection-item` (the child element), but Vuetify reads this variable from the **group container** parent. This PR sets it at the correct scope, removing the need for any `ml-*` utility class margin hack — single source of truth for indentation.