### PR TITLE
Fix : Update studies on the Dashboard

### DIFF
--- a/src/controllers/StudyController.js
+++ b/src/controllers/StudyController.js
@@ -24,7 +24,24 @@ export default class StudyController extends Controller {
     )
     payload.answersDocId = answerDoc.id
 
-    return await super.create(COLLECTION, payload.toFirestore())
+    const docRef = await super.create(COLLECTION, payload.toFirestore())
+
+    const userDocId = payload?.testAdmin?.userDocId
+    if (userDocId) {
+      await userController.update(userDocId, {
+        [`myTests.${docRef.id}`]: {
+          testDocId: docRef.id,
+          testTitle: payload.testTitle || payload.title || 'Untitled Test',
+          testType: payload.testType || 'UNKNOWN',
+          subType: payload.subType || null,
+          numberColaborators: payload.cooperators?.length || 0,
+          creationDate: payload.creationDate || Date.now(),
+          updateDate: Date.now(),
+        },
+      })
+    }
+
+    return docRef
   }
   async duplicateStudy(payload) {
     try {

--- a/src/store/modules/Study.js
+++ b/src/store/modules/Study.js
@@ -105,12 +105,39 @@ export default {
     },
   },
   actions: {
-    async createStudy({ commit }, payload) {
+    async createStudy({ commit, state, rootGetters }, payload) {
       commit('setLoading', true)
       try {
         const res = await studyController.createStudy(payload)
         payload.id = res.id
         commit('SET_TEST', payload)
+        const nextTests = Array.isArray(state.tests) ? [...state.tests] : []
+        const existingIndex = nextTests.findIndex((t) => t?.id === payload.id)
+        if (existingIndex === -1) nextTests.unshift(payload)
+        else nextTests.splice(existingIndex, 1, payload)
+        commit('SET_TESTS', nextTests)
+
+        const userId = payload?.testAdmin?.userDocId || rootGetters?.user?.id
+        if (userId) {
+          try {
+            const userController = new UserController()
+            const userDoc = await userController.getById(userId)
+            userDoc.myTests = userDoc.myTests || {}
+            userDoc.myTests[payload.id] = {
+              testDocId: payload.id,
+              testTitle: payload.testTitle || payload.title || 'Untitled Test',
+              testType: payload.testType || 'UNKNOWN',
+              subType: payload.subType || null,
+              numberColaborators: payload.cooperators?.length || 0,
+              creationDate: payload.creationDate || Date.now(),
+              updateDate: Date.now(),
+            }
+            await userController.update(userDoc.id, userDoc.toFirestore())
+            commit('SET_USER', userDoc, { root: true })
+          } catch (userErr) {
+            console.warn('Failed to update user tests after study creation', userErr)
+          }
+        }
         return res.id
       } catch (err) {
         commit('setError', {

--- a/src/store/modules/Study.js
+++ b/src/store/modules/Study.js
@@ -134,8 +134,8 @@ export default {
             }
             await userController.update(userDoc.id, userDoc.toFirestore())
             commit('SET_USER', userDoc, { root: true })
-          } catch (userErr) {
-            console.warn('Failed to update user tests after study creation', userErr)
+          } catch (error_) {
+            console.warn('Failed to update user tests after study creation', error_)
           }
         }
         return res.id

--- a/src/store/modules/Study.js
+++ b/src/store/modules/Study.js
@@ -9,6 +9,7 @@ import { getAuth } from 'firebase/auth'
 import { STUDY_TYPES } from '@/shared/constants/methodDefinitions'
 
 const studyController = new StudyController()
+const userController = new UserController()
 
 export default {
   state: {
@@ -105,7 +106,7 @@ export default {
     },
   },
   actions: {
-    async createStudy({ commit, state, rootGetters }, payload) {
+    async createStudy({ commit, state }, payload) {
       commit('setLoading', true)
       try {
         const res = await studyController.createStudy(payload)
@@ -116,28 +117,6 @@ export default {
         if (existingIndex === -1) nextTests.unshift(payload)
         else nextTests.splice(existingIndex, 1, payload)
         commit('SET_TESTS', nextTests)
-
-        const userId = payload?.testAdmin?.userDocId || rootGetters?.user?.id
-        if (userId) {
-          try {
-            const userController = new UserController()
-            const userDoc = await userController.getById(userId)
-            userDoc.myTests = userDoc.myTests || {}
-            userDoc.myTests[payload.id] = {
-              testDocId: payload.id,
-              testTitle: payload.testTitle || payload.title || 'Untitled Test',
-              testType: payload.testType || 'UNKNOWN',
-              subType: payload.subType || null,
-              numberColaborators: payload.cooperators?.length || 0,
-              creationDate: payload.creationDate || Date.now(),
-              updateDate: Date.now(),
-            }
-            await userController.update(userDoc.id, userDoc.toFirestore())
-            commit('SET_USER', userDoc, { root: true })
-          } catch (error_) {
-            console.warn('Failed to update user tests after study creation', error_)
-          }
-        }
         return res.id
       } catch (err) {
         commit('setError', {
@@ -261,7 +240,6 @@ export default {
         const user = auth.currentUser
 
         if (user) {
-          const userController = new UserController()
           const userDoc = await userController.getUserWithStudies(user.uid)
 
           if (userDoc) {


### PR DESCRIPTION
Fixes #1731 

**Summary**
- Fix dashboard/studies list not showing a newly created study by updating Vuex `tests` state immediately after creation.
- Keep user’s `myTests` in sync so future fetches reflect the newly created study without relying on async Cloud Functions.

**Risk / Rollback**
- Risk level: Low
- Rollback plan: Revert `/RUXAILAB/src/store/modules/Study.js`.

**Screenshots**
<img width="1137" height="551" alt="image" src="https://github.com/user-attachments/assets/2f989d47-4736-4bd2-93a3-bb549e082156" />

**Checklist**
- [x] Self-review completed
- [ ] Added or updated tests, or not needed
- [ ] Updated docs or inline comments where needed

**Problem**
After creating a study and returning to the dashboard, the “Active Studies Overview” card remains empty. This occurs because the dashboard reads from `store.getters.tests`, but `createStudy` did not update the `tests` array in the Vuex store. The new study only appeared after a full re-fetch (which can be delayed or not triggered).

**Fix**
`createStudy` now immediately updates Vuex state:
- Inserts the newly created study into `state.tests`, which drives:
  - Dashboard Active Studies list
  - Stats cards (Total Studies, Participants)
  - Top Methods data
- Updates the user document’s `myTests` entry to keep persisted data consistent, then updates the Auth store user record.

**Code Changes**
- `/RUXAILAB/src/store/modules/Study.js`
  - `createStudy`: update Vuex `tests` immediately and sync `myTests` for the current user.

**Impact**
- The dashboard now shows newly created studies immediately.
- Related dashboard widgets (stats + top methods) update correctly in the same session.
- Reduces reliance on async Cloud Function timing for user `myTests`.