### PR TITLE
fix: dialog header spacing in heuristic edit dialogs

### DIFF
--- a/src/ux/Heuristic/components/HeuristicsTable.vue
+++ b/src/ux/Heuristic/components/HeuristicsTable.vue
@@ -507,13 +507,10 @@
     <!-- Add Question Dialog -->
     <v-dialog v-model="dialogQuestion" max-width="600" persistent>
       <v-card>
-        <v-card-title
-          class="text-h5 pa-6"
-          style="background-color: #fca326; color: white"
-        >
+        <v-card-title class="text-h5 bg-orange pa-4 text-white">
           {{ $t('HeuristicsTable.titles.newQuestion') }}
         </v-card-title>
-        <v-card-text class="pa-6 pt-0">
+        <v-card-text class="pa-6">
           <v-form ref="formQuestionRef" @submit.prevent="addQuestion">
             <v-text-field
               v-if="dialogQuestion && newQuestion"
@@ -549,17 +546,14 @@
     <!-- Edit Heuristic/Question Dialog -->
     <v-dialog v-model="dialogEdit" max-width="600" persistent>
       <v-card>
-        <v-card-title
-          class="text-h5 pa-6"
-          style="background-color: #fca326; color: white"
-        >
+        <v-card-title class="text-h5 bg-orange pa-4 text-white">
           {{
             itemEdit && !isDialogClosing
               ? itemEdit.title
               : $t('HeuristicsTable.titles.loading')
           }}
         </v-card-title>
-        <v-card-text class="pa-6 pt-0">
+        <v-card-text class="pa-6">
           <v-form ref="formEditRef" @submit.prevent="validateEdit">
             <v-text-field
               v-if="itemEdit && !isDialogClosing"


### PR DESCRIPTION
## Summary

This PR fixes the UI bug where dialog headers overlap with content in the Heuristic Edit page dialogs. The fix replaces inline CSS styles with Vuetify utility classes and adjusts padding for proper visual spacing.
Fixes #1744.
## Changes Made

### HeuristicsTable.vue

#### 1. Edit Heuristic/Question Dialog

**Before:**

```vue
<v-card-title
  class="text-h5 pa-6"
  style="background-color: #fca326; color: white"
>
```

```vue
<v-card-text class="pa-6 pt-0">
```

**After:**

```vue
<v-card-title class="text-h5 bg-orange pa-4 text-white">
```

```vue
<v-card-text class="pa-6">
```

#### 2. Add Question Dialog

**Before:**

```vue
<v-card-title
  class="text-h5 pa-6"
  style="background-color: #fca326; color: white"
>
```

```vue
<v-card-text class="pa-6 pt-0">
```

**After:**

```vue
<v-card-title class="text-h5 bg-orange pa-4 text-white">
```

```vue
<v-card-text class="pa-6">
```

## Technical Details

### Style Improvements

1. **Replaced Inline Styles**: Changed `style="background-color: #fca326; color: white"` to Vuetify classes `bg-orange text-white`
2. **Optimized Header Padding**: Reduced from `pa-6` to `pa-4` for better proportions
3. **Fixed Content Spacing**: Removed `pt-0` from `v-card-text` to ensure proper spacing between header and content
4. **Consistent Styling**: Applied same fixes to all affected dialogs


## Visual Changes

### Before
<img width="1228" height="1156" alt="Screenshot 2026-02-23 204103" src="https://github.com/user-attachments/assets/df009806-3b13-4645-a3b4-190e3f233424" />


- Orange header with excessive padding (24px)
- Content area with negative top padding causing overlap
- Cramped appearance

### After
<img width="2489" height="1149" alt="Screenshot 2026-02-23 204742" src="https://github.com/user-attachments/assets/e9af85f2-e56b-46d8-85a8-129513206356" />

- Orange header with optimized padding (16px)
- Proper spacing between header and content (24px)
- Clean, professional appearance

