### PR TITLE
Fix(auth): remove early return that prevented new Google user registration

### DIFF
--- a/src/features/auth/store/Auth.js
+++ b/src/features/auth/store/Auth.js
@@ -124,9 +124,8 @@ export default {
         let dbUser = null
         try {
           dbUser = await userController.getById(user.uid)
-        } catch (error) {
+        } catch {
           // User doesn't exist in DB, will be created below
-          return error
         }
 
         // Create user if they don't exist yet


### PR DESCRIPTION
## Summary

  - Removes the return error statement in the signInWithGoogle() catch block that was terminating the entire action when a new user wasn't found in the database
  - New Google sign-in users can now proceed to the user creation flow as originally intended
  
---

## Problem

  In src/features/auth/store/Auth.js, when userController.getById(user.uid) threw an error for a first-time Google user (no
  Firestore document yet), the catch block executed return error, exiting the Vuex action immediately. The user creation code on lines 140–148 was never reached, silently leaving new Google users without a database record.

---

##  Fix

  Removed the return error from the catch block so execution falls through to the existing if (!dbUser || !dbUser.email) check,
  which correctly handles creating the user document.

---

##  Test plan

  - Sign in with a Google account that has never used the app before — verify a new user document is created in Firestore
  - Sign in with an existing Google account — verify normal login still works
  - Verify the user is redirected properly after first-time Google sign-in
 
---

## Images
<img width="801" height="548" alt="Screenshot 2026-02-23 at 11 09 57 PM" src="https://github.com/user-attachments/assets/430664e4-fd5a-4dd0-ae25-8c3a05085b7a" />

---

Fixes : #1747 
