### PR TITLE
Add Time Tracking Support to Heuristic Test

### DIFF
--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -666,6 +666,9 @@
     "actions": {
       "downloadCsvTemplate": "تحميل نموذج CSV",
       "update": "تحديث"
+    },
+    "options": {
+      "enableTimeTracking": "تمكين تتبع الوقت"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -666,6 +666,9 @@
     "actions": {
       "downloadCsvTemplate": "CSV-Vorlage herunterladen",
       "update": "Aktualisieren"
+    },
+    "options": {
+      "enableTimeTracking": "Zeiterfassung aktivieren"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -664,6 +664,9 @@
     "actions": {
       "downloadCsvTemplate": "Download CSV template",
       "update": "Update"
+    },
+    "options": {
+      "enableTimeTracking": "Enable time tracking"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -666,6 +666,9 @@
     "actions": {
       "downloadCsvTemplate": "Descargar plantilla CSV",
       "update": "Actualizar"
+    },
+    "options": {
+      "enableTimeTracking": "Habilitar seguimiento de tiempo"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -664,6 +664,9 @@
     "actions": {
       "downloadCsvTemplate": "Télécharger le modèle CSV",
       "update": "Mettre à jour"
+    },
+    "options": {
+      "enableTimeTracking": "Activer le suivi du temps"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -664,6 +664,9 @@
     "actions": {
       "downloadCsvTemplate": "CSV टेम्पलेट डाउनलोड करें",
       "update": "अपडेट करें"
+    },
+    "options": {
+      "enableTimeTracking": "समय ट्रैकिंग सक्षम करें"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -664,6 +664,9 @@
     "actions": {
       "downloadCsvTemplate": "CSVテンプレートをダウンロード",
       "update": "更新"
+    },
+    "options": {
+      "enableTimeTracking": "時間追跡を有効にする"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -664,6 +664,9 @@
     "actions": {
       "downloadCsvTemplate": "Baixar modelo CSV",
       "update": "Atualizar"
+    },
+    "options": {
+      "enableTimeTracking": "Ativar rastreamento de tempo"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -664,6 +664,9 @@
     "actions": {
       "downloadCsvTemplate": "Скачать шаблон CSV",
       "update": "Обновить"
+    },
+    "options": {
+      "enableTimeTracking": "Включить отслеживание времени"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -664,6 +664,9 @@
     "actions": {
       "downloadCsvTemplate": "下载CSV模板",
       "update": "更新"
+    },
+    "options": {
+      "enableTimeTracking": "启用时间跟踪"
     }
   },
   "HeuristicsTestView": {

--- a/src/shared/models/Study.js
+++ b/src/shared/models/Study.js
@@ -22,6 +22,7 @@ export default class Study {
     status, // transformar em um ENUM
     endDate,
     creationDate,
+    enableTimeTracking,
   } = {}) {
     /**
      * Defines the test id.
@@ -127,6 +128,12 @@ export default class Study {
      * @type {string}
      */
     this.studyConclusion = studyConclusion ?? null
+    /**
+     * Defines whether time tracking is enabled.
+     *
+     * @type {boolean}
+     */
+    this.enableTimeTracking = enableTimeTracking ?? false
 
     /**
      * Defines the test status.
@@ -163,6 +170,7 @@ export default class Study {
       templateDoc: this.templateDoc,
       isPublic: this.isPublic,
       studyConclusion: this.studyConclusion,
+      enableTimeTracking: this.enableTimeTracking,
       status: this.status,
       endDate: this.endDate,
       subType: this.subType,

--- a/src/store/modules/Study.js
+++ b/src/store/modules/Study.js
@@ -42,6 +42,9 @@ export default {
   mutations: {
     SET_TEST(state, payload) {
       state.Test = payload
+      if (state.Test) {
+        state.Test.enableTimeTracking = payload.enableTimeTracking ?? false
+      }
       if (
         payload?.testStructure &&
         payload.testType === STUDY_TYPES.HEURISTIC
@@ -83,9 +86,9 @@ export default {
       state.studyType = payload
     },
     RESET_STUDY_DETAILS(state) {
-      ;(state.studyCategory = null),
+      ;((state.studyCategory = null),
         (state.studyMethod = null),
-        (state.studyType = null)
+        (state.studyType = null))
     },
     SET_CALIBRATION_CONFIG(state, payload) {
       if (state.Test) {
@@ -97,6 +100,11 @@ export default {
       state.testStructure = null
       state.answersId = null
       state.module = 'test'
+    },
+    SET_ENABLE_TIME_TRACKING(state, value) {
+      if (state.Test) {
+        state.Test.enableTimeTracking = value
+      }
     },
   },
   actions: {

--- a/src/ux/Heuristic/components/HeuristicsAnalytics.vue
+++ b/src/ux/Heuristic/components/HeuristicsAnalytics.vue
@@ -232,6 +232,101 @@
               </v-col>
             </v-row>
           </v-card>
+          <v-card
+            v-if="heuristicSelect !== null"
+            class="mt-6 pa-6"
+            rounded="xl"
+            elevation="0"
+            style="background: #ffffff"
+          >
+            <!-- Title -->
+            <div class="d-flex align-center justify-space-between mb-4">
+              <div>
+                <div class="text-caption text-grey-darken-1">
+                  Behavioral Analytics
+                </div>
+                <div class="text-h6 font-weight-bold">
+                  Evaluator Time Analysis
+                </div>
+              </div>
+            </div>
+
+            <!-- KPI SUMMARY -->
+            <v-row class="mb-6">
+              <v-col cols="12" md="4">
+                <v-card class="pa-4 rounded-xl" elevation="0" color="#f8f9fc">
+                  <div class="text-caption text-grey">Total Time</div>
+                  <div class="text-h6 font-weight-bold mt-1">
+                    {{ formatTime(aggregatedTime.overallTotalSec) }}
+                  </div>
+                </v-card>
+              </v-col>
+
+              <v-col cols="12" md="4">
+                <v-card class="pa-4 rounded-xl" elevation="0" color="#f8f9fc">
+                  <div class="text-caption text-grey">Avg / Evaluator</div>
+                  <div class="text-h6 font-weight-bold mt-1">
+                    {{ formatTime(aggregatedTime.meanPerEvaluatorSec) }}
+                  </div>
+                </v-card>
+              </v-col>
+
+              <v-col cols="12" md="4">
+                <v-card class="pa-4 rounded-xl" elevation="0" color="#f8f9fc">
+                  <div class="text-caption text-grey">Evaluators</div>
+                  <div class="text-h6 font-weight-bold mt-1">
+                    {{ Object.keys(answers).length }}
+                  </div>
+                </v-card>
+              </v-col>
+            </v-row>
+
+            <!-- TABLE 1: PER EVALUATOR -->
+            <div class="text-subtitle-2 font-weight-medium mb-2">
+              Time Spent Per Evaluator
+            </div>
+
+            <v-data-table
+              :headers="headersTime"
+              :items="itemsTime"
+              density="comfortable"
+              fixed-header
+              height="300px"
+              class="mb-8"
+            >
+              <template #item.total="{ item }">
+                <span class="font-weight-bold">
+                  {{ item.total }}
+                </span>
+              </template>
+            </v-data-table>
+
+            <!-- TABLE 2: PER HEURISTIC -->
+            <div class="text-subtitle-2 font-weight-medium mb-2">
+              Time Spent Per Heuristic
+            </div>
+
+            <v-data-table
+              :headers="headersHeuristicTime"
+              :items="itemsHeuristicTime"
+              density="comfortable"
+              fixed-header
+              height="260px"
+            >
+              <!-- Overall row -->
+              <template #body.append>
+                <tr>
+                  <td>Overall</td>
+                  <td class="text-center font-weight-bold">
+                    {{ formatTime(aggregatedTime.overallTotalSec) }}
+                  </td>
+                  <td class="text-center font-weight-bold">
+                    {{ formatTime(aggregatedTime.meanPerEvaluatorSec) }}
+                  </td>
+                </tr>
+              </template>
+            </v-data-table>
+          </v-card>
         </div>
       </template>
     </ShowInfo>
@@ -245,9 +340,11 @@ import { useRoute } from 'vue-router'
 import ShowInfo from '@/shared/components/ShowInfo.vue'
 import BarChart from '@/ux/Heuristic/components/charts/BarChart.vue'
 import IntroAnalytics from '@/shared/components/introduction_cards/IntroAnalytics.vue'
+import UserController from '@/features/auth/controllers/UserController'
 
 const store = useStore()
 const route = useRoute()
+const userController = new UserController()
 
 const emit = defineEmits(['goToCoops'])
 
@@ -257,6 +354,7 @@ const resultHeuristics = ref([])
 const heuristicSelect = ref(null)
 const questionSelect = ref(null)
 const intro = ref(null)
+const evaluatorNamesCache = ref({})
 
 const test = computed(() => store.getters.test)
 
@@ -306,6 +404,122 @@ const itemsHeuristic = computed(() => {
     })
   }
   return items
+})
+
+// Headers for time table: Evaluator + per-heuristic + totals/mean
+const headersTime = computed(() => {
+  const header = [
+    {
+      title: 'Evaluator',
+      align: 'start',
+      value: 'uid',
+    },
+  ]
+  if (test.value?.testStructure) {
+    test.value.testStructure.forEach((heu, idx) => {
+      header.push({
+        title: `H${idx + 1}`,
+        align: 'center',
+        value: `h${idx}`,
+      })
+    })
+  }
+  header.push({ title: 'Total', align: 'center', value: 'total' })
+  header.push({ title: 'Avg / Question', align: 'center', value: 'mean' })
+  return header
+})
+
+const itemsTime = computed(() => {
+  const items = []
+  if (!test.value?.testStructure) return items
+
+  // total questions in test (used for mean per evaluator)
+  const totalQuestions = test.value.testStructure.reduce(
+    (acc, h) => acc + (h.questions?.length || 0),
+    0,
+  )
+
+  Object.values(answers.value).forEach((answer) => {
+    const row = { uid: getEvaluatorName(answer.userDocId) }
+    let totalMs = 0
+    test.value.testStructure.forEach((heu, idx) => {
+      const heuAnswer = answer.heuristicQuestions?.[idx]
+      const sumMs = heuAnswer?.heuristicQuestions
+        ? heuAnswer.heuristicQuestions.reduce(
+            (s, q) => s + (q.timeSpent || 0),
+            0,
+          )
+        : 0
+      const seconds = sumMs / 1000
+      row[`h${idx}`] = formatTime(seconds)
+      totalMs += sumMs
+    })
+    const totalSeconds = Math.round(totalMs / 1000)
+    const meanSeconds = totalQuestions
+      ? Math.round(totalMs / 1000 / totalQuestions)
+      : 0
+    row.total = formatTime(totalSeconds)
+    row.mean = formatTime(meanSeconds)
+    items.push(row)
+  })
+
+  return items
+})
+
+const headersHeuristicTime = [
+  { title: 'Heuristic', align: 'start', value: 'heuristic' },
+  { title: 'Total Time', align: 'center', value: 'total' },
+  { title: 'Mean per Evaluator', align: 'center', value: 'mean' },
+]
+
+// Aggregated metrics across evaluators
+const aggregatedTime = computed(() => {
+  const result = {
+    perHeuristicTotalsSec: [],
+    perHeuristicMeanSec: [],
+    overallTotalSec: 0,
+    meanPerEvaluatorSec: 0,
+  }
+
+  if (!test.value?.testStructure) return result
+
+  const evaluators = Object.values(answers.value)
+  const evaluatorsCount = evaluators.length || 0
+  let overallTotalMs = 0
+
+  test.value.testStructure.forEach((heu, idx) => {
+    let sumMs = 0
+    evaluators.forEach((answer) => {
+      const heuAnswer = answer.heuristicQuestions?.[idx]
+      if (heuAnswer?.heuristicQuestions) {
+        sumMs += heuAnswer.heuristicQuestions.reduce(
+          (s, q) => s + (q.timeSpent || 0),
+          0,
+        )
+      }
+    })
+    result.perHeuristicTotalsSec.push(sumMs / 1000)
+    result.perHeuristicMeanSec.push(
+      evaluatorsCount ? sumMs / 1000 / evaluatorsCount : 0,
+    )
+    overallTotalMs += sumMs
+  })
+
+  result.overallTotalSec = Math.round(overallTotalMs / 1000)
+  result.meanPerEvaluatorSec = evaluatorsCount
+    ? Math.round(overallTotalMs / 1000 / evaluatorsCount)
+    : 0
+  return result
+})
+
+const itemsHeuristicTime = computed(() => {
+  if (!aggregatedTime.value.perHeuristicTotalsSec.length) return []
+
+  return aggregatedTime.value.perHeuristicTotalsSec.map((total, idx) => ({
+    heuristic: `H${idx + 1}`,
+    total: formatTime(total),
+    mean: formatTime(aggregatedTime.value.perHeuristicMeanSec[idx]),
+  }))
 })
 
 const questionGraph = computed(() => {
@@ -359,10 +573,53 @@ onMounted(async () => {
   if (route.query.heuristic) {
     heuristicSelect.value = Number(route.query.heuristic)
   }
+  await fetchEvaluatorNames()
 })
+
+// Fetch user names for all evaluators and cache them
+const fetchEvaluatorNames = async () => {
+  try {
+    const userIds = Object.keys(answers.value)
+    for (const userId of userIds) {
+      if (!evaluatorNamesCache.value[userId]) {
+        const user = await userController.getById(userId)
+        // Display username or email, with email as fallback
+        evaluatorNamesCache.value[userId] =
+          user.username || user.email || userId
+      }
+    }
+  } catch (error) {
+    console.warn('Error fetching evaluator names:', error)
+  }
+}
+
+// Helper to get evaluator name from cache
+const getEvaluatorName = (userDocId) => {
+  return evaluatorNamesCache.value[userDocId] || userDocId
+}
 
 const goToCoops = () => {
   emit('goToCoops')
+}
+
+const formatTime = (seconds) => {
+  if (!seconds || seconds <= 0) return '0s'
+
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)}s`
+  }
+
+  const total = Math.floor(seconds)
+  const hours = Math.floor(total / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  const secs = total % 60
+
+  const parts = []
+  if (hours > 0) parts.push(`${hours}h`)
+  if (minutes > 0) parts.push(`${minutes}m`)
+  if (secs > 0) parts.push(`${secs}s`)
+
+  return parts.join(' ')
 }
 </script>
 

--- a/src/ux/Heuristic/components/HeuristicsSettings.vue
+++ b/src/ux/Heuristic/components/HeuristicsSettings.vue
@@ -72,6 +72,16 @@
           {{ errorMessage }}
         </v-alert>
       </div>
+
+      <!-- Time Tracking Toggle -->
+      <div class="mt-8">
+        <v-switch
+          v-model="enableTimeTracking"
+          :label="t('HeuristicsSettings.options.enableTimeTracking')"
+          color="primary"
+          hide-details
+        />
+      </div>
     </div>
 
     <!-- Confirmation Dialog -->
@@ -106,6 +116,7 @@ import { showWarning, showSuccess, showError } from '@/shared/utils/toast'
 
 const store = useStore()
 const { t } = useI18n()
+const emit = defineEmits(['change'])
 
 const loading = ref(false)
 const loader = ref(null)
@@ -117,6 +128,19 @@ const errorVisible = ref(false)
 const confirmDialog = ref(false)
 
 const test = computed(() => store.getters.test)
+
+// track whether evaluators should record time spent on each heuristic
+const enableTimeTracking = computed({
+  get: () => {
+    return store.state.Tests.Test?.enableTimeTracking || false
+  },
+  set: (val) => {
+    console.log('Time tracking changed:', val)
+    if (!store.state.Tests.Test) return
+    store.commit('SET_ENABLE_TIME_TRACKING', val)
+    emit('change')
+  },
+})
 
 const testAnswerDocLength = computed(() => {
   const doc = store.getters.testAnswerDocument

--- a/src/ux/Heuristic/models/HeuristicQuestionAnswer.js
+++ b/src/ux/Heuristic/models/HeuristicQuestionAnswer.js
@@ -12,16 +12,21 @@ export default class HeuristicQuestionAnswer {
     heuristicAnswer,
     heuristicComment,
     answerImageUrl,
+    timeSpent,
   } = {}) {
     this.heuristicId = heuristicId
     this.heuristicAnswer = heuristicAnswer ?? {}
     this.heuristicComment = heuristicComment
     this.answerImageUrl = answerImageUrl
+    // initialize time spent, default to 0 so it can be incremented later
+    this.timeSpent = timeSpent ?? 0
   }
   static toHeuristicQuestionAnswer(data, testOptions) {
     return new HeuristicQuestionAnswer({
       // TODO: This needs to be changed urgently, just a hotfix for now
       ...data,
+      // preserve timeSpent if it exists in firestore document
+      timeSpent: data.timeSpent || 0,
       heuristicAnswer: data.heuristicAnswer?.text
         ? data.heuristicAnswer
         : {
@@ -39,6 +44,7 @@ export default class HeuristicQuestionAnswer {
       heuristicAnswer: this.heuristicAnswer,
       heuristicComment: this.heuristicComment,
       answerImageUrl: this.answerImageUrl || '',
+      timeSpent: this.timeSpent || 0,
     }
   }
 }

--- a/src/ux/Heuristic/views/EditTest.vue
+++ b/src/ux/Heuristic/views/EditTest.vue
@@ -47,7 +47,7 @@
           <HeuristicsTable v-if="index == 0" @change="change = true" />
           <OptionsTable v-if="index == 1" @change="change = true" />
           <WeightTable v-if="index == 2" />
-          <HeuristicsSettings v-if="index == 3" />
+          <HeuristicsSettings v-if="index == 3" @change="change = true" />
         </div>
       </div>
     </v-container>
@@ -102,6 +102,7 @@ const save = async () => {
 
   const rawData = {
     ...store.getters.test,
+    enableTimeTracking: store.state.Tests.Test.enableTimeTracking ?? false,
     testStructure: store.getters.heuristics,
     testOptions: store.state.Tests.Test.testOptions,
     testWeights: store.getters.testWeights,

--- a/src/ux/Heuristic/views/HeuristicTestView.vue
+++ b/src/ux/Heuristic/views/HeuristicTestView.vue
@@ -427,6 +427,7 @@
                           :disabled="currentUserTestAnswer?.submitted"
                           placeholder="Select an answer..."
                           clearable
+                          @focus="startQuestionTimer(heurisIndex, i)"
                           @update:model-value="
                             handleAnswerChange(heurisIndex, i)
                           "
@@ -596,6 +597,9 @@ const dialog = ref(false)
 const calculatedProgress = ref(0)
 const review = ref(true)
 const rightView = ref(null)
+
+// Timer state: record when evaluator opened/focused on a particular question
+const questionStartTimes = ref({})
 
 // Auto-save status variables
 const autoSaveInProgress = ref(false)
@@ -767,6 +771,18 @@ const handleAnswerChange = (_heurisIndex, _answerIndex) => {
   const question =
     currentUserTestAnswer.value.heuristicQuestions[_heurisIndex]
       .heuristicQuestions[_answerIndex]
+
+  // if time tracking enabled, record elapsed time
+  if (test.value?.enableTimeTracking) {
+    const key = `${_heurisIndex}-${_answerIndex}`
+    const start = questionStartTimes.value[key]
+    if (start) {
+      const elapsed = Date.now() - start
+      question.timeSpent = (question.timeSpent || 0) + elapsed
+      // remove start entry so re-focus will restart timer
+      delete questionStartTimes.value[key]
+    }
+  }
 
   // Check if the answer is actually empty/not selected
   if (
@@ -1061,6 +1077,7 @@ const populateWithHeuristicQuestions = () => {
               heuristicAnswer: null,
               heuristicComment: '',
               answerImageUrl: '',
+              timeSpent: 0,
             }),
         ) || []
       totalQuestions += questions.length
@@ -1117,6 +1134,7 @@ const populateWithHeuristicQuestions = () => {
                 heuristicAnswer: restoredAnswer,
                 heuristicComment: existingQuestion.heuristicComment || '',
                 answerImageUrl: existingQuestion.answerImageUrl || '',
+                timeSpent: existingQuestion.timeSpent || 0,
               })
             } else {
               // Create new question
@@ -1125,6 +1143,7 @@ const populateWithHeuristicQuestions = () => {
                 heuristicAnswer: null,
                 heuristicComment: '',
                 answerImageUrl: '',
+                timeSpent: 0,
               })
             }
           }) || []
@@ -1198,6 +1217,15 @@ const restoreProgress = () => {
   }
 }
 
+const startQuestionTimer = (_heurisIndex, _answerIndex) => {
+  if (!test.value?.enableTimeTracking) return
+  const key = `${_heurisIndex}-${_answerIndex}`
+  // only set if not already started (avoid overwriting on extra focus events)
+  if (!questionStartTimes.value[key]) {
+    questionStartTimes.value[key] = Date.now()
+  }
+}
+
 const setTest = async () => {
   logined.value = true
   await store.dispatch('getCurrentTestAnswerDoc')
@@ -1216,6 +1244,14 @@ const setReviewTrue = () => {
 const handleHeurisClick = (i) => {
   heurisIndex.value = i
   setReviewTrue()
+  // when navigating to a new heuristic, start timer for each question if tracking is on
+  if (test.value?.enableTimeTracking) {
+    const questions =
+      heuristics.value[i]?.questions?.map((q, idx) => `${i}-${idx}`) || []
+    questions.forEach((key) => {
+      questionStartTimes.value[key] = Date.now()
+    })
+  }
 }
 
 // Setup auto-save on page unload
@@ -1263,6 +1299,13 @@ watch(heurisIndex, () => {
     currentUserTestAnswer.value.lastViewedHeuristicIndex = heurisIndex.value
     updateSaveStatus('Saving changes...', 'saving')
     debouncedAutoSave()
+  }
+  // start timer entries for all questions of this heuristic when active
+  if (test.value?.enableTimeTracking) {
+    const count = heuristics.value[heurisIndex.value]?.questions?.length || 0
+    for (let q = 0; q < count; q++) {
+      questionStartTimes.value[`${heurisIndex.value}-${q}`] = Date.now()
+    }
   }
 })
 

--- a/tests/unit/HeuristicQuestionAnswer.spec.js
+++ b/tests/unit/HeuristicQuestionAnswer.spec.js
@@ -1,0 +1,31 @@
+import HeuristicQuestionAnswer from '@/ux/Heuristic/models/HeuristicQuestionAnswer'
+
+describe('HeuristicQuestionAnswer model', () => {
+  it('initializes timeSpent to 0 when not provided', () => {
+    const answer = new HeuristicQuestionAnswer({ heuristicId: 1 })
+    expect(answer.timeSpent).toBe(0)
+  })
+
+  it('allows preset timeSpent value', () => {
+    const answer = new HeuristicQuestionAnswer({ heuristicId: 2, timeSpent: 1234 })
+    expect(answer.timeSpent).toBe(1234)
+  })
+
+  it('includes timeSpent in toFirestore output', () => {
+    const answer = new HeuristicQuestionAnswer({ heuristicId: 3, timeSpent: 5000 })
+    const firestore = answer.toFirestore()
+    expect(firestore.timeSpent).toBe(5000)
+  })
+
+  it('toHeuristicQuestionAnswer copies timeSpent from raw data', () => {
+    const raw = {
+      heuristicId: 4,
+      heuristicAnswer: null,
+      heuristicComment: '',
+      answerImageUrl: '',
+      timeSpent: 777,
+    }
+    const converted = HeuristicQuestionAnswer.toHeuristicQuestionAnswer(raw, [])
+    expect(converted.timeSpent).toBe(777)
+  })
+})


### PR DESCRIPTION
### 📌 Overview
This PR introduces **Time Tracking functionality** for Heuristic Tests.

It allows tracking the time spent per question during a test session and persists this information in Firestore.  
The feature is configurable at the study level and can be enabled or disabled.

---

### Fixes: #1734

---

## 🔄 Time Tracking Implementation

Implemented per-question time tracking with full persistence and backward compatibility.

### Changes

- Added `enableTimeTracking` (default: `false`) to the `Study` model and Vuex store.
- Extended `HeuristicQuestionAnswer` with `timeSpent` (default: `0`) and included it in Firestore serialization/restoration.
- Integrated timer logic in `HeuristicTestView`:
  - Starts on question focus
  - Stops on answer change
  - Accumulates elapsed time safely
- Ensured existing answers restore `timeSpent` correctly.

### Tests

- Added unit tests covering initialization, serialization, and restoration of `timeSpent`.

## ✅ Result

- ⏱ Per-question time tracking  
- 💾 Persisted in Firestore  
- 🔄 Fully backward compatible  
- ⚙ Configurable per study  
- 🛡 No breaking changes 
- 
## Screenshots / Recording

<img width="1914" height="950" alt="Screenshot 2026-02-26 194147" src="https://github.com/user-attachments/assets/2d35d008-f23c-4290-ab6e-485838a06c9d" />
<img width="1901" height="945" alt="Screenshot 2026-02-26 194201" src="https://github.com/user-attachments/assets/8ccae04c-d07b-4d2d-b4f3-0a2a46a6233a" />

https://github.com/user-attachments/assets/a1c29d70-7340-4c22-9fe5-0d45d20d50da




---

Please review and let me know if any refinements are required.