### PR TITLE
feat(user-test)#1765: track tipPressCount per task in UserTestView and ModeratedTestView

### DIFF
--- a/src/ux/UserTest/components/TipButton.vue
+++ b/src/ux/UserTest/components/TipButton.vue
@@ -12,6 +12,7 @@
         block
         prepend-icon="mdi-lightbulb-outline"
         v-bind="props"
+        @click="onTipPress"
       >
         Tip
       </v-btn>
@@ -75,6 +76,7 @@
 <script setup>
 import { ref } from 'vue'
 
+const emit = defineEmits(['tip-pressed'])
 defineProps({
   task: {
     type: Object,
@@ -86,6 +88,8 @@ defineProps({
 })
 
 const dialog = ref(false)
+const onTipPress = () => emit('tip-pressed')
+
 </script>
 
 <style scoped>

--- a/src/ux/UserTest/components/steps/TaskStep.vue
+++ b/src/ux/UserTest/components/steps/TaskStep.vue
@@ -214,7 +214,7 @@
                           Having trouble? Get helpful guidance to complete this
                           task.
                         </p>
-                        <TipButton :task="task" />
+                        <TipButton :task="task" @tip-pressed="onTipPressed" />
                       </div>
                     </v-col>
 
@@ -521,6 +521,7 @@ const emit = defineEmits([
   'update:tamAnswers',
   'update:sartAnswers',
   'startTask',
+  'tip-pressed',
 ])
 
 onBeforeUnmount(() => {
@@ -859,6 +860,9 @@ function onUpdateTaskObservations(val) {
 }
 function onUpdateNasaTlx(val) {
   emit('update:nasaTlxAnswers', val)
+}
+function onTipPressed() {
+  emit('tip-pressed', props.taskIndex)
 }
 function onTimerStopped(elapsedTime) {
   emit('timer-stopped', elapsedTime, props.taskIndex)

--- a/src/ux/UserTest/models/TaskAnswer.js
+++ b/src/ux/UserTest/models/TaskAnswer.js
@@ -10,6 +10,7 @@ export default class TaskAnswer {
     taskTime,
     completed,
     attempted,
+    tipPressCount,
     audioRecordURL,
     moderatorAudioURL,
     screenRecordURL,
@@ -31,6 +32,7 @@ export default class TaskAnswer {
     this.taskTime = taskTime ?? null
     this.completed = completed ?? null
     this.attempted = attempted ?? false
+    this.tipPressCount = Number.isFinite(tipPressCount) ? tipPressCount : 0
     this.audioRecordURL = audioRecordURL ?? null
     this.moderatorAudioURL = moderatorAudioURL ?? null
     this.screenRecordURL = screenRecordURL ?? null
@@ -83,6 +85,7 @@ export default class TaskAnswer {
       taskTime: this.taskTime,
       completed: this.completed,
       attempted: this.attempted,
+      tipPressCount: this.tipPressCount,
       audioRecordURL: this.audioRecordURL,
       moderatorAudioURL: this.moderatorAudioURL,
       screenRecordURL: this.screenRecordURL,

--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -513,6 +513,7 @@
               @show-loading="isLoading = true"
               @stop-show-loading="isLoading = false"
               @recording-started="isVisualizerVisible = $event"
+              @tip-pressed="handleTipPressed"
               @timer-stopped="handleTimerStopped"
             />
 
@@ -1076,6 +1077,19 @@ const handleTimerStopped = (elapsedTime, idx) => {
   }
 }
 
+const handleTipPressed = (idx) => {
+  if (idx === undefined || idx === null) {
+    return
+  }
+
+  if (!localTestAnswer.tasks?.[idx]) {
+    return
+  }
+
+  const current = Number(localTestAnswer.tasks[idx].tipPressCount || 0)
+  localTestAnswer.tasks[idx].tipPressCount = current + 1
+}
+
 const completeStep = async (id, type, userCompleted = true) => {
   displayVideoCallComponent.value = true
   try {
@@ -1238,6 +1252,7 @@ const mappingSteps = async () => {
               postAnswer: '',
               taskTime: 0,
               completed: false,
+              tipPressCount: 0,
               susAnswers: [],
               nasaTlxAnswers: null,
             })

--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -416,6 +416,7 @@
             @show-loading="isLoading = true"
             @stop-show-loading="isLoading = false"
             @recording-started="isVisualizerVisible = $event"
+            @tip-pressed="handleTipPressed"
             @timer-stopped="handleTimerStopped"
             @start-task="
               () => {
@@ -915,6 +916,14 @@ const handleTimerStopped = (elapsedTime, idx) => {
   }
 }
 
+const handleTipPressed = (idx) => {
+  if (idx === undefined || idx === null) return
+  if (!localTestAnswer.tasks?.[idx]) return
+
+  const current = Number(localTestAnswer.tasks[idx].tipPressCount || 0)
+  localTestAnswer.tasks[idx].tipPressCount = current + 1
+}
+
 const completeStep = (id, type, userCompleted = true) => {
   try {
     if (type === 'consent') {
@@ -1161,6 +1170,7 @@ const mappingSteps = async () => {
               taskTime: 0,
               completed: false,
               attempted: false, // Track whether task has been attempted
+              tipPressCount: 0,
               susAnswers: [],
               nasaTlxAnswers: {},
               tamAnswers: {},


### PR DESCRIPTION
## Fixes #1765

### Description
This PR implements tip-press tracking for User Test tasks by reusing the existing answer flow and task model persistence.  
When a participant clicks the task **Tip** button, the event is captured, mapped to the correct `taskIndex`, and stored as `tipPressCount` inside that task’s answer data.

## Key File Changes

### 1. `src/ux/UserTest/components/TipButton.vue`
Tip click now emits a dedicated event (`tip-pressed`) instead of using unrelated task answer events.  
This keeps TipButton as UI trigger only and avoids mixing answer text updates with telemetry.

```diff
<template #activator="{ props }">
  <v-btn
    color="success"
    variant="outlined"
    size="small"
    block
    prepend-icon="mdi-lightbulb-outline"
    v-bind="props"
+   @click="onTipPress"
  >
    Tip
  </v-btn>
</template>

<script setup>
import { ref } from 'vue'
+const emit = defineEmits(['tip-pressed'])
...
const dialog = ref(false)
+const onTipPress = () => emit('tip-pressed')
</script>
```

---

### 2. `src/ux/UserTest/components/steps/TaskStep.vue`
`TaskStep` now bridges the event and adds `taskIndex` so parent views can update the correct task entry.

```diff
-<TipButton :task="task" />
+<TipButton :task="task" @tip-pressed="onTipPressed" />

const emit = defineEmits([
  'done',
  'couldNotFinish',
  ...
  'startTask',
+ 'tip-pressed',
])

+function onTipPressed() {
+  emit('tip-pressed', props.taskIndex)
+}
```

---

### 3. `src/ux/UserTest/views/UserTestView.vue` (Unmoderated flow)
Unmoderated flow now listens to `tip-pressed` and increments `tipPressCount` for that specific `taskIndex`.

```diff
<TaskStep
  ...
+ @tip-pressed="handleTipPressed"
  @timer-stopped="handleTimerStopped"
  ...
/>

+const handleTipPressed = (idx) => {
+  if (idx === undefined || idx === null) return
+  if (!localTestAnswer.tasks?.[idx]) return
+
+  const current = Number(localTestAnswer.tasks[idx].tipPressCount || 0)
+  localTestAnswer.tasks[idx].tipPressCount = current + 1
+}

const newTask = new TaskAnswer({
  taskId: task.id || i,
  taskAnswer: '',
  taskObservations: '',
  postAnswer: '',
  taskTime: 0,
  completed: false,
  attempted: false,
+ tipPressCount: 0,
  susAnswers: [],
  nasaTlxAnswers: {},
  tamAnswers: {},
  sartAnswers: {},
})
```

---

### 4. `src/ux/UserTest/views/ModeratedTestView.vue` (Moderated flow)
Moderated flow now has the same behavior, ensuring parity across both user-test types.

```diff
<TaskStep
  ...
+ @tip-pressed="handleTipPressed"
  @timer-stopped="handleTimerStopped"
/>

+const handleTipPressed = (idx) => {
+  if (idx === undefined || idx === null) return
+  if (!localTestAnswer.tasks?.[idx]) return
+
+  const current = Number(localTestAnswer.tasks[idx].tipPressCount || 0)
+  localTestAnswer.tasks[idx].tipPressCount = current + 1
+}

const newTask = new TaskAnswer({
  taskId: task.id || i,
  taskAnswer: '',
  taskObservations: '',
  postAnswer: '',
  taskTime: 0,
  completed: false,
+ tipPressCount: 0,
  susAnswers: [],
  nasaTlxAnswers: null,
})
```

---

### 5. `src/ux/UserTest/models/TaskAnswer.js`
Added persistent task-level field `tipPressCount` to keep storage in the existing expected path (`taskAnswers -> tasks -> taskIndex`).

```diff
constructor({
  taskId,
  taskAnswer,
  taskObservations,
  taskTime,
  completed,
  attempted,
+ tipPressCount,
  ...
} = {}) {
  this.taskTime = taskTime ?? null
  this.completed = completed ?? null
  this.attempted = attempted ?? false
+ this.tipPressCount = Number.isFinite(tipPressCount) ? tipPressCount : 0
  ...
}

toFirestore() {
  return {
    taskId: this.taskId,
    taskAnswer: this.taskAnswer,
    taskObservations: this.taskObservations,
    taskTime: this.taskTime,
    completed: this.completed,
    attempted: this.attempted,
+   tipPressCount: this.tipPressCount,
    ...
  }
}
```

---

## Before and After Flow

### Before
1. User clicks **Tip**.
2. Tip modal opens.
3. No tip interaction data is persisted.

### After
1. User clicks **Tip** in a task.
2. `TipButton` emits `tip-pressed`.
3. `TaskStep` re-emits with `props.taskIndex`.
4. Parent view increments `localTestAnswer.tasks[idx].tipPressCount`.
5. Existing save flow persists into `taskAnswers.{userDocId}.tasks.{idx}.tipPressCount`.

---

## Proof of Work 

https://github.com/user-attachments/assets/d0eed6ce-ff13-46a6-868f-b4e78b338047


