### PR TITLE
fix - ui : add responsive logo to login page for mobile #1771

### DIFF
--- a/src/features/auth/views/SignInView.vue
+++ b/src/features/auth/views/SignInView.vue
@@ -1,13 +1,19 @@
 <template>
   <div class="signin-wrapper">
-    <!-- LEFT: LOGO -->
     <div class="logo-side d-none d-md-flex align-center justify-center">
       <img src="@/assets/logo_full.png" alt="RUXAILAB" class="logo-img" />
     </div>
 
-    <!-- RIGHT: FORM -->
     <div class="form-side d-flex align-center justify-center">
       <div class="signin-box">
+        <div class="d-md-none text-center mb-6">
+          <img
+            src="@/assets/logo_full.png"
+            alt="RUXAILAB"
+            class="mobile-logo-img"
+          />
+        </div>
+
         <h1 class="text-h6">
           {{ $t('auth.SIGNIN.sign-in-title') }}
         </h1>
@@ -208,6 +214,11 @@ const onGoogleSignInError = (error) => {
   width: 100%;
 }
 
+.mobile-logo-img {
+  max-width: 220px;
+  width: 100%;
+}
+
 /* RIGHT SIDE FORM */
 .form-side {
   width: 50%;
@@ -237,16 +248,18 @@ const onGoogleSignInError = (error) => {
 /* RESPONSIVE ADJUSTMENTS */
 @media (max-width: 960px) {
   .logo-side {
-    display: none; /* hide logo on smaller screens */
+    display: none;
   }
 
   .form-side {
     width: 100%;
     padding: 24px;
+    align-items: center;
   }
 
   .signin-box {
     padding: 24px;
+    box-shadow: none; /* Clean for mobile view */
   }
 }
 


### PR DESCRIPTION
Closes #1771 

This PR addresses the missing branding on mobile by introducing a responsive logo that appears above the sign-in form on screens smaller than 960px.

<img width="665" height="850" alt="image" src="https://github.com/user-attachments/assets/9cedcfe6-0425-4d07-aff7-60236095e7e2" />
