### PR TITLE
chore: remove debug console logs from attachMediaToTasks

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -797,18 +797,15 @@ const attachMediaToTasks = (answer, mediaUrls) => {
     for (const type in medias) {
       if (type === 'sizes') {
         const sizes = medias[type]
-        console.log(`Found sizes for Task ${taskIndex}:`, sizes)
+
         if (sizes.screenRecordURL) {
           task.screenSize = sizes.screenRecordURL
-          console.log('Set screenSize:', task.screenSize)
         }
         if (sizes.audioRecordURL) {
           task.audioSize = sizes.audioRecordURL
-          console.log('Set audioSize:', task.audioSize)
         }
         if (sizes.webcamRecordURL) {
           task.webcamSize = sizes.webcamRecordURL
-          console.log('Set webcamSize:', task.webcamSize)
         }
         continue
       }


### PR DESCRIPTION
This PR removes leftover debug console.log statements from the attachMediaToTasks function in UserTestView.vue.

No functional changes were made and all tests pass.