### PR TITLE
chore: remove debug console logs from attachMediaToTasks

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -797,18 +797,15 @@ const attachMediaToTasks = (answer, mediaUrls) => {
     for (const type in medias) {
       if (type === 'sizes') {
         const sizes = medias[type]
-        console.log(`Found sizes for Task ${taskIndex}:`, sizes)
+
         if (sizes.screenRecordURL) {
           task.screenSize = sizes.screenRecordURL
-          console.log('Set screenSize:', task.screenSize)
         }
         if (sizes.audioRecordURL) {
           task.audioSize = sizes.audioRecordURL
-          console.log('Set audioSize:', task.audioSize)
         }
         if (sizes.webcamRecordURL) {
           task.webcamSize = sizes.webcamRecordURL
-          console.log('Set webcamSize:', task.webcamSize)
         }
         continue
       }


### PR DESCRIPTION
Closes #1782

## Description

This PR removes leftover debug `console.log` statements from the 
`attachMediaToTasks` function in:

src/ux/UserTest/views/UserTestView.vue

These logs were used during development and are no longer necessary.

## Why this change

- Reduces unnecessary console output
- Prevents exposure of internal state in production
- Improves overall code cleanliness and maintainability
- Aligns with project logging standards

## Scope of Change

- Removed debug `console.log` statements
- No logic or functional behavior was modified

## Testing

- All existing unit tests pass
- No functional regressions observed

<img width="1089" height="690" alt="Screenshot 2026-03-03 033854" src="https://github.com/user-attachments/assets/a31b12c6-6a8c-467e-9bfb-38cf0fd5fc72" />


