### PR TITLE
fix(store): add error handling to Answer.js actions that silently swallowed failures

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -393,7 +393,10 @@
     "globalError": "An error has occurred, sorry for the inconvenience.",
     "cameraPermissionDenied": "Camera permission denied. Please allow camera access in your browser settings.",
     "sendError": "Failed to send invitation. Please try again",
-    "missingVariableTitles": "Cannot save: Some variables are missing titles"
+    "missingVariableTitles": "Cannot save: Some variables are missing titles",
+    "failedToLoadAnswers": "Failed to load answers. Please try again.",
+    "failedToUpdateAnswer": "Failed to update answer. Please try again.",
+    "failedToRemoveCooperator": "Failed to remove cooperator. Please try again."
   },
   "Introduction": {
     "title": "UX Remote LAB",


### PR DESCRIPTION
Replace 5 empty/commented catch blocks in `src/shared/store/Answer.js` with proper error notifications.

## Problem

Five Vuex actions in the Answer store silently swallow errors — catch blocks are either completely empty or have commented-out error handling (`// commit("setError", true);`). When Firestore operations fail, the user receives zero feedback and data loss goes unnoticed.

## Changes

- Imported `showError` from `@/shared/utils/toast` (same pattern used in `Auth.js`)
- Replaced all 5 silent catch blocks with:
  - `console.error()` with `[Answer Store]` prefix for debugging
  - `showError()` with i18n-compatible error keys for user feedback
- Added 3 new i18n error keys to `en.json`:
  - `errors.failedToLoadAnswers`
  - `errors.failedToUpdateAnswer`
  - `errors.failedToRemoveCooperator`

## Files Modified

- `src/shared/store/Answer.js` — 5 catch blocks replaced
- `src/app/plugins/locales/en.json` — 3 new error message keys

## Verification

- Prettier: Passes
- ESLint: Only expected `no-console` warnings for intentional `console.error` (consistent with rest of codebase)
- No behavior change for success paths — only adds error feedback where none existed

Closes #1788
