### PR TITLE
fix(store): add error handling to Answer.js actions that silently swa…

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -393,7 +393,10 @@
     "globalError": "An error has occurred, sorry for the inconvenience.",
     "cameraPermissionDenied": "Camera permission denied. Please allow camera access in your browser settings.",
     "sendError": "Failed to send invitation. Please try again",
-    "missingVariableTitles": "Cannot save: Some variables are missing titles"
+    "missingVariableTitles": "Cannot save: Some variables are missing titles",
+    "failedToLoadAnswers": "Failed to load answers. Please try again.",
+    "failedToUpdateAnswer": "Failed to update answer. Please try again.",
+    "failedToRemoveCooperator": "Failed to remove cooperator. Please try again."
   },
   "Introduction": {
     "title": "UX Remote LAB",

--- a/src/shared/store/Answer.js
+++ b/src/shared/store/Answer.js
@@ -5,6 +5,7 @@ import { formatTimeSpentFromMs } from '@/ux/Heuristic/utils/statistics'
 import { STUDY_TYPES } from '@/shared/constants/methodDefinitions'
 import UserStudyEvaluatorAnswer from '@/ux/UserTest/models/UserStudyEvaluatorAnswer'
 import TaskAnswer from '@/ux/UserTest/models/TaskAnswer'
+import { showError } from '@/shared/utils/toast'
 
 const answerController = new AnswerController()
 
@@ -241,8 +242,9 @@ export default {
         const answerDoc =
           await answerController.getAnswerById(currentAnswersDocId)
         commit('SET_ANSWER_DOCUMENT', answerDoc)
-      } catch {
-        // commit("setError", true);
+      } catch (error) {
+        console.error('[Answer Store] Failed to fetch answer document:', error)
+        showError('errors.failedToLoadAnswers')
       } finally {
         commit('setLoading', false)
       }
@@ -251,8 +253,9 @@ export default {
       commit('setLoading', true)
       try {
         await answerController.updateUserAnswer(payload)
-      } catch {
-        // commit("setError", true);
+      } catch (error) {
+        console.error('[Answer Store] Failed to update user answer:', error)
+        showError('errors.failedToUpdateAnswer')
       } finally {
         commit('setLoading', false)
       }
@@ -265,7 +268,8 @@ export default {
           testDocId: payload.test.id,
         })
       } catch (e) {
-        // commit("setError", true);
+        console.error('[Answer Store] Failed to remove cooperator:', e)
+        showError('errors.failedToRemoveCooperator')
       } finally {
         commit('setLoading', false)
       }
@@ -304,8 +308,7 @@ export default {
           })
         }
       } catch (e) {
-        console.error('Error in save test answer', e)
-        // commit("setError", true);
+        console.error('[Answer Store] Failed to save test answer:', e)
         if (payload.errorMessage) {
           commit('SET_TOAST', {
             type: 'error',
@@ -321,7 +324,9 @@ export default {
       commit('setLoading', true)
       try {
         await answerController.updateTaskAnswer(payload, answersDocId)
-      } catch {
+      } catch (error) {
+        console.error('[Answer Store] Failed to update task answer:', error)
+        showError('errors.failedToUpdateAnswer')
       } finally {
         commit('setLoading', false)
       }


### PR DESCRIPTION
Replace 5 empty/commented catch blocks in `src/shared/store/Answer.js` with proper error notifications.

## Problem

Five Vuex actions in the Answer store silently swallow errors — catch blocks are either completely empty or have commented-out error handling. When Firestore operations fail, the user receives zero feedback and data loss goes unnoticed.

## Changes

- Imported `showError` from `@/shared/utils/toast` (same pattern used in `Auth.js`)
- Replaced all 5 silent catch blocks with:
  - `console.error()` with `[Answer Store]` prefix for debugging
  - `showError()` with i18n-compatible error keys for user feedback
- Added 3 new i18n error keys to `en.json`:
  - `errors.failedToLoadAnswers`
  - `errors.failedToUpdateAnswer`
  - `errors.failedToRemoveCooperator`

## Files Modified

- `src/shared/store/Answer.js` — 5 catch blocks replaced
- `src/app/plugins/locales/en.json` — 3 new error message keys

## Code Changes

[
<img width="1910" height="3591" alt="answer_js_diff_final_1772574713377" src="https://github.com/user-attachments/assets/8113a10f-c7bd-47b9-b8f4-4e64e165026a" />
](url)
**Full commit diff:** https://github.com/Harshit2405-2004/RUXAILAB/commit/4a12abcf5709c515ab462d33a66e7cea3901699c

## Verification

- Prettier: Passes
- ESLint: Only expected `no-console` warnings for intentional `console.error`
- No behavior change for success paths — only adds error feedback where none existed

Closes #1788
