### PR TITLE
feat(ux): add character counter and helper text to textareas

### DIFF
--- a/src/app/plugins/firebase/index.js
+++ b/src/app/plugins/firebase/index.js
@@ -19,7 +19,13 @@ const firebaseConfig = {
 const firebaseApp = initializeApp(firebaseConfig)
 const auth = getAuth(firebaseApp)
 const db = getFirestore(firebaseApp)
-const analytics = getAnalytics(firebaseApp)
+
+// Analytics doesn't work well with emulators and fake API keys
+let analytics = null
+if (process.env.VUE_APP_USE_EMULATORS !== 'true' && process.env.VUE_APP_FIREBASE_API_KEY && !process.env.VUE_APP_FIREBASE_API_KEY.includes('dummy')) {
+  analytics = getAnalytics(firebaseApp)
+}
+
 const fbFunctions = getFunctions(firebaseApp)
 const storage = getStorage(firebaseApp, `gs://${firebaseConfig.storageBucket}`)
 const database = getDatabase(firebaseApp, firebaseConfig.databaseURL)

--- a/src/app/plugins/firebase/index.js
+++ b/src/app/plugins/firebase/index.js
@@ -20,11 +20,7 @@ const firebaseApp = initializeApp(firebaseConfig)
 const auth = getAuth(firebaseApp)
 const db = getFirestore(firebaseApp)
 
-// Analytics doesn't work well with emulators and fake API keys
-let analytics = null
-if (process.env.VUE_APP_USE_EMULATORS !== 'true' && process.env.VUE_APP_FIREBASE_API_KEY && !process.env.VUE_APP_FIREBASE_API_KEY.includes('dummy')) {
-  analytics = getAnalytics(firebaseApp)
-}
+const analytics = getAnalytics(firebaseApp)
 
 const fbFunctions = getFunctions(firebaseApp)
 const storage = getStorage(firebaseApp, `gs://${firebaseConfig.storageBucket}`)

--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -112,7 +112,9 @@
     "user": "مستخدم",
     "id": "ID",
     "itemsPerPage": "عدد العناصر في الصفحة:",
-    "visible": "مرئي"
+    "visible": "مرئي",
+    "valuableFeedback": "Your qualitative feedback is highly valuable",
+    "characters": "characters"
   },
   "storage": {
     "pageTitle": "التخزين",

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -112,7 +112,9 @@
     "user": "Benutzer",
     "id": "ID",
     "itemsPerPage": "Elemente pro Seite:",
-    "visible": "Sichtbar"
+    "visible": "Sichtbar",
+    "valuableFeedback": "Your qualitative feedback is highly valuable",
+    "characters": "characters"
   },
   "storage": {
     "pageTitle": "Speicher",

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -47,6 +47,8 @@
   },
   "common": {
     "enterTextHere": "Enter text here...",
+    "valuableFeedback": "Your qualitative feedback is highly valuable",
+    "characters": "characters",
     "units": {
       "mb": "MB",
       "gb": "GB"

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -47,6 +47,8 @@
   },
   "common": {
     "enterTextHere": "Ingrese texto aquí...",
+    "valuableFeedback": "Tus comentarios cualitativos son muy valiosos",
+    "characters": "caracteres",
     "units": {
       "mb": "MB",
       "gb": "GB"

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -112,7 +112,9 @@
     "user": "Utilisateur",
     "id": "ID",
     "itemsPerPage": "Éléments par page :",
-    "visible": "Visible"
+    "visible": "Visible",
+    "valuableFeedback": "Your qualitative feedback is highly valuable",
+    "characters": "characters"
   },
   "storage": {
     "pageTitle": "Stockage",

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -112,7 +112,9 @@
     "user": "उपयोगकर्ता",
     "id": "आईडी",
     "itemsPerPage": "प्रति पृष्ठ आइटम:",
-    "visible": "दृश्य"
+    "visible": "दृश्य",
+    "valuableFeedback": "Your qualitative feedback is highly valuable",
+    "characters": "characters"
   },
   "storage": {
     "pageTitle": "संग्रहण",

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -112,7 +112,9 @@
     "user": "ユーザー",
     "id": "ID",
     "itemsPerPage": "ページごとの項目数：",
-    "visible": "表示"
+    "visible": "表示",
+    "valuableFeedback": "Your qualitative feedback is highly valuable",
+    "characters": "characters"
   },
   "storage": {
     "pageTitle": "ストレージ",

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -112,7 +112,9 @@
     "user": "Usuário",
     "id": "ID",
     "itemsPerPage": "Itens por página:",
-    "visible": "Visível"
+    "visible": "Visível",
+    "valuableFeedback": "Your qualitative feedback is highly valuable",
+    "characters": "characters"
   },
   "storage": {
     "pageTitle": "Armazenamento",

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -112,7 +112,9 @@
     "user": "Пользователь",
     "id": "ID",
     "itemsPerPage": "Элементов на странице:",
-    "visible": "Видимый"
+    "visible": "Видимый",
+    "valuableFeedback": "Your qualitative feedback is highly valuable",
+    "characters": "characters"
   },
   "storage": {
     "pageTitle": "Хранилище",

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -112,7 +112,9 @@
     "user": "用户",
     "id": "ID",
     "itemsPerPage": "每页项目数：",
-    "visible": "可见"
+    "visible": "可见",
+    "valuableFeedback": "Your qualitative feedback is highly valuable",
+    "characters": "characters"
   },
   "storage": {
     "pageTitle": "存储",

--- a/src/shared/components/TextareaForm.vue
+++ b/src/shared/components/TextareaForm.vue
@@ -25,6 +25,20 @@
             :class="['editor-container', { 'editor-readonly': props.readonly }]"
             @ready="applyReadonlyAttributes"
           />
+          
+          <v-row class="mt-2" justify="space-between" align="center" no-gutters>
+            <v-col cols="auto">
+              <span class="text-caption text-medium-emphasis">
+                <v-icon size="small" class="mr-1">mdi-lightbulb-outline</v-icon>
+                {{ props.helperText || t('common.valuableFeedback') }}
+              </span>
+            </v-col>
+            <v-col cols="auto">
+              <span class="text-caption text-medium-emphasis">
+                {{ characterCount }} {{ t('common.characters') }}
+              </span>
+            </v-col>
+          </v-row>
         </v-card-text>
       </v-card>
     </v-col>
@@ -54,10 +68,20 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  helperText: {
+    type: String,
+    default: '',
+  },
   readonly: {
     type: Boolean,
     default: false,
   },
+})
+
+const characterCount = computed(() => {
+  if (!value.value) return 0
+  // Strip HTML tags for an accurate character count, as Quill outputs HTML
+  return value.value.replace(/<[^>]*>?/gm, '').trim().length
 })
 
 const editorOptions = computed(() => ({

--- a/src/shared/components/TextareaForm.vue
+++ b/src/shared/components/TextareaForm.vue
@@ -80,8 +80,12 @@ const props = defineProps({
 
 const characterCount = computed(() => {
   if (!value.value) return 0
-  // Strip HTML tags for an accurate character count, as Quill outputs HTML
-  return value.value.replace(/<[^>]*>?/gm, '').trim().length
+  // Use DOMParser to derive plain text from HTML, decoding entities for an accurate count
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(value.value, 'text/html')
+  const text = doc.body?.textContent || ''
+
+  return text.trim().length
 })
 
 const editorOptions = computed(() => ({


### PR DESCRIPTION
#### What does this PR do?
This PR enhances the UX of the core `TextareaForm.vue` component used throughout the platform for collecting user feedback (e.g., SUS variants, TAM questionnaires, and Heuristic study conclusions). 

#### Why is it needed?
RUXAILAB collects incredibly valuable qualitative user data. By adding a live character counter and an encouraging helper text ("Your qualitative feedback is highly valuable"), we implicitly guide evaluators and participants to provide richer, more detailed open-ended feedback rather than rushing through text areas. 

#### Changes made:
- Updated `TextareaForm.vue` to include a live `characterCount` computed property (stripping raw HTML from Quill for accuracy).
- Added a non-intrusive lightbulb helper text snippet below the editor.
- Updated `en.json` and `es.json` locale files with the new translation keys (`common.valuableFeedback` and `common.characters`) to maintain full i18n support. 

Fixes #1803

https://github.com/user-attachments/assets/4d0f4c06-dcb4-4145-b3cf-542083dfcf9d
