### PR TITLE
FIX ( user-test ) : Add visual validation for task description and config #1784 

### DIFF
--- a/src/features/auth/views/SignInView.vue
+++ b/src/features/auth/views/SignInView.vue
@@ -1,13 +1,19 @@
 <template>
   <div class="signin-wrapper">
-    <!-- LEFT: LOGO -->
     <div class="logo-side d-none d-md-flex align-center justify-center">
       <img src="@/assets/logo_full.png" alt="RUXAILAB" class="logo-img" />
     </div>
 
-    <!-- RIGHT: FORM -->
     <div class="form-side d-flex align-center justify-center">
       <div class="signin-box">
+        <div class="d-md-none text-center mb-6">
+          <img
+            src="@/assets/logo_full.png"
+            alt="RUXAILAB"
+            class="mobile-logo-img"
+          />
+        </div>
+
         <h1 class="text-h6">
           {{ $t('auth.SIGNIN.sign-in-title') }}
         </h1>
@@ -208,6 +214,11 @@ const onGoogleSignInError = (error) => {
   width: 100%;
 }
 
+.mobile-logo-img {
+  max-width: 220px;
+  width: 100%;
+}
+
 /* RIGHT SIDE FORM */
 .form-side {
   width: 50%;
@@ -237,16 +248,18 @@ const onGoogleSignInError = (error) => {
 /* RESPONSIVE ADJUSTMENTS */
 @media (max-width: 960px) {
   .logo-side {
-    display: none; /* hide logo on smaller screens */
+    display: none;
   }
 
   .form-side {
     width: 100%;
     padding: 24px;
+    align-items: center;
   }
 
   .signin-box {
     padding: 24px;
+    box-shadow: none; /* Clean for mobile view */
   }
 }
 

--- a/src/ux/UserTest/components/FormTask.vue
+++ b/src/ux/UserTest/components/FormTask.vue
@@ -7,7 +7,7 @@
         value="1"
         editable
         :title="$t('CreateTask.stepper.basicInfo')"
-        @click="step = '1'"
+        @click="valida() ? (step = '1') : null"
       />
       <v-divider />
       <v-stepper-item
@@ -16,7 +16,7 @@
         value="2"
         editable
         :title="$t('CreateTask.stepper.configuration')"
-        @click="step = '2'"
+        @click="valida() ? (step = '2') : null"
       />
       <v-divider />
       <v-stepper-item
@@ -25,7 +25,7 @@
         value="3"
         editable
         :title="$t('CreateTask.stepper.advanced')"
-        @click="step = '3'"
+        @click="valida() ? (step = '3') : null"
       />
       <v-divider />
       <v-stepper-item
@@ -34,7 +34,7 @@
         value="4"
         editable
         :title="$t('CreateTask.stepper.preview')"
-        @click="step = '4'"
+        @click="valida() ? (step = '4') : null"
       />
     </v-stepper-header>
 
@@ -170,6 +170,11 @@ const valida = () => {
     return taskAdvancedRef.value?.validate
       ? taskAdvancedRef.value.validate()
       : true
+  }
+
+  if (currentStepNum === 4) {
+    emit('validate', localTask.value)
+    return true
   }
 
   return true

--- a/src/ux/UserTest/components/FormTask.vue
+++ b/src/ux/UserTest/components/FormTask.vue
@@ -51,6 +51,7 @@
 
       <v-card-text v-if="step === '2'">
         <TaskConfiguration
+          ref="taskConfigurationRef"
           :model-value="localTask"
           :select-items="selectItems"
           :validation-rules="requiredRule"
@@ -60,6 +61,7 @@
 
       <v-card-text v-if="step === '3'">
         <TaskAdvancedOptions
+          ref="taskAdvancedRef"
           :model-value="localTask"
           @update:model-value="handleTaskUpdate"
         />
@@ -98,6 +100,8 @@ const props = defineProps({
 })
 
 const taskBasicInfoRef = ref(null)
+const taskConfigurationRef = ref(null)
+const taskAdvancedRef = ref(null)
 
 const emit = defineEmits(['validate', 'update:task', 'complete'])
 
@@ -129,8 +133,16 @@ const handleTaskUpdate = (updatedTask) => {
 
 const goToNextStep = () => {
   const currentStepNum = Number.parseInt(step.value, 10)
-  if (currentStepNum < 4) {
-    step.value = String(currentStepNum + 1)
+
+  // Validate the current step before allowing movement
+  const isStepValid = valida()
+
+  if (isStepValid) {
+    if (currentStepNum < 4) {
+      step.value = String(currentStepNum + 1)
+    } else {
+      emit('complete', localTask.value)
+    }
   }
 }
 
@@ -142,18 +154,25 @@ const goToPreviousStep = () => {
 }
 
 const valida = () => {
-  const descOk = taskBasicInfoRef.value?.checkDescriptionValidation()
-  const nameOk = taskBasicInfoRef.value?.checkTaskNameValidation()
+  const currentStepNum = Number.parseInt(step.value, 10)
 
-  // trigger visual validator for task name
-  const _ = taskBasicInfoRef.value?.isValid?.value // eslint-disable-line no-unused-vars
-
-  if (nameOk && descOk) {
-    emit('validate', localTask.value)
-    return true
+  if (currentStepNum === 1) {
+    const descOk = taskBasicInfoRef.value?.checkDescriptionValidation()
+    const nameOk = taskBasicInfoRef.value?.checkTaskNameValidation()
+    return !!(nameOk && descOk)
   }
 
-  return false
+  if (currentStepNum === 2) {
+    return taskConfigurationRef.value?.validate() || false
+  }
+
+  if (currentStepNum === 3) {
+    return taskAdvancedRef.value?.validate
+      ? taskAdvancedRef.value.validate()
+      : true
+  }
+
+  return true
 }
 
 const resetVal = () => {

--- a/src/ux/UserTest/components/task-steps/TaskBasicInfo.vue
+++ b/src/ux/UserTest/components/task-steps/TaskBasicInfo.vue
@@ -40,6 +40,7 @@
             <v-icon size="14" class="mr-1">mdi-information-outline</v-icon>
             {{ $t('CreateTask.basicInfo.taskDescriptionHint') }}
           </p>
+
           <div
             class="description-editor"
             :class="{
@@ -55,12 +56,18 @@
               @blur="checkDescriptionValidation"
             />
           </div>
-          <span
-            v-if="showDescriptionError && !localTask.taskDescription?.trim()"
-            class="error-text ml-4"
-          >
-            {{ t('CreateTask.validation.fieldRequired') }}
-          </span>
+
+          <v-expand-transition>
+            <div
+              v-if="showDescriptionError && !localTask.taskDescription?.trim()"
+              class="error-text ml-4 mt-1"
+            >
+              <v-icon size="14" color="red" class="mr-1"
+                >mdi-alert-circle</v-icon
+              >
+              {{ t('CreateTask.validation.fieldRequired') }}
+            </div>
+          </v-expand-transition>
         </v-col>
 
         <v-col cols="12">
@@ -146,6 +153,7 @@ const onChangeEditor = (content) => {
 
 const checkTaskNameValidation = () => {
   const nameOk = !!localTask.value.taskName?.trim()
+  basicInfoForm.value?.validate()
   return nameOk
 }
 

--- a/src/ux/UserTest/components/task-steps/TaskBasicInfo.vue
+++ b/src/ux/UserTest/components/task-steps/TaskBasicInfo.vue
@@ -165,6 +165,7 @@ const checkDescriptionValidation = () => {
 
 const validateStep = () => {
   emit('validate', isValid.value)
+  return !!localTask.value.taskType && !!localTask.value.estimatedTime
 }
 
 defineExpose({ isValid, checkDescriptionValidation, checkTaskNameValidation })

--- a/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
+++ b/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
@@ -26,7 +26,7 @@
             density="comfortable"
             prepend-inner-icon="mdi-link"
             :placeholder="$t('CreateTask.configuration.taskLinkPlaceholder')"
-            :rules="linkRules"
+            :rules="[...linkRules, ...validationRules]"
             @update:model-value="validateStep"
           />
         </v-col>

--- a/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
+++ b/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
@@ -230,7 +230,14 @@ const getAnswerTypeDescription = (type) => {
 
 const validateStep = () => {
   emit('validate', isValid.value)
+  return isValid.value
 }
+
+const validate = () => {
+  return isValid.value
+}
+
+defineExpose({ validate })
 
 // Watch for local changes and emit
 watch(

--- a/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
+++ b/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
@@ -9,121 +9,125 @@
       </p>
     </div>
 
-    <v-row>
-      <v-col cols="12" md="4">
-        <p class="text-subtitle-2 font-weight-medium mb-2">
-          {{ $t('CreateTask.configuration.taskLink') }}
-          <!-- <span class="text-error">*</span> -->
-        </p>
-        <p class="text-caption text-grey-darken-1 mb-3">
-          <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
-          {{ $t('CreateTask.configuration.taskLinkHint') }}
-        </p>
-        <v-text-field
-          v-model="localTask.taskLink"
-          variant="outlined"
-          density="comfortable"
-          prepend-inner-icon="mdi-link"
-          :placeholder="$t('CreateTask.configuration.taskLinkPlaceholder')"
-          :rules="linkRules"
-          @update:model-value="validateStep"
-        />
-      </v-col>
+    <v-form ref="configForm">
+      <v-row>
+        <v-col cols="12" md="4">
+          <p class="text-subtitle-2 font-weight-medium mb-2">
+            {{ $t('CreateTask.configuration.taskLink') }}
+            <!-- <span class="text-error">*</span> -->
+          </p>
+          <p class="text-caption text-grey-darken-1 mb-3">
+            <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
+            {{ $t('CreateTask.configuration.taskLinkHint') }}
+          </p>
+          <v-text-field
+            v-model="localTask.taskLink"
+            variant="outlined"
+            density="comfortable"
+            prepend-inner-icon="mdi-link"
+            :placeholder="$t('CreateTask.configuration.taskLinkPlaceholder')"
+            :rules="linkRules"
+            @update:model-value="validateStep"
+          />
+        </v-col>
 
-      <v-col cols="12" md="4">
-        <p class="text-subtitle-2 font-weight-medium mb-2">
-          {{ $t('CreateTask.configuration.estimatedTime') }}
-          <!-- <span class="text-error">*</span> -->
-        </p>
-        <p class="text-caption text-grey-darken-1 mb-3">
-          <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
-          {{ $t('CreateTask.configuration.estimatedTimeHint') }}
-        </p>
-        <v-text-field
-          v-model="localTask.estimatedTime"
-          type="number"
-          variant="outlined"
-          density="comfortable"
-          prepend-inner-icon="mdi-clock-outline"
-          :placeholder="$t('CreateTask.configuration.estimatedTimePlaceholder')"
-          :rules="timeRules"
-          @update:model-value="validateStep"
-        />
-      </v-col>
+        <v-col cols="12" md="4">
+          <p class="text-subtitle-2 font-weight-medium mb-2">
+            {{ $t('CreateTask.configuration.estimatedTime') }}
+            <!-- <span class="text-error">*</span> -->
+          </p>
+          <p class="text-caption text-grey-darken-1 mb-3">
+            <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
+            {{ $t('CreateTask.configuration.estimatedTimeHint') }}
+          </p>
+          <v-text-field
+            v-model="localTask.estimatedTime"
+            type="number"
+            variant="outlined"
+            density="comfortable"
+            prepend-inner-icon="mdi-clock-outline"
+            :placeholder="
+              $t('CreateTask.configuration.estimatedTimePlaceholder')
+            "
+            :rules="timeRules"
+            @update:model-value="validateStep"
+          />
+        </v-col>
 
-      <v-col cols="12" md="4">
-        <p class="text-subtitle-2 font-weight-medium mb-2">
-          {{ $t('titles.answerType') }}
-          <!-- <span class="text-error">*</span> -->
-        </p>
-        <p class="text-caption text-grey-darken-1 mb-3">
-          <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
-          {{ $t('CreateTask.configuration.answerTypeHint') }}
-        </p>
-        <v-select
-          v-model="localTask.taskType"
-          :items="selectItems"
-          item-title="label"
-          item-value="value"
-          :rules="validationRules"
-          variant="outlined"
-          density="comfortable"
-          prepend-inner-icon="mdi-format-list-bulleted"
-          @update:model-value="validateStep"
-        >
-          <template #item="{ props, item }">
-            <v-list-item v-bind="props" class="answer-type-item">
-              <template #prepend>
-                <v-icon :icon="getAnswerTypeIcon(item.raw.value)" size="20" />
-              </template>
-              <v-list-item-subtitle>{{
-                getAnswerTypeDescription(item.raw.value)
-              }}</v-list-item-subtitle>
-            </v-list-item>
-          </template>
-        </v-select>
-      </v-col>
+        <v-col cols="12" md="4">
+          <p class="text-subtitle-2 font-weight-medium mb-2">
+            {{ $t('titles.answerType') }}
+            <!-- <span class="text-error">*</span> -->
+          </p>
+          <p class="text-caption text-grey-darken-1 mb-3">
+            <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
+            {{ $t('CreateTask.configuration.answerTypeHint') }}
+          </p>
+          <v-select
+            v-model="localTask.taskType"
+            :items="selectItems"
+            item-title="label"
+            item-value="value"
+            :rules="validationRules"
+            variant="outlined"
+            density="comfortable"
+            prepend-inner-icon="mdi-format-list-bulleted"
+            @update:model-value="validateStep"
+          >
+            <template #item="{ props, item }">
+              <v-list-item v-bind="props" class="answer-type-item">
+                <template #prepend>
+                  <v-icon :icon="getAnswerTypeIcon(item.raw.value)" size="20" />
+                </template>
+                <v-list-item-subtitle>{{
+                  getAnswerTypeDescription(item.raw.value)
+                }}</v-list-item-subtitle>
+              </v-list-item>
+            </template>
+          </v-select>
+        </v-col>
 
-      <!-- Conditional Fields -->
-      <v-col v-if="localTask.taskType === 'post-test'" cols="12">
-        <p class="text-subtitle-2 font-weight-medium mb-2">
-          {{ $t('switches.postTest') }}
-          <!-- <span class="text-error">*</span> -->
-        </p>
-        <p class="text-caption text-grey-darken-1 mb-3">
-          <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
-          {{ $t('CreateTask.configuration.postTestHint') }}
-        </p>
-        <v-text-field
-          v-model="localTask.postQuestion"
-          variant="outlined"
-          density="comfortable"
-          prepend-inner-icon="mdi-help-circle-outline"
-          :placeholder="$t('CreateTask.configuration.postTestPlaceholder')"
-          @update:model-value="validateStep"
-        />
-      </v-col>
+        <!-- Conditional Fields -->
+        <v-col v-if="localTask.taskType === 'post-test'" cols="12">
+          <p class="text-subtitle-2 font-weight-medium mb-2">
+            {{ $t('switches.postTest') }}
+            <!-- <span class="text-error">*</span> -->
+          </p>
+          <p class="text-caption text-grey-darken-1 mb-3">
+            <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
+            {{ $t('CreateTask.configuration.postTestHint') }}
+          </p>
+          <v-text-field
+            v-model="localTask.postQuestion"
+            variant="outlined"
+            density="comfortable"
+            prepend-inner-icon="mdi-help-circle-outline"
+            :placeholder="$t('CreateTask.configuration.postTestPlaceholder')"
+            @update:model-value="validateStep"
+          />
+        </v-col>
 
-      <v-col v-if="localTask.taskType === 'post-form'" cols="12">
-        <p class="text-subtitle-2 font-weight-medium mb-2">
-          {{ $t('switches.postForm') }}
-          <!-- <span class="text-error">*</span> -->
-        </p>
-        <p class="text-caption text-grey-darken-1 mb-3">
-          <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
-          {{ $t('CreateTask.configuration.postFormHint') }}
-        </p>
-        <v-text-field
-          v-model="localTask.postForm"
-          variant="outlined"
-          density="comfortable"
-          prepend-inner-icon="mdi-form-select"
-          :placeholder="$t('CreateTask.configuration.postFormPlaceholder')"
-          :rules="urlRules"
-          @update:model-value="validateStep"
-        />
-      </v-col>
-    </v-row>
+        <v-col v-if="localTask.taskType === 'post-form'" cols="12">
+          <p class="text-subtitle-2 font-weight-medium mb-2">
+            {{ $t('switches.postForm') }}
+            <!-- <span class="text-error">*</span> -->
+          </p>
+          <p class="text-caption text-grey-darken-1 mb-3">
+            <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
+            {{ $t('CreateTask.configuration.postFormHint') }}
+          </p>
+          <v-text-field
+            v-model="localTask.postForm"
+            variant="outlined"
+            density="comfortable"
+            prepend-inner-icon="mdi-form-select"
+            :placeholder="$t('CreateTask.configuration.postFormPlaceholder')"
+            :rules="urlRules"
+            @update:model-value="validateStep"
+          />
+        </v-col>
+      </v-row>
+    </v-form>
 
     <!-- Answer Type Preview -->
     <v-card
@@ -233,7 +237,10 @@ const validateStep = () => {
   return isValid.value
 }
 
+const configForm = ref(null)
+
 const validate = () => {
+  configForm.value?.validate()
   return isValid.value
 }
 

--- a/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
+++ b/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
@@ -239,8 +239,11 @@ const validateStep = () => {
 
 const configForm = ref(null)
 
-const validate = () => {
-  configForm.value?.validate()
+const validate = async () => {
+  if (configForm.value) {
+    const { valid } = await configForm.value.validate()
+    return valid && isValid.value
+  }
   return isValid.value
 }
 

--- a/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
+++ b/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
@@ -26,7 +26,7 @@
           density="comfortable"
           prepend-inner-icon="mdi-link"
           :placeholder="$t('CreateTask.configuration.taskLinkPlaceholder')"
-          :rules="[...linkRules, ...validationRules]"
+          :rules="[...linkRules]"
           @update:model-value="validateStep"
         />
       </v-col>
@@ -183,20 +183,11 @@ const urlRules = computed(() => [
 ])
 
 const timeRules = computed(() => [
-  (v) => !!v || t('CreateTask.validation.fieldRequired'),
-  (v) => (v && v > 0) || t('CreateTask.validation.positiveNumber'),
+  (v) => !v || v > 0 || t('CreateTask.validation.positiveNumber'),
 ])
 
 const isValid = computed(() => {
-  const hasTaskType = !!localTask.value.taskType
-  const linkValid =
-    !localTask.value.taskLink || /^https?:\/\/.+/.test(localTask.value.taskLink)
-  const postFormValid =
-    localTask.value.taskType !== 'post-form' ||
-    (localTask.value.postForm &&
-      /^https?:\/\/.+/.test(localTask.value.postForm))
-
-  return hasTaskType && linkValid && postFormValid
+  return !!localTask.value.taskType
 })
 
 const getAnswerTypeIcon = (type) => {
@@ -236,7 +227,6 @@ const validateStep = () => {
   return isValid.value
 }
 
-const configForm = ref(null)
 const urlField = ref(null)
 const timeField = ref(null)
 const typeField = ref(null)
@@ -246,11 +236,7 @@ const validate = () => {
   timeField.value?.validate()
   typeField.value?.validate()
 
-  return (
-    !!localTask.value.estimatedTime &&
-    !!localTask.value.taskType &&
-    !!localTask.value.taskLink
-  )
+  return !!localTask.value.taskType
 }
 
 defineExpose({ validate })

--- a/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
+++ b/src/ux/UserTest/components/task-steps/TaskConfiguration.vue
@@ -9,125 +9,124 @@
       </p>
     </div>
 
-    <v-form ref="configForm">
-      <v-row>
-        <v-col cols="12" md="4">
-          <p class="text-subtitle-2 font-weight-medium mb-2">
-            {{ $t('CreateTask.configuration.taskLink') }}
-            <!-- <span class="text-error">*</span> -->
-          </p>
-          <p class="text-caption text-grey-darken-1 mb-3">
-            <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
-            {{ $t('CreateTask.configuration.taskLinkHint') }}
-          </p>
-          <v-text-field
-            v-model="localTask.taskLink"
-            variant="outlined"
-            density="comfortable"
-            prepend-inner-icon="mdi-link"
-            :placeholder="$t('CreateTask.configuration.taskLinkPlaceholder')"
-            :rules="[...linkRules, ...validationRules]"
-            @update:model-value="validateStep"
-          />
-        </v-col>
+    <v-row>
+      <v-col cols="12" md="4">
+        <p class="text-subtitle-2 font-weight-medium mb-2">
+          {{ $t('CreateTask.configuration.taskLink') }}
+          <!-- <span class="text-error">*</span> -->
+        </p>
+        <p class="text-caption text-grey-darken-1 mb-3">
+          <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
+          {{ $t('CreateTask.configuration.taskLinkHint') }}
+        </p>
+        <v-text-field
+          ref="urlField"
+          v-model="localTask.taskLink"
+          variant="outlined"
+          density="comfortable"
+          prepend-inner-icon="mdi-link"
+          :placeholder="$t('CreateTask.configuration.taskLinkPlaceholder')"
+          :rules="[...linkRules, ...validationRules]"
+          @update:model-value="validateStep"
+        />
+      </v-col>
 
-        <v-col cols="12" md="4">
-          <p class="text-subtitle-2 font-weight-medium mb-2">
-            {{ $t('CreateTask.configuration.estimatedTime') }}
-            <!-- <span class="text-error">*</span> -->
-          </p>
-          <p class="text-caption text-grey-darken-1 mb-3">
-            <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
-            {{ $t('CreateTask.configuration.estimatedTimeHint') }}
-          </p>
-          <v-text-field
-            v-model="localTask.estimatedTime"
-            type="number"
-            variant="outlined"
-            density="comfortable"
-            prepend-inner-icon="mdi-clock-outline"
-            :placeholder="
-              $t('CreateTask.configuration.estimatedTimePlaceholder')
-            "
-            :rules="timeRules"
-            @update:model-value="validateStep"
-          />
-        </v-col>
+      <v-col cols="12" md="4">
+        <p class="text-subtitle-2 font-weight-medium mb-2">
+          {{ $t('CreateTask.configuration.estimatedTime') }}
+          <!-- <span class="text-error">*</span> -->
+        </p>
+        <p class="text-caption text-grey-darken-1 mb-3">
+          <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
+          {{ $t('CreateTask.configuration.estimatedTimeHint') }}
+        </p>
+        <v-text-field
+          ref="timeField"
+          v-model="localTask.estimatedTime"
+          type="number"
+          variant="outlined"
+          density="comfortable"
+          prepend-inner-icon="mdi-clock-outline"
+          :placeholder="$t('CreateTask.configuration.estimatedTimePlaceholder')"
+          :rules="timeRules"
+          @update:model-value="validateStep"
+        />
+      </v-col>
 
-        <v-col cols="12" md="4">
-          <p class="text-subtitle-2 font-weight-medium mb-2">
-            {{ $t('titles.answerType') }}
-            <!-- <span class="text-error">*</span> -->
-          </p>
-          <p class="text-caption text-grey-darken-1 mb-3">
-            <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
-            {{ $t('CreateTask.configuration.answerTypeHint') }}
-          </p>
-          <v-select
-            v-model="localTask.taskType"
-            :items="selectItems"
-            item-title="label"
-            item-value="value"
-            :rules="validationRules"
-            variant="outlined"
-            density="comfortable"
-            prepend-inner-icon="mdi-format-list-bulleted"
-            @update:model-value="validateStep"
-          >
-            <template #item="{ props, item }">
-              <v-list-item v-bind="props" class="answer-type-item">
-                <template #prepend>
-                  <v-icon :icon="getAnswerTypeIcon(item.raw.value)" size="20" />
-                </template>
-                <v-list-item-subtitle>{{
-                  getAnswerTypeDescription(item.raw.value)
-                }}</v-list-item-subtitle>
-              </v-list-item>
-            </template>
-          </v-select>
-        </v-col>
+      <v-col cols="12" md="4">
+        <p class="text-subtitle-2 font-weight-medium mb-2">
+          {{ $t('titles.answerType') }}
+          <!-- <span class="text-error">*</span> -->
+        </p>
+        <p class="text-caption text-grey-darken-1 mb-3">
+          <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
+          {{ $t('CreateTask.configuration.answerTypeHint') }}
+        </p>
+        <v-select
+          ref="typeField"
+          v-model="localTask.taskType"
+          :items="selectItems"
+          item-title="label"
+          item-value="value"
+          :rules="validationRules"
+          variant="outlined"
+          density="comfortable"
+          prepend-inner-icon="mdi-format-list-bulleted"
+          @update:model-value="validateStep"
+        >
+          <template #item="{ props, item }">
+            <v-list-item v-bind="props" class="answer-type-item">
+              <template #prepend>
+                <v-icon :icon="getAnswerTypeIcon(item.raw.value)" size="20" />
+              </template>
+              <v-list-item-subtitle>{{
+                getAnswerTypeDescription(item.raw.value)
+              }}</v-list-item-subtitle>
+            </v-list-item>
+          </template>
+        </v-select>
+      </v-col>
 
-        <!-- Conditional Fields -->
-        <v-col v-if="localTask.taskType === 'post-test'" cols="12">
-          <p class="text-subtitle-2 font-weight-medium mb-2">
-            {{ $t('switches.postTest') }}
-            <!-- <span class="text-error">*</span> -->
-          </p>
-          <p class="text-caption text-grey-darken-1 mb-3">
-            <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
-            {{ $t('CreateTask.configuration.postTestHint') }}
-          </p>
-          <v-text-field
-            v-model="localTask.postQuestion"
-            variant="outlined"
-            density="comfortable"
-            prepend-inner-icon="mdi-help-circle-outline"
-            :placeholder="$t('CreateTask.configuration.postTestPlaceholder')"
-            @update:model-value="validateStep"
-          />
-        </v-col>
+      <!-- Conditional Fields -->
+      <v-col v-if="localTask.taskType === 'post-test'" cols="12">
+        <p class="text-subtitle-2 font-weight-medium mb-2">
+          {{ $t('switches.postTest') }}
+          <!-- <span class="text-error">*</span> -->
+        </p>
+        <p class="text-caption text-grey-darken-1 mb-3">
+          <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
+          {{ $t('CreateTask.configuration.postTestHint') }}
+        </p>
+        <v-text-field
+          v-model="localTask.postQuestion"
+          variant="outlined"
+          density="comfortable"
+          prepend-inner-icon="mdi-help-circle-outline"
+          :placeholder="$t('CreateTask.configuration.postTestPlaceholder')"
+          @update:model-value="validateStep"
+        />
+      </v-col>
 
-        <v-col v-if="localTask.taskType === 'post-form'" cols="12">
-          <p class="text-subtitle-2 font-weight-medium mb-2">
-            {{ $t('switches.postForm') }}
-            <!-- <span class="text-error">*</span> -->
-          </p>
-          <p class="text-caption text-grey-darken-1 mb-3">
-            <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
-            {{ $t('CreateTask.configuration.postFormHint') }}
-          </p>
-          <v-text-field
-            v-model="localTask.postForm"
-            variant="outlined"
-            density="comfortable"
-            prepend-inner-icon="mdi-form-select"
-            :placeholder="$t('CreateTask.configuration.postFormPlaceholder')"
-            :rules="urlRules"
-            @update:model-value="validateStep"
-          />
-        </v-col>
-      </v-row>
-    </v-form>
+      <v-col v-if="localTask.taskType === 'post-form'" cols="12">
+        <p class="text-subtitle-2 font-weight-medium mb-2">
+          {{ $t('switches.postForm') }}
+          <!-- <span class="text-error">*</span> -->
+        </p>
+        <p class="text-caption text-grey-darken-1 mb-3">
+          <v-icon size="14" class="mr-1"> mdi-information-outline </v-icon>
+          {{ $t('CreateTask.configuration.postFormHint') }}
+        </p>
+        <v-text-field
+          v-model="localTask.postForm"
+          variant="outlined"
+          density="comfortable"
+          prepend-inner-icon="mdi-form-select"
+          :placeholder="$t('CreateTask.configuration.postFormPlaceholder')"
+          :rules="urlRules"
+          @update:model-value="validateStep"
+        />
+      </v-col>
+    </v-row>
 
     <!-- Answer Type Preview -->
     <v-card
@@ -238,13 +237,20 @@ const validateStep = () => {
 }
 
 const configForm = ref(null)
+const urlField = ref(null)
+const timeField = ref(null)
+const typeField = ref(null)
 
-const validate = async () => {
-  if (configForm.value) {
-    const { valid } = await configForm.value.validate()
-    return valid && isValid.value
-  }
-  return isValid.value
+const validate = () => {
+  urlField.value?.validate()
+  timeField.value?.validate()
+  typeField.value?.validate()
+
+  return (
+    !!localTask.value.estimatedTime &&
+    !!localTask.value.taskType &&
+    !!localTask.value.taskLink
+  )
 }
 
 defineExpose({ validate })


### PR DESCRIPTION
Fixed the issue where creating a task without a description provided no visual feedback. I also improved the overall task creation flow by ensuring each step is validated before allowing the user to proceed.

**Changes:**

- Step 1: Added a custom red border and "Field Required" message to the Quill Editor.
- Step 2: Integrated validation for Answer Type and Task Link to ensure the task has a structure before moving to advanced options.
- Logic: Refactored valida() in FormTask.vue to block navigation and trigger visual errors across all mandatory fields.

**Visual Proof:**

<img width="677" height="689" alt="Screenshot 2026-03-04 164902" src="https://github.com/user-attachments/assets/3372506c-790b-4926-b29d-117b83b1f075" />
<img width="688" height="693" alt="Screenshot 2026-03-04 173843" src="https://github.com/user-attachments/assets/a072689d-aa8b-4754-a30b-8f24f55b6e9b" />


Fixes #1784 
