### PR TITLE
fix(functions): add error handling and input validation to test triggers

### DIFF
--- a/functions/src/triggers/onTestCreate.js
+++ b/functions/src/triggers/onTestCreate.js
@@ -1,28 +1,48 @@
 import { functions } from '../f.firebase.js'
 import UserRepository from '../repositories/UserRepository.js'
-import logger from "../utils/logger.js";
+import logger from '../utils/logger.js'
 
 export const onTestCreate = functions.onTrigger({
   path: 'tests/{docId}',
   event: 'created',
   handler: async (event) => {
     const snapshot = event.data
-    if (!snapshot) return logger.info("No data associated with the event");
+    if (!snapshot) return logger.info('No data associated with the event')
 
     const test = snapshot.data()
-    const userRepository = new UserRepository()
-    const user = await userRepository.get(test.testAdmin.userDocId)
 
-    user.myTests[snapshot.id] = {
-      testDocId: snapshot.id,
-      testTitle: test.testTitle || test.title || 'Untitled Test',
-      testType: test.testType || 'UNKNOWN',
-      subType: test.subType || null,
-      numberColaborators: test.cooperators?.length || 0,
-      creationDate: test.creationDate || test.createdAt || Date.now(),
-      updateDate: Date.now(),
+    if (!test.testAdmin?.userDocId) {
+      logger.warn('onTestCreate: missing testAdmin.userDocId', {
+        testId: snapshot.id,
+      })
+      return
     }
 
-    await userRepository.update(test.testAdmin.userDocId, user)
+    try {
+      const userRepository = new UserRepository()
+      const user = await userRepository.get(test.testAdmin.userDocId)
+
+      user.myTests[snapshot.id] = {
+        testDocId: snapshot.id,
+        testTitle: test.testTitle || test.title || 'Untitled Test',
+        testType: test.testType || 'UNKNOWN',
+        subType: test.subType || null,
+        numberColaborators: test.cooperators?.length || 0,
+        creationDate: test.creationDate || test.createdAt || Date.now(),
+        updateDate: Date.now(),
+      }
+
+      await userRepository.update(test.testAdmin.userDocId, user)
+      logger.info('onTestCreate: updated user myTests', {
+        testId: snapshot.id,
+        userId: test.testAdmin.userDocId,
+      })
+    } catch (error) {
+      logger.error('onTestCreate: failed to update user myTests', {
+        testId: snapshot.id,
+        userId: test.testAdmin.userDocId,
+        error: error.message,
+      })
+    }
   },
 })

--- a/functions/src/triggers/onTestUpdate.js
+++ b/functions/src/triggers/onTestUpdate.js
@@ -1,28 +1,48 @@
 import { functions } from '../f.firebase.js'
 import UserRepository from '../repositories/UserRepository.js'
-import logger from "../utils/logger.js";
+import logger from '../utils/logger.js'
 
 export const onTestUpdate = functions.onTrigger({
   path: 'tests/{docId}',
   event: 'updated',
   handler: async (event) => {
     const snapshot = event.data.after
-    if (!snapshot) return logger.info("No data associated with the event");
+    if (!snapshot) return logger.info('No data associated with the event')
 
     const newTest = snapshot.data()
-    const userRepository = new UserRepository()
-    const user = await userRepository.get(newTest.testAdmin.userDocId)
 
-    user.myTests[snapshot.id] = {
-      testDocId: snapshot.id,
-      testTitle: newTest.testTitle || newTest.title || 'Untitled Test',
-      testType: newTest.testType || 'UNKNOWN',
-      subType: newTest.subType || null,
-      numberColaborators: newTest.cooperators?.length || 0,
-      creationDate: newTest.creationDate || newTest.createdAt || Date.now(),
-      updateDate: Date.now(),
+    if (!newTest.testAdmin?.userDocId) {
+      logger.warn('onTestUpdate: missing testAdmin.userDocId', {
+        testId: snapshot.id,
+      })
+      return
     }
 
-    await userRepository.update(newTest.testAdmin.userDocId, user)
-  }
+    try {
+      const userRepository = new UserRepository()
+      const user = await userRepository.get(newTest.testAdmin.userDocId)
+
+      user.myTests[snapshot.id] = {
+        testDocId: snapshot.id,
+        testTitle: newTest.testTitle || newTest.title || 'Untitled Test',
+        testType: newTest.testType || 'UNKNOWN',
+        subType: newTest.subType || null,
+        numberColaborators: newTest.cooperators?.length || 0,
+        creationDate: newTest.creationDate || newTest.createdAt || Date.now(),
+        updateDate: Date.now(),
+      }
+
+      await userRepository.update(newTest.testAdmin.userDocId, user)
+      logger.info('onTestUpdate: updated user myTests', {
+        testId: snapshot.id,
+        userId: newTest.testAdmin.userDocId,
+      })
+    } catch (error) {
+      logger.error('onTestUpdate: failed to update user myTests', {
+        testId: snapshot.id,
+        userId: newTest.testAdmin.userDocId,
+        error: error.message,
+      })
+    }
+  },
 })


### PR DESCRIPTION
Add error handling, input validation, and structured logging to `onTestCreate` and `onTestUpdate` Cloud Function triggers.

## Problem

Both triggers have **zero try/catch blocks** — if Firestore `userRepository.get()` or `.update()` fails, the Cloud Function crashes silently with no logging. Neither trigger validates that `test.testAdmin.userDocId` exists before use.

## Changes

- Added null-guard: `if (!test.testAdmin?.userDocId)` → `logger.warn(...)` + early return
- Wrapped handler bodies in `try/catch` with `logger.error()` and structured context
- Added `logger.info()` success log with `testId` and `userId` for traceability
- Both files follow the same consistent pattern

## Files Modified

- `functions/src/triggers/onTestCreate.js` — +40/-20 lines
- `functions/src/triggers/onTestUpdate.js` — +40/-20 lines

## Code Changes

<img width="1910" height="4881" alt="pr1789_diff_1772644918511" src="https://github.com/user-attachments/assets/f563f9a3-8a6f-491c-8123-e82e8d06fffb" />

## Verification

- Prettier: Passes (unchanged)
- No new dependencies added
- Existing `logger` utility used (already imported)

Closes #1789
