### PR TITLE
Add CI workflow to validate Dockerfile on pull requests

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,20 @@
+name: Docker Build Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        run: docker build -t ruxailab-test .


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that builds the Docker image on every pull request.

Tested locally with:
docker build -t ruxailab-test .

The build succeeds and ensures the Dockerfile remains valid in future changes.

closes: #1668