### PR TITLE
feat(user-test): improve email selection UI in send invitation component

### DIFF
--- a/src/shared/components/dialogs/InviteDialog.vue
+++ b/src/shared/components/dialogs/InviteDialog.vue
@@ -30,17 +30,17 @@
           </template>
         </v-combobox>
 
-        <v-chip-group>
+        <div class="d-flex flex-wrap mt-1">
           <v-chip
             v-for="(coop, i) in selectedCoops"
             :key="i"
             closable
-            class="ml-2 mt-2"
+            class="mb-2 mr-2 email-chip"
             @click:close="removeSelectedCoop(i)"
           >
             {{ typeof coop == 'object' ? coop.email : coop }}
           </v-chip>
-        </v-chip-group>
+        </div>
 
         <v-select
           v-model="selectedRole"
@@ -332,5 +332,9 @@ watch(
 .v-btn {
   font-weight: 600;
   text-transform: unset !important;
+}
+
+.email-chip {
+  max-width: 100%;
 }
 </style>


### PR DESCRIPTION
### Description

- Fixed #1785

The previous UI displayed selected emails in a horizontal slider, which made it difficult to view all emails when many were added because users had to scroll horizontally.

This update changes the layout to **display selected emails vertically**, making it easier for users to see all the entered emails without horizontal scrolling. This improves the readability and usability of the **Send Invitation** component when multiple emails are selected.

**Changes**

* Changed selected email display from horizontal slider to **vertical layout**
* Improved visibility when multiple emails are added
* Removed the need for horizontal scrolling
* Enhanced user experience in the **Send Invitation** component

### Changes

<img width="646" height="675" alt="Screenshot From 2026-03-06 14-11-53" src="https://github.com/user-attachments/assets/7fafb279-e8a6-435b-bc86-0ea93b140e90" />
