### PR TITLE
fix(analytics): align timeline export day keys to ISO format

### DIFF
--- a/src/ux/UserTest/components/UnmoderatedTestAnalytics/GeneralAnalytics.vue
+++ b/src/ux/UserTest/components/UnmoderatedTestAnalytics/GeneralAnalytics.vue
@@ -1270,7 +1270,7 @@ const onExportTimeline = () => {
   const counts = {}
 
   for (let d = new Date(oneMonthAgo); d <= now; d.setDate(d.getDate() + 1)) {
-    const key = formatDate(d)
+    const key = d.toISOString().split('T')[0]
     counts[key] = 0
   }
 


### PR DESCRIPTION
## Summary

This PR fixes the unmoderated analytics timeline CSV export issue caused by inconsistent day-key formatting and an undefined `formatDate` reference.

---

## Problem

`onExportTimeline()` initialized date buckets using one date format, while the counting logic incremented counts using a different format. This inconsistency led to incorrect—often zero—counts in the exported CSV files. Additionally, the function referenced formatDate within the file even though it was not defined there, resulting in a runtime error (formatDate is not defined) during export.
  
---

## Fix

- Updated date-bucket initialization to use ISO date keys:
<img width="1083" height="150" alt="image" src="https://github.com/user-attachments/assets/3bf700e6-0cb7-43b2-9947-53a01424907e" />

---

## ScreenShot of CSV

<img width="233" height="139" alt="image" src="https://github.com/user-attachments/assets/4ac43ccc-74ac-4837-99f8-4c65c43275c7" />

The count for the number of test cases is calculated correctly.

fixes #1751 