### PR TITLE
fix: calibration url not working on prod

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -673,8 +673,11 @@ function handleIrisData(data) {
 }
 
 const openCalibration = () => {
+  const calibrationBaseUrl =
+    (process.env.VUE_APP_EYE_LAB_FRONTEND_URL || '').trim() ||
+    window.location.origin
   calibrationPopup.value = window.open(
-    `${process.env.VUE_APP_EYE_LAB_FRONTEND_URL}/calibration/camera?auth=${user.value?.id}&test=${test.value.id}`,
+    `${calibrationBaseUrl}/calibration/camera?auth=${user.value?.id}&test=${test.value.id}`,
     '_blank',
   )
   calibrationInProgress.value = true


### PR DESCRIPTION
## What this fixes
Calibration link was broken in production when `VUE_APP_EYE_LAB_FRONTEND_URL` was unset or empty, resulting in a URL like `undefined/calibration/camera?...`.

## What I changed
- **src/ux/UserTest/views/UserTestView.vue**: Build the calibration base URL from `VUE_APP_EYE_LAB_FRONTEND_URL` when set and non-empty; otherwise use `window.location.origin` so the calibration page opens on the same host in prod.

## How I tested it
- With `VUE_APP_EYE_LAB_FRONTEND_URL` unset/empty, the opened URL uses the current origin (e.g. `https://prod-domain.com/calibration/camera?auth=...`).
- With the env var set, the opened URL uses that value.
- Ran `npm run lint` with no new issues.

## Notes
If calibration is hosted on a different domain in prod, set `VUE_APP_EYE_LAB_FRONTEND_URL` in the production environment; the fallback only applies when it is missing.

Closes #1766