### PR TITLE
fix: defer camera initialization in moderated video calls

### DIFF
--- a/src/ux/UserTest/components/VideoCall.vue
+++ b/src/ux/UserTest/components/VideoCall.vue
@@ -1014,10 +1014,7 @@ watch([localVideo, localStream], ([videoEl, stream]) => {
 onMounted(async () => {
   // Moderator gets media preview but doesn't join room yet
   if (props.isModerator) {
-    // Just get local media for preview
-    if (!isObservator.value) {
-      await initLocalMedia()
-    }
+    // Do NOT initialize local media here  wait for startCall()
   } else {
     // Participants and observators wait for room to be opened by moderator
     const showVideoCallRef = dbRef(
@@ -1465,6 +1462,9 @@ function dismissJoinDialog() {
 const startCall = async () => {
   // Moderator joins the room and signals others
   try {
+    if (!localStream.value) {
+      await initLocalMedia()
+    }
     // Set flag first so others can join
     await update(dbRef(database, `rooms/${props.roomId}`), {
       showVideoCall: true,


### PR DESCRIPTION
fixes #1524 
## Description
Fix camera initialisation timing in moderated user test sessions. Previously, the camera would start when clicking "Start Test", but it should only start after the moderator clicks "Start Moderated Session".




## AFTER:

https://github.com/user-attachments/assets/05d280a4-1310-4d4c-b403-760c75e700be

