### PR TITLE
fix(user-test): ensure task state is reset on dialog close/open #1786

### DIFF
--- a/src/ux/UserTest/components/FormDialog.vue
+++ b/src/ux/UserTest/components/FormDialog.vue
@@ -72,7 +72,10 @@ const localTask = reactive(Task.fromJson({ ...props.task }))
 watch(
   () => props.dialog,
   (val) => {
-    if (val) Object.assign(localTask, props.task)
+    if (val) {
+      Object.assign(localTask, Task.fromJson({}))
+      Object.assign(localTask, Task.fromJson({ ...props.task }))
+    }
   },
 )
 
@@ -91,6 +94,7 @@ const submit = (task) => {
 }
 
 const reset = () => {
+  Object.assign(localTask, Task.fromJson({}))
   form.value?.resetVal()
 }
 </script>


### PR DESCRIPTION
Closes #1786 

Previously, when a user opened a task for editing and then closed the dialog, the reactive state (localTask) was not being cleared. Due to how Object.assign was used in the watcher, opening a subsequent task (or a new task) could result in "ghost data" from the previous session appearing in the form fields.

<img width="797" height="656" alt="Screenshot 2026-03-07 142707" src="https://github.com/user-attachments/assets/f891b703-4a4a-402c-b6ea-6fd1270ca951" />
