### PR TITLE
test: add e2e tests for public pages (signup, faq, terms, privacy, 404)

### DIFF
--- a/e2e/helpers/setup.js
+++ b/e2e/helpers/setup.js
@@ -1,0 +1,22 @@
+/**
+ * Logs in to the application with the given credentials.
+ * Navigates to the sign-in page, fills in email and password, and clicks the sign-in button.
+ */
+export const logIn = async (page, email, password) => {
+  await page.goto('http://localhost:8080/signin')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password', { exact: true }).fill(password)
+  await page.getByTestId('sign-in-button').click()
+}
+
+/**
+ * Attaches console, request and response listeners for debugging.
+ * Useful in beforeEach hooks to trace test failures.
+ */
+export const attachDebugListeners = (page) => {
+  page.on('console', (msg) => console.log('Console:', msg.text()))
+  page.on('request', (req) => console.log('Request:', req.url()))
+  page.on('response', (res) =>
+    console.log('Response:', res.url(), res.status()),
+  )
+}

--- a/e2e/publicPages.spec.js
+++ b/e2e/publicPages.spec.js
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test'
+import { attachDebugListeners } from './helpers/setup'
+
+const BASE_URL = 'http://localhost:8080'
+
+test.describe('Public Page Tests', () => {
+  test.beforeEach(async ({ page }) => {
+    page.setDefaultTimeout(60000)
+    page.setDefaultNavigationTimeout(60000)
+    attachDebugListeners(page)
+  })
+
+  test.describe('Sign Up Page', () => {
+    test('loads and displays the sign up form', async ({ page }) => {
+      await page.goto(`${BASE_URL}/signup`, { waitUntil: 'networkidle' })
+      await expect(page.locator('#app')).toBeVisible()
+
+      // Verify form fields are present
+      await expect(page.getByLabel('Email')).toBeVisible()
+      await expect(page.getByLabel('Password', { exact: true })).toBeVisible()
+      await expect(page.getByLabel('Confirm password')).toBeVisible()
+    })
+
+    test('shows validation errors on empty form submission', async ({
+      page,
+    }) => {
+      await page.goto(`${BASE_URL}/signup`, { waitUntil: 'networkidle' })
+
+      // Click submit without filling anything
+      await page.getByRole('button', { name: /sign up/i }).click()
+
+      // Should show validation messages
+      await expect(page.locator('body')).toContainText(/required/i)
+    })
+
+    test('has a link to sign in page', async ({ page }) => {
+      await page.goto(`${BASE_URL}/signup`, { waitUntil: 'networkidle' })
+
+      // Find and click the "Sign In" link
+      const signInButton = page.getByRole('button', { name: /sign in/i })
+      await expect(signInButton).toBeVisible()
+      await signInButton.click()
+
+      await expect(page).toHaveURL(/\/signin/)
+    })
+  })
+
+  test.describe('FAQ Page', () => {
+    test('loads and displays FAQ content', async ({ page }) => {
+      await page.goto(`${BASE_URL}/faq`, { waitUntil: 'networkidle' })
+      await expect(page.locator('#app')).toBeVisible()
+
+      // Verify main heading exists
+      const heading = page.locator('h1')
+      await expect(heading).toBeVisible()
+
+      // Verify FAQ has multiple question sections (h2 elements)
+      const questions = page.locator('.faq h2')
+      await expect(questions).toHaveCount(9)
+    })
+
+    test('contains links to other pages', async ({ page }) => {
+      await page.goto(`${BASE_URL}/faq`, { waitUntil: 'networkidle' })
+
+      // FAQ should link to privacy policy
+      const privacyLink = page.locator('a[href="/privacy-policy"]')
+      await expect(privacyLink).toBeVisible()
+
+      // FAQ should link to help page
+      const helpLink = page.locator('a[href="/help"]')
+      await expect(helpLink).toBeVisible()
+    })
+  })
+
+  test.describe('Terms of Service Page', () => {
+    test('loads and displays all sections', async ({ page }) => {
+      await page.goto(`${BASE_URL}/terms-of-service`, {
+        waitUntil: 'networkidle',
+      })
+      await expect(page.locator('#app')).toBeVisible()
+
+      // Verify main heading
+      await expect(page.locator('h1')).toHaveText('Terms of Service')
+
+      // Verify key sections exist
+      const sections = page.locator('.terms-of-service h2')
+      const expectedSections = [
+        '1. Acceptance of Terms',
+        '2. License',
+        '3. User Responsibilities',
+        '4. Contributions',
+        '5. No Warranty',
+        '6. Limitation of Liability',
+        '7. Changes to These Terms',
+        '8. Contact Us',
+      ]
+
+      await expect(sections).toHaveCount(expectedSections.length)
+
+      for (const sectionTitle of expectedSections) {
+        await expect(
+          page.locator(`h2:has-text("${sectionTitle}")`),
+        ).toBeVisible()
+      }
+    })
+  })
+
+  test.describe('Privacy Policy Page', () => {
+    test('loads and displays all sections', async ({ page }) => {
+      await page.goto(`${BASE_URL}/privacy-policy`, {
+        waitUntil: 'networkidle',
+      })
+      await expect(page.locator('#app')).toBeVisible()
+
+      // Verify main heading exists
+      const heading = page.locator('h1')
+      await expect(heading).toBeVisible()
+
+      // Verify the page has multiple sections
+      const sections = page.locator('.privacy-policy h2')
+      await expect(sections).toHaveCount(8)
+    })
+  })
+
+  test.describe('404 Page', () => {
+    test('displays not found page for invalid routes', async ({ page }) => {
+      await page.goto(`${BASE_URL}/this-page-does-not-exist`, {
+        waitUntil: 'networkidle',
+      })
+      await expect(page.locator('#app')).toBeVisible()
+
+      // The page should indicate the route was not found
+      await expect(page.locator('body')).toContainText(/not found/i)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1825

Hi, I added e2e test coverage for public pages that had no tests:
- /signup - form loading, validation errors, navigation to sign-in
- /faq - 9 FAQ questions rendered, links to privacy-policy and help
- /terms-of-service - all 8 sections present with correct headings
- /privacy-policy - all 8 sections visible
- 404 page - invalid routes show not found message

Also includes the shared test helper (e2e/helpers/setup.ts) for the attachDebugListeners utility.
<img width="1429" height="660" alt="Screenshot 2026-03-07 at 6 48 54 PM" src="https://github.com/user-attachments/assets/2a2fc8f3-d8b6-4ae2-8f82-3ee0af0c8ee9" />
<img width="1428" height="834" alt="Screenshot 2026-03-07 at 6 49 18 PM" src="https://github.com/user-attachments/assets/121b0041-6dd3-4d07-9d39-673e153d345c" />
<img width="1427" height="836" alt="Screenshot 2026-03-07 at 6 49 45 PM" src="https://github.com/user-attachments/assets/acf82fc0-1544-4b37-a909-aa8adb7fc2e4" />
