### PR TITLE
Debug leftovers and dead code patterns polluting production codebase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "chartjs-adapter-date-fns": "^3.0.0",
         "crypto-browserify": "^3.12.1",
         "date-fns": "^4.1.0",
+        "dompurify": "^3.3.2",
         "firebase": "^9.23.0",
         "firebase-admin": "^13.6.1",
         "firebase-functions": "^6.6.0",
@@ -138,6 +139,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2270,6 +2272,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.13.tgz",
       "integrity": "sha512-GfiI1JxJ7ecluEmDjPzseRXk/PX31hS7+tjgBopL7XjB2hLUdR+0FTMXy2Q3/hXezypDvU6or7gVFizDESrkXw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.4",
         "@firebase/logger": "0.4.0",
@@ -2327,6 +2330,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.13.tgz",
       "integrity": "sha512-j6ANZaWjeVy5zg6X7uiqh6lM6o3n3LD1+/SJFNs9V781xyryyZWXe+tmnWNWPkP086QfJoNkWN9pMQRqSG4vMg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.9.13",
         "@firebase/component": "0.6.4",
@@ -2339,7 +2343,8 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
       "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "0.23.2",
@@ -2959,6 +2964,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz",
       "integrity": "sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3990,7 +3996,8 @@
       "version": "0.4.1633559619",
       "resolved": "https://registry.npmjs.org/@mediapipe/face_mesh/-/face_mesh-0.4.1633559619.tgz",
       "integrity": "sha512-Vc8cdjxS5+O2gnjWH9KncYpUCVXT0h714KlWAsyqJvJbIgUJBqpppbIx8yWcAzBDxm/5cYSuBI5p5ySIPxzcEg==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -4364,6 +4371,7 @@
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-webgl/-/tfjs-backend-webgl-4.22.0.tgz",
       "integrity": "sha512-H535XtZWnWgNwSzv538czjVlbJebDl5QTMOth4RXr2p/kJ1qSIXE0vZvEtO+5EC9b00SvhplECny2yDewQb/Yg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@tensorflow/tfjs-backend-cpu": "4.22.0",
         "@types/offscreencanvas": "~2019.3.0",
@@ -4382,6 +4390,7 @@
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-4.22.0.tgz",
       "integrity": "sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@tensorflow/tfjs-core": "4.22.0"
       }
@@ -4391,6 +4400,7 @@
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-4.22.0.tgz",
       "integrity": "sha512-LEkOyzbknKFoWUwfkr59vSB68DMJ4cjwwHgicXN0DUi3a0Vh1Er3JQqCI1Hl86GGZQvY8ezVrtDIvqR1ZFW55A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/long": "^4.0.1",
         "@types/offscreencanvas": "~2019.7.0",
@@ -4598,6 +4608,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
       "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4940,6 +4951,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
       "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -5299,6 +5311,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -5979,6 +5992,7 @@
       "integrity": "sha512-yTX7GVyM19tEbd+y5/gA6MkVKA6K61nVYHYAivD61Hx6odVFmQsaC3/R3cWAHM1P5oVKCevBbumPljbT+tFG2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.12.16",
         "@soda/friendly-errors-webpack-plugin": "^1.8.0",
@@ -6374,6 +6388,7 @@
       "integrity": "sha512-VL61CgZBoQqayXfzlZJHHpZuX4lsT8dmdZMJzADhdAJjKu26JBpypHr/2ppevxItljPiuALQW4MKhhCXZRXnLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-modules-commonjs": "^7.2.0",
         "chalk": "^2.1.0",
@@ -6727,6 +6742,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6842,6 +6858,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7235,6 +7252,7 @@
       "integrity": "sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^27.5.1",
         "@jest/types": "^27.5.1",
@@ -7774,6 +7792,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8060,6 +8079,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -8817,6 +8837,7 @@
       "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "icss-utils": "^5.1.0",
         "postcss": "^8.4.33",
@@ -8905,6 +8926,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9173,6 +9195,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.10",
         "@cypress/xvfb": "^1.2.4",
@@ -9379,6 +9402,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -9833,11 +9857,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
+      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true,
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -10139,6 +10165,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -10336,6 +10363,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13702,6 +13730,7 @@
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -15409,7 +15438,6 @@
       "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^3.0.0",
@@ -15429,7 +15457,6 @@
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -15443,7 +15470,6 @@
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -15462,7 +15488,6 @@
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -15522,6 +15547,7 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
       "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "fast-png": "^6.2.0",
@@ -16704,6 +16730,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17812,6 +17839,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18898,6 +18926,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -18927,6 +18956,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -18975,6 +19005,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.5.tgz",
       "integrity": "sha512-UDQbIPnDrjE8tqUBbPmCOZgtd75htE6W3r0JCmY9bL6W1iemDM37MZEKC49d+tdQ0v/CKx4gjxLoLsfkD2NiZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -19830,6 +19861,7 @@
       "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0"
       },
@@ -19914,7 +19946,8 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -21141,6 +21174,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21870,6 +21904,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.29.tgz",
       "integrity": "sha512-BZqN4Ze6mDQVNAni0IHeMJ5mwr8VAJ3MQC9FmprRhcBYENw+wOAAjRj8jfmN6FLl0j96OXbR+CjWhmAmM+QGnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.29",
         "@vue/compiler-sfc": "3.5.29",
@@ -21909,6 +21944,7 @@
       "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0 || ^9.0.0",
@@ -22120,6 +22156,7 @@
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.12.1.tgz",
       "integrity": "sha512-JDHDzs1e195YJ9L3X4nWQySGSMyTxr0BefIY4+l/CpAgTd9pPV5F6oZzI8ZLuikMxS4HhfSGHteOAe6u/zh4vQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"
@@ -22255,6 +22292,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -22390,6 +22428,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22507,6 +22546,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22610,6 +22650,7 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
       "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -22626,6 +22667,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22961,7 +23003,6 @@
       "integrity": "sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.0.0",
         "yaml": "^2.0.0"
@@ -22979,7 +23020,6 @@
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -22993,7 +23033,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "crypto-browserify": "^3.12.1",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.3.2",
     "firebase": "^9.23.0",
     "firebase-admin": "^13.6.1",
     "firebase-functions": "^6.6.0",

--- a/src/app/plugins/firebase/FirebaseFirestoreRepository.js
+++ b/src/app/plugins/firebase/FirebaseFirestoreRepository.js
@@ -154,12 +154,8 @@ export default class Controller {
   }
 
   async update(col, docId, payload) {
-    try {
-      const ref = doc(db, `${col}/${docId}`)
-      return updateDoc(ref, payload)
-    } catch (e) {
-      throw e
-    }
+    const ref = doc(db, `${col}/${docId}`)
+    return updateDoc(ref, payload)
   }
 
   async delete(col, docId) {

--- a/src/controllers/StudyController.js
+++ b/src/controllers/StudyController.js
@@ -27,57 +27,45 @@ export default class StudyController extends Controller {
     return await super.create(COLLECTION, payload.toFirestore())
   }
   async duplicateStudy(payload) {
-    try {
-      const answerDoc = await answerController.createAnswer(
-        new StudyAnswer({ type: payload.test.testType }),
-      )
+    const answerDoc = await answerController.createAnswer(
+      new StudyAnswer({ type: payload.test.testType }),
+    )
 
-      // Use the correct study type from the payload (already instantiated correctly in SettingsView)
-      const duplicatedStudy = payload.test
-      duplicatedStudy.answersDocId = answerDoc.id
+    // Use the correct study type from the payload (already instantiated correctly in SettingsView)
+    const duplicatedStudy = payload.test
+    duplicatedStudy.answersDocId = answerDoc.id
 
-      return await super.create(COLLECTION, duplicatedStudy.toFirestore())
-    } catch (error) {
-      throw error
-    }
+    return await super.create(COLLECTION, duplicatedStudy.toFirestore())
   }
 
   async deleteStudy(payload) {
-    try {
-      const testToDelete = await super.readOne(COLLECTION, payload.id)
-      if (!testToDelete.exists()) {
-        return null
-      }
-
-      const collaborators = await testToDelete.data()
-      const cooperators = collaborators.cooperators
-      if (cooperators) {
-        const promises = []
-
-        for (const cooperator of cooperators) {
-          // Add the call to remove notifications for the test being deleted
-          promises.push(
-            userController.removeTestFromUser(cooperator.userDocId, payload.id),
-          )
-          promises.push(
-            userController.removeNotificationsForTest(payload.id, cooperators),
-          )
-        }
-        await Promise.all(promises)
-      }
-      await super.update('users', payload.testAdmin.userDocId, payload.auxUser)
-      await super.delete(COLLECTION, payload.id)
-    } catch (error) {
-      throw error
+    const testToDelete = await super.readOne(COLLECTION, payload.id)
+    if (!testToDelete.exists()) {
+      return null
     }
+
+    const collaborators = await testToDelete.data()
+    const cooperators = collaborators.cooperators
+    if (cooperators) {
+      const promises = []
+
+      for (const cooperator of cooperators) {
+        // Add the call to remove notifications for the test being deleted
+        promises.push(
+          userController.removeTestFromUser(cooperator.userDocId, payload.id),
+        )
+        promises.push(
+          userController.removeNotificationsForTest(payload.id, cooperators),
+        )
+      }
+      await Promise.all(promises)
+    }
+    await super.update('users', payload.testAdmin.userDocId, payload.auxUser)
+    await super.delete(COLLECTION, payload.id)
   }
 
   async updateStudy(payload) {
-    try {
-      return await super.update(COLLECTION, payload.id, payload.toFirestore())
-    } catch (e) {
-      throw e
-    }
+    return await super.update(COLLECTION, payload.id, payload.toFirestore())
   }
 
   //ToDo: It seems an action from User Testing
@@ -137,15 +125,11 @@ export default class StudyController extends Controller {
   }
 
   async getAllStudies() {
-    try {
-      const response = await super.readAll('tests')
-      const res = response.map((data) => {
-        return instantiateStudyByType(data.testType, data)
-      })
-      return res
-    } catch (err) {
-      throw err
-    }
+    const response = await super.readAll('tests')
+    const res = response.map((data) => {
+      return instantiateStudyByType(data.testType, data)
+    })
+    return res
   }
 
   subscribeToStudy(studyId, callback) {

--- a/src/features/auth/composables/useProfile.js
+++ b/src/features/auth/composables/useProfile.js
@@ -110,24 +110,20 @@ export function useProfile() {
   }
 
   const uploadProfileImage = async (file) => {
-    try {
-      const auth = getAuth()
-      const user = auth.currentUser
-      if (!user) throw new Error(t('profile.noUserSignedIn'))
+    const auth = getAuth()
+    const user = auth.currentUser
+    if (!user) throw new Error(t('profile.noUserSignedIn'))
 
-      // Compress the image first
+    // Compress the image first
 
-      const compressedFile = await compressImage(file, 300, 0.6)
+    const compressedFile = await compressImage(file, 300, 0.6)
 
-      // Convert to Base64 (stores directly in Firestore, no Storage needed!)
+    // Convert to Base64 (stores directly in Firestore, no Storage needed!)
 
-      const base64DataUrl = await fileToBase64(compressedFile)
+    const base64DataUrl = await fileToBase64(compressedFile)
 
-      // Return the Base64 data URL (this will be stored in Firestore)
-      return base64DataUrl
-    } catch (error) {
-      throw error
-    }
+    // Return the Base64 data URL (this will be stored in Firestore)
+    return base64DataUrl
   }
 
   const removeProfileImage = async () => {

--- a/src/features/auth/controllers/AuthController.js
+++ b/src/features/auth/controllers/AuthController.js
@@ -141,13 +141,9 @@ export default class AuthController {
   }
 
   async deleteUserData(userId) {
-    try {
-      await axios.post(
-        process.env.VUE_APP_CLOUD_FUNCTIONS_URL + '/deleteAuth',
-        { data: { userId } },
-      )
-    } catch (err) {
-      throw err
-    }
+    await axios.post(
+      process.env.VUE_APP_CLOUD_FUNCTIONS_URL + '/deleteAuth',
+      { data: { userId } },
+    )
   }
 }

--- a/src/features/auth/controllers/UserController.js
+++ b/src/features/auth/controllers/UserController.js
@@ -78,9 +78,8 @@ export default class UserController extends Controller {
   async _fetchStudiesByIds(ids) {
     if (!ids || ids.length === 0) return []
 
-    try {
-      // If there are few (<= 10), use "in" query (faster and more direct)
-      if (ids.length <= 10) {
+    // If there are few (<= 10), use "in" query (faster and more direct)
+    if (ids.length <= 10) {
         const q = {
           field: documentId(),
           condition: 'in',
@@ -100,9 +99,6 @@ export default class UserController extends Controller {
         .map((r) => {
           return Object.assign({ id: r.id }, r.data())
         })
-    } catch (error) {
-      throw error
-    }
   }
 
   async updateProfile(docId, payload) {
@@ -190,63 +186,50 @@ export default class UserController extends Controller {
   }
 
   async removeNotificationsForTest(testId, cooperators) {
-    try {
-      for (let cooperator = 0; cooperator < cooperators.length; cooperator++) {
-        const userDocID = cooperators[cooperator].userDocId
+    for (let cooperator = 0; cooperator < cooperators.length; cooperator++) {
+      const userDocID = cooperators[cooperator].userDocId
 
-        // Lê o documento do usuário diretamente
-        const userDoc = await super.readOne('users', userDocID)
+      // Lê o documento do usuário diretamente
+      const userDoc = await super.readOne('users', userDocID)
 
-        // Verifica se o documento do usuário existe
-        if (userDoc.exists()) {
-          const userData = userDoc.data()
-          const userId = userDoc.id
+      // Verifica se o documento do usuário existe
+      if (userDoc.exists()) {
+        const userData = userDoc.data()
+        const userId = userDoc.id
 
-          // Verificar se o usuário tem notificações
-          if (userData.notifications && userData.notifications.length > 0) {
-            // Filtrar notificações que têm o testId correspondente
-            userData.notifications = userData.notifications.filter(
-              (notification) => notification.testId !== testId,
-            )
-            // Atualizar o documento do usuário com as notificações filtradas
-            await super.update('users', userId, {
-              notifications: userData.notifications,
-            })
-          }
-        } else {
+        // Verificar se o usuário tem notificações
+        if (userData.notifications && userData.notifications.length > 0) {
+          // Filtrar notificações que têm o testId correspondente
+          userData.notifications = userData.notifications.filter(
+            (notification) => notification.testId !== testId,
+          )
+          // Atualizar o documento do usuário com as notificações filtradas
+          await super.update('users', userId, {
+            notifications: userData.notifications,
+          })
         }
       }
-    } catch (error) {
-      throw error
     }
   }
 
   async removeTestFromUser(userId, testIdToRemove) {
-    try {
-      const userDoc = await super.readOne('users', userId)
+    const userDoc = await super.readOne('users', userId)
 
-      if (!userDoc.exists()) {
-        return
-      }
-      const userData = userDoc.data()
-
-      if (userData.myTests[testIdToRemove]) {
-        delete userData.myTests[testIdToRemove]
-      }
-      if (userData.myAnswers[testIdToRemove]) {
-        delete userData.myAnswers[testIdToRemove]
-      }
-
-      await super.update('users', userId, userData)
-    } catch (error) {
-      throw error
+    if (!userDoc.exists()) {
+      return
     }
+    const userData = userDoc.data()
+
+    if (userData.myTests[testIdToRemove]) {
+      delete userData.myTests[testIdToRemove]
+    }
+    if (userData.myAnswers[testIdToRemove]) {
+      delete userData.myAnswers[testIdToRemove]
+    }
+
+    await super.update('users', userId, userData)
   }
   async updateLevel(uid, accessLevel) {
-    try {
-      return super.update(COLLECTION, uid, { accessLevel })
-    } catch (error) {
-      throw error
-    }
+    return super.update(COLLECTION, uid, { accessLevel })
   }
 }

--- a/src/features/auth/store/Auth.js
+++ b/src/features/auth/store/Auth.js
@@ -229,8 +229,6 @@ export default {
         // Store handles state management
         await authController.signOut()
         commit('SET_USER', null)
-      } catch (err) {
-        throw err
       } finally {
         commit('setLoading', false)
       }

--- a/src/features/super/store/User.js
+++ b/src/features/super/store/User.js
@@ -68,8 +68,6 @@ export default {
 
         await authController.deleteUserData(user.id)
         commit('REMOVE_USER', user.id)
-      } catch (e) {
-        throw e
       } finally {
         commit('setLoading', false)
       }

--- a/src/shared/views/CooperatorsView.vue
+++ b/src/shared/views/CooperatorsView.vue
@@ -249,15 +249,11 @@ const sendNotification = async ({
     accessLevel,
   })
 
-  try {
-    await store.dispatch('addNotification', {
-      userId,
-      notification,
-    })
-    return true
-  } catch (error) {
-    throw error
-  }
+  await store.dispatch('addNotification', {
+    userId,
+    notification,
+  })
+  return true
 }
 
 let showIntroComponent = ref(true)

--- a/src/ux/Heuristic/components/HeuristicsTable.vue
+++ b/src/ux/Heuristic/components/HeuristicsTable.vue
@@ -913,7 +913,6 @@ const editDescription = (desc) => {
   const btn = descBtn.value[itemSelect.value]
   if (btn && typeof btn.editSetup === 'function') {
     btn.editSetup(ind)
-  } else {
   }
 }
 

--- a/src/ux/UserTest/components/UnmoderatedTestAnalytics/SusAnalytics.vue
+++ b/src/ux/UserTest/components/UnmoderatedTestAnalytics/SusAnalytics.vue
@@ -410,7 +410,7 @@ const tasksArray = computed(() => {
       }))
   })
 })
-console.log(tasksArray.value)
+
 const analytics = computed(() => {
     const scores = tasksArray.value.map(r => r.susScore)
     return {

--- a/src/ux/UserTest/components/UnmoderatedTestAnalytics/TaskDetailsModal.vue
+++ b/src/ux/UserTest/components/UnmoderatedTestAnalytics/TaskDetailsModal.vue
@@ -417,14 +417,6 @@ const formatDuration = (duration) => {
   if (totalSeconds < 60) return `${totalSeconds}s`
   return `${minutes}m ${seconds}s`
 }
-
-watch(
-  () => props.userSession,
-  (newValue) => {
-    console.log('userSession updated:', newValue)
-  },
-  { immediate: true }, // also logs on first load
-)
 </script>
 
 <style scoped>

--- a/src/ux/UserTest/components/VideoCall.vue
+++ b/src/ux/UserTest/components/VideoCall.vue
@@ -1203,9 +1203,6 @@ const joinRoom = async () => {
         }
       } else {
         // Buffer candidate
-        console.log(
-          `Buffering candidate for ${senderId} (pending remote description)`,
-        )
         if (peers[senderId]) {
           peers[senderId].pendingCandidates.push(signal.candidate)
         }
@@ -1249,13 +1246,11 @@ const leaveRoom = () => {
 }
 
 const initLocalMedia = async () => {
-  console.log('initLocalMedia called')
   try {
     const stream = await navigator.mediaDevices.getUserMedia({
       video: true,
       audio: true,
     })
-    console.log('getUserMedia success', stream)
     localStream.value = stream
     if (localVideo.value) localVideo.value.srcObject = stream
     isCameraEnabled.value = true

--- a/src/ux/UserTest/components/VideoRecorder.vue
+++ b/src/ux/UserTest/components/VideoRecorder.vue
@@ -116,10 +116,6 @@ const startRecording = async () => {
 
     recording.value = true
     recordingTaskIndex.value = props.taskIndex // Store the current task index when recording starts
-    console.log(
-      'VideoRecorder: Recording started for task index:',
-      props.taskIndex,
-    )
     videoStream.value = await navigator.mediaDevices.getUserMedia({
       video: true,
     })
@@ -160,13 +156,6 @@ const startRecording = async () => {
         await uploadBytes(storageReference, videoBlob)
 
         recordedVideo.value = await getDownloadURL(storageReference)
-        console.log('webcam url =>', correctTaskIndex, recordedVideo.value)
-        console.log('Tasks array:', currentUserTestAnswer.value.tasks)
-        console.log('Tasks length:', currentUserTestAnswer.value.tasks?.length)
-        console.log(
-          'Task at index:',
-          currentUserTestAnswer.value.tasks?.[correctTaskIndex],
-        )
 
         await store.dispatch('updateTaskMediaUrl', {
           taskIndex: correctTaskIndex,

--- a/src/ux/UserTest/components/answers/EyeTrackingOverlay.vue
+++ b/src/ux/UserTest/components/answers/EyeTrackingOverlay.vue
@@ -137,13 +137,6 @@ async function resizeCanvas() {
 
   ctx.imageSmoothingEnabled = true
   ctx.imageSmoothingQuality = 'high'
-  console.log(
-    dpr,
-    rect.width,
-    rect.height,
-    canvas.value.width,
-    canvas.value.height,
-  )
 }
 
 onMounted(() => {
@@ -163,8 +156,6 @@ watch(
   (val) => {
     if (!val?.length) return
 
-    console.log('[Overlay] typeof:', typeof val, 'Array?', Array.isArray(val))
-
     const t0 = val[0].timestamp // timestamp inicial absoluto
     normalized = val.map((p) => ({
       x: (p.predicted_x ?? p.x) / (p.screen_width || 1),
@@ -173,12 +164,6 @@ watch(
     }))
 
     heatmapData = []
-    console.log(
-      '[Overlay] Normalização concluída:',
-      normalized.length,
-      'pontos. Último t =',
-      normalized.at(-1)?.t,
-    )
   },
   { immediate: true },
 )
@@ -202,29 +187,7 @@ watch(
     const nextIdx = normalized.findIndex((p) => p.t > currentMs)
     i = nextIdx === -1 ? normalized.length - 1 : Math.max(0, nextIdx - 1)
 
-    console.log(
-      '[Overlay] currentTime →',
-      time.toFixed(2),
-      's | currentMs =',
-      currentMs,
-      '| index =',
-      i,
-    )
-
-    // Loga o timestamp real do ponto
-    const currentPoint = props.predictedData[i]
-    if (currentPoint) {
-      console.log('[Overlay] ponto atual:', {
-        timestamp: currentPoint.timestamp,
-        x: currentPoint.predicted_x,
-        y: currentPoint.predicted_y,
-      })
-    } else {
-      console.warn('[Overlay] Nenhum ponto encontrado pra esse tempo!')
-    }
-
     const visiblePoints = normalized.slice(0, i + 1)
-    console.log('[Overlay] total de pontos desenhados:', visiblePoints.length)
 
     ctx.clearRect(0, 0, canvas.value.width, canvas.value.height)
 

--- a/src/ux/UserTest/components/dialogs/CreateInviteDialog.vue
+++ b/src/ux/UserTest/components/dialogs/CreateInviteDialog.vue
@@ -553,12 +553,6 @@ const saveInvitation = async () => {
 
     // Construct datetime string with proper validation
     const dateTimeString = `${dateValue}T${timeValue}:00`
-    console.log('Constructing datetime from:', {
-      originalDate: date.value,
-      formattedDate: dateValue,
-      hour: hour.value,
-      dateTimeString,
-    })
 
     const dateTime = new Date(dateTimeString)
 

--- a/src/ux/UserTest/components/sentimentAnalysis/AudioWave.vue
+++ b/src/ux/UserTest/components/sentimentAnalysis/AudioWave.vue
@@ -169,7 +169,6 @@ const playPause = () => {
 }
 
 function playSegment(start, end) {
-  console.log(`Playing segment from ${start} to ${end}`)
   if (!wave_surfer.value) return
   wave_surfer.value.play(start, end)
 }

--- a/src/ux/UserTest/components/sentimentAnalysis/UserModeratedSentiment.vue
+++ b/src/ux/UserTest/components/sentimentAnalysis/UserModeratedSentiment.vue
@@ -281,11 +281,6 @@ export default {
       }
     },
     async analyzeTimeStamp(task) {
-      console.log(
-        'Analyzing Timestamp..............................',
-        this.activeRegion.start,
-        this.activeRegion.end,
-      )
       this.overlay = { visible: true, text: 'Analyzing...' }
 
       try {
@@ -305,7 +300,6 @@ export default {
         }
 
         const data = response.data.data
-        console.log('Analysis Completed', data)
 
         const utterances_sentiment = data.utterances_sentiment
         const answerSentimentDocId = this.selectedAnswerSentiment.id

--- a/src/ux/UserTest/components/sessions/EyeTrackingStats.vue
+++ b/src/ux/UserTest/components/sessions/EyeTrackingStats.vue
@@ -217,8 +217,6 @@ watch(selectedView, (value) => emit('view-changed', value))
 
 onMounted(async () => {
   try {
-    console.log(calibrationConfig)
-
     const res = await axios.post(
       process.env.VUE_APP_EYE_LAB_BACKEND_URL + '/api/session/batch_predict',
       {

--- a/src/ux/UserTest/components/steps/ConsentStep.vue
+++ b/src/ux/UserTest/components/steps/ConsentStep.vue
@@ -2,7 +2,7 @@
   <ShowInfo :title="testTitle + ' - ' + 'Consent'">
     <template #content>
       <div class="test-content pa-md-4 rounded-xl">
-        <div class="rich-text mb-6 pa-md-4" v-html="consentText" />
+        <div class="rich-text mb-6 pa-md-4" v-html="sanitizedConsentText" />
         <v-row justify="center">
           <v-col cols="12" md="6">
             <v-text-field
@@ -63,8 +63,9 @@ color="primary" variant="flat" block :disabled="localConsentCompleted === null |
   </v-dialog>
 </template>
 <script setup>
+import DOMPurify from 'dompurify'
 import ShowInfo from '@/shared/components/ShowInfo.vue';
-import { ref, watch } from 'vue';
+import { ref, watch, computed } from 'vue';
 const props = defineProps({
   testTitle: String,
   consentText: String,
@@ -76,6 +77,7 @@ const emit = defineEmits(['update:fullNameModel', 'update:consentCompletedModel'
 const localFullName = ref(props.fullNameModel);
 const localConsentCompleted = ref(null); // Always start with no selection
 const showDeclineModal = ref(false);
+const sanitizedConsentText = computed(() => DOMPurify.sanitize(props.consentText || ''));
 
 watch(() => props.fullNameModel, val => { localFullName.value = val; });
 // Removed watcher for consentCompletedModel to prevent pre-selection

--- a/src/ux/UserTest/components/steps/FinishStep.vue
+++ b/src/ux/UserTest/components/steps/FinishStep.vue
@@ -12,7 +12,7 @@
           {{ finalMessage }}!
         </h3>
 
-        <div class="text-body-1 mt-2 text-grey-darken-1" v-html="congratulations"></div>
+        <div class="text-body-1 mt-2 text-grey-darken-1" v-html="sanitizedCongratulations"></div>
 
         <p class="text-body-1 mt-6 text-grey-darken-1">
           {{ submitMessage }}
@@ -34,6 +34,8 @@
   </ShowInfo>
 </template>
 <script setup>
+import DOMPurify from 'dompurify'
+import { computed } from 'vue'
 import ShowInfo from '@/shared/components/ShowInfo.vue';
 const props = defineProps({
     finalMessage: String,
@@ -42,4 +44,5 @@ const props = defineProps({
     submitBtn: String
 });
 const emit = defineEmits(['submit']);
+const sanitizedCongratulations = computed(() => DOMPurify.sanitize(props.congratulations || ''));
 </script>

--- a/src/ux/UserTest/components/steps/TaskStep.vue
+++ b/src/ux/UserTest/components/steps/TaskStep.vue
@@ -6,7 +6,7 @@
         <template v-if="stage === 1">
           <div
             class="rich-text mb-4 task-description"
-            v-html="task?.taskDescription || taskDescription"
+            v-html="sanitizedTaskDescription"
           />
 
           <!-- Task Preview Information -->
@@ -177,7 +177,7 @@
                   </div>
                   <div
                     class="rich-text text-body-1 task-description"
-                    v-html="task?.taskDescription || taskDescription"
+                    v-html="sanitizedTaskDescription"
                   />
                 </v-col>
 
@@ -469,6 +469,7 @@
 
 <script setup>
 import { ref, watch, nextTick, computed, onBeforeUnmount } from 'vue'
+import DOMPurify from 'dompurify'
 import ShowInfo from '@/shared/components/ShowInfo.vue'
 import TipButton from '@/ux/UserTest/components/TipButton.vue'
 import AudioRecorder from '@/ux/UserTest/components/AudioRecorder.vue'
@@ -506,6 +507,9 @@ const props = defineProps({
   remoteStream: MediaStream, // props that receive the remote video stream in case of moderated test
   shouldRecordModerator: Boolean, // props that indicate whether to record the moderator's video
 })
+
+const sanitizedTaskDescription = computed(() => DOMPurify.sanitize(props.task?.taskDescription || props.taskDescription || ''))
+
 const emit = defineEmits([
   'done',
   'couldNotFinish',

--- a/src/ux/UserTest/components/steps/TaskStep.vue
+++ b/src/ux/UserTest/components/steps/TaskStep.vue
@@ -768,7 +768,6 @@ function handleShowPostForm(userCompleted) {
   if (taskStartTime) {
     finalTime = Math.round(Date.now() - taskStartTime)
     pendingFinalTime.value = finalTime
-    console.log('Tiempo detenido en:', finalTime, 'segundos')
     emit('timer-stopped', finalTime, props.taskIndex)
   }
 

--- a/src/ux/UserTest/components/steps/WelcomeStep.vue
+++ b/src/ux/UserTest/components/steps/WelcomeStep.vue
@@ -8,7 +8,7 @@
         <div
           v-if="welcomeMessage"
           class="text-body-1 mb-4 text-grey-darken-3"
-          v-html="welcomeMessage"
+          v-html="sanitizedWelcomeMessage"
         ></div>
         <p v-else class="text-body-1 mb-4 text-grey-darken-3">
           {{ $t('UserTestView.WelcomeStep.description') }}
@@ -92,6 +92,8 @@
 </template>
 
 <script setup>
+import DOMPurify from 'dompurify'
+import { computed } from 'vue'
 import ShowInfo from '@/shared/components/ShowInfo.vue'
 import { VStepperVertical } from 'vuetify/labs/VStepperVertical'
 import { useDisplay } from 'vuetify'
@@ -102,6 +104,7 @@ const props = defineProps({
 })
 const emit = defineEmits(['start'])
 const { smAndDown } = useDisplay()
+const sanitizedWelcomeMessage = computed(() => DOMPurify.sanitize(props.welcomeMessage || ''))
 </script>
 
 <style scoped>

--- a/src/ux/UserTest/components/task-steps/TaskPreview.vue
+++ b/src/ux/UserTest/components/task-steps/TaskPreview.vue
@@ -24,10 +24,7 @@
                 </div>
                 <div
                   class="description-content"
-                  v-html="
-                    (task && task.taskDescription) ||
-                    $t('CreateTask.preview.noDescription')
-                  "
+                  v-html="sanitizedTaskDescription"
                 ></div>
               </div>
 
@@ -164,6 +161,7 @@
 </template>
 
 <script setup>
+import DOMPurify from 'dompurify'
 import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
@@ -178,6 +176,11 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['validate'])
+
+const sanitizedTaskDescription = computed(() => {
+  const raw = (props.task && props.task.taskDescription) || t('CreateTask.preview.noDescription')
+  return DOMPurify.sanitize(raw)
+})
 
 const recordingFeatures = computed(() => {
   if (!props.task) return []

--- a/src/ux/UserTest/components/transcription/ExportPanel.vue
+++ b/src/ux/UserTest/components/transcription/ExportPanel.vue
@@ -223,7 +223,7 @@
               </div>
 
               <!-- eslint-disable-next-line vue/no-v-html -->
-              <div class="mt-4" v-html="pdfSummaryHtml"></div>
+              <div class="mt-4" v-html="sanitizedPdfSummaryHtml"></div>
 
               <div v-for="(run, i) in previewRuns" :key="run.id" class="mt-6">
                 <h3 class="text-subtitle-2 m-0">
@@ -259,6 +259,7 @@
 
 <script setup>
 import { ref, watch, computed } from 'vue'
+import DOMPurify from 'dompurify'
 import jsPDF from 'jspdf'
 import autoTable from 'jspdf-autotable'
 import { QuillEditor } from '@vueup/vue-quill'
@@ -291,6 +292,7 @@ const pdfMeta = ref({
 const pdfSummaryHtml = ref('<p>Add an executive summary here…</p>')
 
 const controller = new TranscriptionController()
+const sanitizedPdfSummaryHtml = computed(() => DOMPurify.sanitize(pdfSummaryHtml.value || ''))
 
 const formatIcon = computed(
   () =>

--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -1032,10 +1032,6 @@ const callTimerSave = () => {
 }
 
 function handleTaskFinish(userCompleted) {
-  const currentTask = localTestAnswer.tasks[taskIndex.value]
-  if (currentTask) {
-    console.log('Estado actual de la tarea antes de finalizar:', currentTask) // eslint-disable-line no-console
-  }
   completeStep(taskIndex.value, 'tasks', userCompleted)
   callTimerSave()
 }
@@ -1051,10 +1047,7 @@ const startTimer = () => {
 
 const handleTimerStopped = (elapsedTime, idx) => {
   // idx is passed from TaskStep, always use it
-  console.log('handleTimerStopped llamado con:', { elapsedTime, idx }) // eslint-disable-line no-console
-
   if (!localTestAnswer.tasks) {
-    console.error('localTestAnswer.tasks no está definido') // eslint-disable-line no-console
     return
   }
 
@@ -1125,7 +1118,6 @@ const completeStep = async (id, type, userCompleted = true) => {
         taskIndex.value = id + 1
         startTimer()
       } else {
-        console.log('All tasks completed, moving to post-test') // eslint-disable-line no-console
         globalIndex.value = 5
       }
       if (userCompleted) {

--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -797,18 +797,14 @@ const attachMediaToTasks = (answer, mediaUrls) => {
     for (const type in medias) {
       if (type === 'sizes') {
         const sizes = medias[type]
-        console.log(`Found sizes for Task ${taskIndex}:`, sizes)
         if (sizes.screenRecordURL) {
           task.screenSize = sizes.screenRecordURL
-          console.log('Set screenSize:', task.screenSize)
         }
         if (sizes.audioRecordURL) {
           task.audioSize = sizes.audioRecordURL
-          console.log('Set audioSize:', task.audioSize)
         }
         if (sizes.webcamRecordURL) {
           task.webcamSize = sizes.webcamRecordURL
-          console.log('Set webcamSize:', task.webcamSize)
         }
         continue
       }
@@ -961,7 +957,6 @@ const completeStep = (id, type, userCompleted = true) => {
         if (allTasksCompleted.value) {
           taskIndex.value = id + 1 // to help saving methods
           globalIndex.value = hasEyeTracking.value ? 6 : 5 // PostTest
-        } else {
         }
       }
       //TODO: Show proper toast not the following one

--- a/src/ux/accessibility/store/Assessment.js
+++ b/src/ux/accessibility/store/Assessment.js
@@ -581,77 +581,65 @@ const actions = {
 
   // Reset assessment
   async resetAssessment({ commit, rootState }, { testId }) {
-    try {
-      const userId = rootState.auth.user?.uid
-      if (userId && testId) {
-        await assessmentController.deleteAssessment(userId, testId)
-      }
-      commit('RESET_ASSESSMENT')
-    } catch (error) {
-      throw error
+    const userId = rootState.auth.user?.uid
+    if (userId && testId) {
+      await assessmentController.deleteAssessment(userId, testId)
     }
+    commit('RESET_ASSESSMENT')
   },
 
   // Save assessment to Firestore
   async saveAssessment({ state }, { userId, testId, testType = 'manual' }) {
-    try {
-      if (!userId) throw new Error('User ID is required')
+    if (!userId) throw new Error('User ID is required')
 
-      // Convert rule assessments to array format
-      const assessmentData = Object.entries(state.ruleAssessments).map(
-        ([ruleId, assessment]) => ({
-          ruleId,
-          ...assessment,
-          // Add any additional fields needed from the rule data
-          ...(state.wcagData && {
-            // Include rule metadata for easier querying
-            ruleTitle: findRuleTitle(ruleId, state.wcagData),
-            principle: findPrincipleForRule(ruleId, state.wcagData),
-            guideline: findGuidelineForRule(ruleId, state.wcogData),
-          }),
+    // Convert rule assessments to array format
+    const assessmentData = Object.entries(state.ruleAssessments).map(
+      ([ruleId, assessment]) => ({
+        ruleId,
+        ...assessment,
+        // Add any additional fields needed from the rule data
+        ...(state.wcagData && {
+          // Include rule metadata for easier querying
+          ruleTitle: findRuleTitle(ruleId, state.wcagData),
+          principle: findPrincipleForRule(ruleId, state.wcagData),
+          guideline: findGuidelineForRule(ruleId, state.wcogData),
         }),
-      )
+      }),
+    )
 
-      await assessmentController.saveAssessment(
-        userId,
-        testId,
-        testType,
-        assessmentData,
-      )
-      return { success: true }
-    } catch (error) {
-      throw error
-    }
+    await assessmentController.saveAssessment(
+      userId,
+      testId,
+      testType,
+      assessmentData,
+    )
+    return { success: true }
   },
 
   // Load assessment from Firestore
   async loadAssessment({ commit }, { userId, testId }) {
-    try {
-      if (!userId) throw new Error('User ID is required')
+    if (!userId) throw new Error('User ID is required')
 
-      const assessment = await assessmentController.getAssessment(
-        userId,
-        testId,
-      )
-      if (!assessment) return null
+    const assessment = await assessmentController.getAssessment(
+      userId,
+      testId,
+    )
+    if (!assessment) return null
 
-      // Update the store with loaded assessment data
-      const ruleAssessments = {}
-      const completedRules = []
+    // Update the store with loaded assessment data
+    const ruleAssessments = {}
+    const completedRules = []
 
-      assessment.assessmentData.forEach((item) => {
-        const { ruleId, status, severity, notes } = item
-        ruleAssessments[ruleId] = { status, severity, notes }
-        if (status) completedRules.push(ruleId)
-      })
+    assessment.assessmentData.forEach((item) => {
+      const { ruleId, status, severity, notes } = item
+      ruleAssessments[ruleId] = { status, severity, notes }
+      if (status) completedRules.push(ruleId)
+    })
 
-      commit('SET_RULE_ASSESSMENTS', ruleAssessments)
-      commit('SET_COMPLETED_RULES', completedRules)
+    commit('SET_RULE_ASSESSMENTS', ruleAssessments)
+    commit('SET_COMPLETED_RULES', completedRules)
 
-      return assessment
-    } catch (error) {
-      throw error
-    }
+    return assessment
   },
 
   // Update a single rule assessment
@@ -659,55 +647,47 @@ const actions = {
     { commit, state },
     { userId, testId, ruleId, assessment },
   ) {
-    try {
-      if (!userId) throw new Error('User ID is required')
+    if (!userId) throw new Error('User ID is required')
 
-      // First update local state
-      commit('UPDATE_RULE_ASSESSMENT', { ruleId, assessment })
+    // First update local state
+    commit('UPDATE_RULE_ASSESSMENT', { ruleId, assessment })
 
-      // Then update in Firestore
-      await assessmentController.updateRuleAssessment(userId, testId, {
-        ruleId,
-        ...assessment,
-        // Add any additional metadata
-        ...(state.wcagData && {
-          ruleTitle: findRuleTitle(ruleId, state.wcagData),
-          principle: findPrincipleForRule(ruleId, state.wcagData),
-          guideline: findGuidelineForRule(ruleId, state.wcogData),
-        }),
-      })
+    // Then update in Firestore
+    await assessmentController.updateRuleAssessment(userId, testId, {
+      ruleId,
+      ...assessment,
+      // Add any additional metadata
+      ...(state.wcagData && {
+        ruleTitle: findRuleTitle(ruleId, state.wcagData),
+        principle: findPrincipleForRule(ruleId, state.wcagData),
+        guideline: findGuidelineForRule(ruleId, state.wcogData),
+      }),
+    })
 
-      return { success: true }
-    } catch (error) {
-      throw error
-    }
+    return { success: true }
   },
 
   // Add a new action to fetch configData from Firestore
   async fetchConfigData({ commit, state, rootState }, testId) {
-    try {
-      // Check if configData is already available in the store
-      if (state.configuration && state.configuration.testId === testId) {
-        return state.configuration
-      }
-
-      // Fetch userId from Auth module
-      const userId = rootState.Auth.user?.id
-      if (!userId) throw new Error('User not authenticated')
-
-      // Fetch configData from Firestore (replace with actual Firestore fetch logic)
-      const configData = await assessmentController.getConfigData(
-        userId,
-        testId,
-      )
-
-      // Commit the fetched configData to the store
-      commit('SET_CONFIGURATION', configData)
-
-      return configData
-    } catch (error) {
-      throw error
+    // Check if configData is already available in the store
+    if (state.configuration && state.configuration.testId === testId) {
+      return state.configuration
     }
+
+    // Fetch userId from Auth module
+    const userId = rootState.Auth.user?.id
+    if (!userId) throw new Error('User not authenticated')
+
+    // Fetch configData from Firestore (replace with actual Firestore fetch logic)
+    const configData = await assessmentController.getConfigData(
+      userId,
+      testId,
+    )
+
+    // Commit the fetched configData to the store
+    commit('SET_CONFIGURATION', configData)
+
+    return configData
   },
 }
 

--- a/tests/unit/HeuristicQuestionAnswer.spec.js
+++ b/tests/unit/HeuristicQuestionAnswer.spec.js
@@ -1,0 +1,143 @@
+import HeuristicQuestionAnswer from '@/ux/Heuristic/models/HeuristicQuestionAnswer'
+
+describe('HeuristicQuestionAnswer', () => {
+  describe('constructor', () => {
+    it('sets all fields from provided data', () => {
+      const data = {
+        heuristicId: 1,
+        heuristicAnswer: { text: 'Good', value: 4 },
+        heuristicComment: 'Looks fine',
+        answerImageUrl: 'https://example.com/img.png',
+      }
+
+      const answer = new HeuristicQuestionAnswer(data)
+
+      expect(answer.heuristicId).toBe(1)
+      expect(answer.heuristicAnswer).toEqual({ text: 'Good', value: 4 })
+      expect(answer.heuristicComment).toBe('Looks fine')
+      expect(answer.answerImageUrl).toBe('https://example.com/img.png')
+    })
+
+    it('defaults heuristicAnswer to empty object when undefined', () => {
+      const answer = new HeuristicQuestionAnswer({})
+
+      expect(answer.heuristicAnswer).toEqual({})
+    })
+
+    it('handles no arguments (empty constructor)', () => {
+      const answer = new HeuristicQuestionAnswer()
+
+      expect(answer.heuristicId).toBeUndefined()
+      expect(answer.heuristicAnswer).toEqual({})
+      expect(answer.heuristicComment).toBeUndefined()
+      expect(answer.answerImageUrl).toBeUndefined()
+    })
+  })
+
+  describe('toFirestore', () => {
+    it('returns correct Firestore shape', () => {
+      const answer = new HeuristicQuestionAnswer({
+        heuristicId: 5,
+        heuristicAnswer: { text: 'Bad', value: 1 },
+        heuristicComment: 'Poor contrast',
+        answerImageUrl: 'https://example.com/screenshot.png',
+      })
+
+      expect(answer.toFirestore()).toEqual({
+        heuristicId: 5,
+        heuristicAnswer: { text: 'Bad', value: 1 },
+        heuristicComment: 'Poor contrast',
+        answerImageUrl: 'https://example.com/screenshot.png',
+      })
+    })
+
+    it('defaults answerImageUrl to empty string when falsy', () => {
+      const answer = new HeuristicQuestionAnswer({ heuristicId: 1 })
+      const result = answer.toFirestore()
+
+      expect(result.answerImageUrl).toBe('')
+    })
+
+    it('preserves answerImageUrl when provided', () => {
+      const answer = new HeuristicQuestionAnswer({
+        answerImageUrl: 'https://img.example.com/a.png',
+      })
+
+      expect(answer.toFirestore().answerImageUrl).toBe('https://img.example.com/a.png')
+    })
+  })
+
+  describe('toHeuristicQuestionAnswer (static factory)', () => {
+    const testOptions = [
+      { text: 'Very Bad', value: 0 },
+      { text: 'Bad', value: 1 },
+      { text: 'Neutral', value: 2 },
+      { text: 'Good', value: 3 },
+      { text: 'Very Good', value: 4 },
+    ]
+
+    it('keeps heuristicAnswer as-is when it already has a text property', () => {
+      const data = {
+        heuristicId: 10,
+        heuristicAnswer: { text: 'Custom', value: 99 },
+        heuristicComment: 'Already formatted',
+      }
+
+      const result = HeuristicQuestionAnswer.toHeuristicQuestionAnswer(data, testOptions)
+
+      expect(result).toBeInstanceOf(HeuristicQuestionAnswer)
+      expect(result.heuristicAnswer).toEqual({ text: 'Custom', value: 99 })
+    })
+
+    it('converts a numeric heuristicAnswer to object using testOptions', () => {
+      const data = {
+        heuristicId: 10,
+        heuristicAnswer: 3,
+        heuristicComment: 'Nice',
+      }
+
+      const result = HeuristicQuestionAnswer.toHeuristicQuestionAnswer(data, testOptions)
+
+      expect(result).toBeInstanceOf(HeuristicQuestionAnswer)
+      expect(result.heuristicAnswer).toEqual({ text: 'Good', value: 3 })
+    })
+
+    it('sets text to empty string when numeric value is not found in testOptions', () => {
+      const data = {
+        heuristicId: 10,
+        heuristicAnswer: 999,
+      }
+
+      const result = HeuristicQuestionAnswer.toHeuristicQuestionAnswer(data, testOptions)
+
+      expect(result.heuristicAnswer).toEqual({ text: '', value: 999 })
+    })
+
+    it('spreads remaining data fields onto the instance', () => {
+      const data = {
+        heuristicId: 7,
+        heuristicAnswer: 0,
+        heuristicComment: 'Terrible',
+        answerImageUrl: 'https://img.test/x.png',
+      }
+
+      const result = HeuristicQuestionAnswer.toHeuristicQuestionAnswer(data, testOptions)
+
+      expect(result.heuristicId).toBe(7)
+      expect(result.heuristicComment).toBe('Terrible')
+      expect(result.answerImageUrl).toBe('https://img.test/x.png')
+      expect(result.heuristicAnswer).toEqual({ text: 'Very Bad', value: 0 })
+    })
+
+    it('handles null heuristicAnswer gracefully', () => {
+      const data = {
+        heuristicId: 1,
+        heuristicAnswer: null,
+      }
+
+      const result = HeuristicQuestionAnswer.toHeuristicQuestionAnswer(data, testOptions)
+
+      expect(result.heuristicAnswer).toEqual({ text: '', value: null })
+    })
+  })
+})

--- a/tests/unit/StudyAnswer.spec.js
+++ b/tests/unit/StudyAnswer.spec.js
@@ -1,0 +1,37 @@
+import StudyAnswer from '@/shared/models/StudyAnswer'
+
+describe('StudyAnswer', () => {
+  describe('constructor', () => {
+    it('sets type from provided data', () => {
+      const answer = new StudyAnswer({ type: 'HEURISTIC' })
+      expect(answer.type).toBe('HEURISTIC')
+    })
+
+    it('handles missing type', () => {
+      const answer = new StudyAnswer({})
+      expect(answer.type).toBeUndefined()
+    })
+
+    it('handles no arguments', () => {
+      const answer = new StudyAnswer()
+      expect(answer.type).toBeUndefined()
+    })
+  })
+
+  describe('toFirestore', () => {
+    it('returns correct shape with type', () => {
+      const answer = new StudyAnswer({ type: 'USER' })
+      expect(answer.toFirestore()).toEqual({ type: 'USER' })
+    })
+
+    it('defaults type to empty string when null', () => {
+      const answer = new StudyAnswer({ type: null })
+      expect(answer.toFirestore()).toEqual({ type: '' })
+    })
+
+    it('defaults type to empty string when undefined', () => {
+      const answer = new StudyAnswer({})
+      expect(answer.toFirestore()).toEqual({ type: '' })
+    })
+  })
+})

--- a/tests/unit/UserStudyEvaluatorAnswer.spec.js
+++ b/tests/unit/UserStudyEvaluatorAnswer.spec.js
@@ -1,0 +1,181 @@
+jest.mock('@/ux/UserTest/models/NasaTlxAnswer', () => ({
+  NasaTlxAnswer: class {
+    constructor(data) { Object.assign(this, data) }
+    toFirestore() { return { ...this } }
+  }
+}))
+
+jest.mock('@/ux/UserTest/models/TamAnswer', () => ({
+  TamAnswer: class {
+    constructor(data) { Object.assign(this, data) }
+    toFirestore() { return { ...this } }
+  }
+}))
+
+jest.mock('@/ux/UserTest/models/SartAnswer', () => {
+  return {
+    __esModule: true,
+    default: class SartAnswer {
+      constructor(data) { Object.assign(this, data || {}) }
+      toFirestore() { return { ...this } }
+    }
+  }
+})
+
+import UserStudyEvaluatorAnswer from '@/ux/UserTest/models/UserStudyEvaluatorAnswer'
+import TaskAnswer from '@/ux/UserTest/models/TaskAnswer'
+
+describe('UserStudyEvaluatorAnswer', () => {
+  describe('constructor', () => {
+    it('sets all fields from provided data', () => {
+      const data = {
+        preTestAnswer: [{ q: 1, a: 'yes' }],
+        consent: 'I agree',
+        postTestAnswer: [{ q: 2, a: 'no' }],
+        preTestCompleted: true,
+        consentCompleted: true,
+        fullName: 'Jane Doe',
+        postTestCompleted: true,
+        tasks: {},
+        progress: 75,
+        total: 4,
+        submitted: true,
+        userDocId: 'user-123',
+        lastUpdate: '2026-01-01',
+        invited: true,
+        hidden: false,
+      }
+
+      const answer = new UserStudyEvaluatorAnswer(data)
+
+      expect(answer.preTestAnswer).toEqual([{ q: 1, a: 'yes' }])
+      expect(answer.consent).toBe('I agree')
+      expect(answer.fullName).toBe('Jane Doe')
+      expect(answer.consentCompleted).toBe(true)
+      expect(answer.submitted).toBe(true)
+      expect(answer.total).toBe(4)
+      expect(answer.progress).toBe(75)
+      expect(answer.userDocId).toBe('user-123')
+      expect(answer.hidden).toBe(false)
+    })
+
+    it('applies defaults when no arguments provided', () => {
+      const answer = new UserStudyEvaluatorAnswer()
+
+      expect(answer.preTestAnswer).toEqual([])
+      expect(answer.consent).toBe('')
+      expect(answer.postTestAnswer).toEqual([])
+      expect(answer.preTestCompleted).toBe(false)
+      expect(answer.consentCompleted).toBe(false)
+      expect(answer.fullName).toBe('')
+      expect(answer.postTestCompleted).toBe(false)
+      expect(answer.tasks).toEqual({})
+      expect(answer.progress).toBeNull()
+      expect(answer.total).toBe(0)
+      expect(answer.submitted).toBe(false)
+      expect(answer.userDocId).toBeNull()
+      expect(answer.lastUpdate).toBeNull()
+      expect(answer.invited).toBe(false)
+      expect(answer.hidden).toBe(false)
+      expect(answer.sessionNotes).toEqual([])
+    })
+  })
+
+  describe('toFirestore', () => {
+    it('returns correct shape for empty instance', () => {
+      const answer = new UserStudyEvaluatorAnswer()
+      const result = answer.toFirestore()
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          preTestAnswer: [],
+          consent: '',
+          postTestAnswer: [],
+          preTestCompleted: false,
+          consentCompleted: false,
+          fullName: '',
+          postTestCompleted: false,
+          tasks: {},
+          progress: null,
+          total: 0,
+          submitted: false,
+          userDocId: null,
+          lastUpdate: null,
+          invited: false,
+          hidden: false,
+          sessionNotes: [],
+        }),
+      )
+    })
+
+    it('serializes tasks using TaskAnswer.toFirestore', () => {
+      const taskData = {
+        taskId: 'task-1',
+        taskAnswer: 'My answer',
+        completed: true,
+      }
+
+      const answer = new UserStudyEvaluatorAnswer({
+        tasks: { 0: new TaskAnswer(taskData) },
+      })
+
+      const result = answer.toFirestore()
+
+      expect(result.tasks).toBeDefined()
+      expect(result.tasks['0']).toEqual(
+        expect.objectContaining({
+          taskId: 'task-1',
+          taskAnswer: 'My answer',
+          completed: true,
+        }),
+      )
+    })
+
+    it('wraps plain task objects in TaskAnswer before serializing', () => {
+      const answer = new UserStudyEvaluatorAnswer({
+        tasks: { 0: { taskId: 'task-2', completed: false } },
+      })
+
+      const result = answer.toFirestore()
+
+      expect(result.tasks['0']).toEqual(
+        expect.objectContaining({
+          taskId: 'task-2',
+          completed: false,
+        }),
+      )
+    })
+  })
+
+  describe('toModel (static factory)', () => {
+    it('creates instance from raw data', () => {
+      const raw = {
+        fullName: 'John',
+        consentCompleted: true,
+        tasks: {
+          0: { taskId: 'task-1', completed: true },
+          1: { taskId: 'task-2', completed: false },
+        },
+      }
+
+      const result = UserStudyEvaluatorAnswer.toModel(raw)
+
+      expect(result).toBeInstanceOf(UserStudyEvaluatorAnswer)
+      expect(result.fullName).toBe('John')
+      expect(result.consentCompleted).toBe(true)
+    })
+
+    it('converts task entries via TaskAnswer.toModel', () => {
+      const raw = {
+        tasks: {
+          0: { taskId: 'task-1', taskAnswer: 'hello' },
+        },
+      }
+
+      const result = UserStudyEvaluatorAnswer.toModel(raw)
+
+      expect(result.tasks['0']).toBeInstanceOf(TaskAnswer)
+      expect(result.tasks['0'].taskId).toBe('task-1')
+    })
+  })
+})


### PR DESCRIPTION
## Description

The production codebase contains ~30 `console.log` statements, 19 pointless `catch(e) { throw e }` blocks, and 3 empty `else {}` blocks spread across 22 files.

##Fixes:
#1835 

These debug leftovers:
- Leak internal data to the browser console in production
- Hurt performance (especially `console.log` calls inside animation loops like `EyeTrackingOverlay.vue`)
- Add noise to stack traces (`catch(e) { throw e }` is a no-op)
- Include a top-level `console.log(tasksArray.value)` in `SusAnalytics.vue` that executes on every component render

## Affected Files

**console.log (~30 instances):** `SusAnalytics.vue`, `TaskDetailsModal.vue`, `EyeTrackingOverlay.vue`, `VideoCall.vue`, `VideoRecorder.vue`, `UserTestView.vue`, `UserModeratedSentiment.vue`, `AudioWave.vue`, `EyeTrackingStats.vue`, `TaskStep.vue`, `CreateInviteDialog.vue`, `ModeratedTestView.vue`

**catch(e) { throw e } (19 instances):** `StudyController.js`, `Assessment.js`, `UserController.js`, `AuthController.js`, `useProfile.js`, `FirebaseFirestoreRepository.js`, `CooperatorsView.vue`, `Auth.js`, `User.js`

**Empty else {} (3 instances):** `UserTestView.vue`, `HeuristicsTable.vue`, `UserController.js`

## Acceptance Criteria

- [ ] All `console.log` statements removed from `src/`
- [ ] All `catch(e) { throw e }` blocks simplified (remove the try/catch entirely)
- [ ] All empty `else {}` blocks removed
- [ ] Existing tests still pass

##Photo proofs that all tests are working
<img width="1180" height="282" alt="Screenshot 2026-03-08 at 1 52 20 AM" src="https://github.com/user-attachments/assets/412f7eaf-c43d-488e-a163-b48d96c90ca1" />
