### PR TITLE
test: enable mobile viewport testing for Pixel 5 and iPhone 12

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,7 +1,7 @@
 // @ts-check
-const { defineConfig, devices } = require('@playwright/test');
+const { defineConfig, devices } = require('@playwright/test')
 
-const devBaseUrl = 'http://localhost:8080';
+const devBaseUrl = 'http://localhost:8080'
 
 module.exports = defineConfig({
   testDir: './e2e',
@@ -55,9 +55,23 @@ module.exports = defineConfig({
     },
     {
       name: 'webkit',
-      use: { 
-        ...devices['Desktop Safari'], 
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
+
+    /* Test against mobile viewports */
+    {
+      name: 'Mobile Chrome',
+      use: {
+        ...devices['Pixel 5'],
+      },
+    },
+    {
+      name: 'Mobile Safari',
+      use: {
+        ...devices['iPhone 12'],
       },
     },
   ],
-});
+})


### PR DESCRIPTION
Fixes #1838

Added Mobile Chrome (Pixel 5) and Mobile Safari (iPhone 12) viewport projects to playwright.config.js. The mobile configs were already present but commented out in the .ts config — this enables them in the active .js config so e2e tests also run against mobile screen sizes.

No test logic was changed, just the config file :)

<img width="1470" height="809" alt="Screenshot 2026-03-08 at 11 07 38 AM" src="https://github.com/user-attachments/assets/82790ee4-ee75-4603-abea-4dc2a87bd9ee" />
