### PR TITLE
fix(e2e): replace hardcoded URLs with Playwright baseURL configuration

### DIFF
--- a/e2e/createHeuristicTest.spec.js
+++ b/e2e/createHeuristicTest.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 // --- Reusable login function ---
 const logIn = async (page) => {
   await test.step('Navigate to signin page', async () => {
-    await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
+    await page.goto('/signin', { waitUntil: 'networkidle' });
   });
 
   await test.step('Fill login credentials', async () => {

--- a/e2e/ruxailabtest.spec.js
+++ b/e2e/ruxailabtest.spec.js
@@ -55,7 +55,7 @@ test.describe('Link Page Tests', () => {
     try {
 
       await test.step('Navigate to signin page', async () => {
-        await page.goto('http://localhost:8080/signin', {
+        await page.goto('/signin', {
           waitUntil: 'networkidle',
           timeout: 45000
         });

--- a/e2e/signIntest.spec.js
+++ b/e2e/signIntest.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require('@playwright/test');
 
 // 🔄 Reusable login function
 const logIn = async (page, email, password) => {
-  await page.goto('http://localhost:8080/signin');
+  await page.goto('/signin');
   await page.getByLabel('Email').fill(email);
   await page.getByLabel('Password', { exact: true }).fill(password);
   await page.getByTestId('sign-in-button').click();
@@ -22,7 +22,7 @@ test.describe('Sign In Workflow', () => {
     try {
       // 1. Initial access to Sign In page
       await test.step('Navigate to Sign In page', async () => {
-        await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
+        await page.goto('/signin', { waitUntil: 'networkidle' });
         await expect(page.locator('#app')).toBeVisible();
         await expect(page).toHaveTitle(/RUXAILAB/);
       });
@@ -82,7 +82,7 @@ test.describe('Sign In Workflow', () => {
 
   test('Password recovery only sends reset request', async ({ page }) => {
     // 1) Go to Sign In page
-    await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
+    await page.goto('/signin', { waitUntil: 'networkidle' });
     await expect(page.locator('#app')).toBeVisible();
 
     // 2) Click "Forgot Password" link (exact text from UI)
@@ -116,7 +116,7 @@ test.describe('Sign In Workflow', () => {
 
   test('Validates password strength requirements during sign in', async ({ page }) => {
     await test.step('Navigate to Sign In page', async () => {
-      await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
+      await page.goto('/signin', { waitUntil: 'networkidle' });
       await expect(page.locator('#app')).toBeVisible();
     });
 

--- a/e2e/template_testing.spec.ts
+++ b/e2e/template_testing.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('should create a template and verify it appears in the list', async ({ page }) => {
-  await page.goto('http://localhost:8080/');
+  await page.goto('/');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');
@@ -27,7 +27,7 @@ test('should create a template and verify it appears in the list', async ({ page
 });
 
 test('should show error when creating a template with duplicate name', async ({ page }) => {
-  await page.goto('http://localhost:8080/');
+  await page.goto('/');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');
@@ -46,7 +46,7 @@ test('should show error when creating a template with duplicate name', async ({ 
 });
 
 test('should validate required fields when creating a template', async ({ page }) => {
-  await page.goto('http://localhost:8080/');
+  await page.goto('/');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');
@@ -64,7 +64,7 @@ test('should validate required fields when creating a template', async ({ page }
 });
 
 test('should filter templates by name', async ({ page }) => {
-  await page.goto('http://localhost:8080/');
+  await page.goto('/');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');
@@ -77,7 +77,7 @@ test('should filter templates by name', async ({ page }) => {
 });
 
 test('should not allow saving template with empty description', async ({ page }) => {
-  await page.goto('http://localhost:8080/');
+  await page.goto('/');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,8 +1,6 @@
 // @ts-check
 const { defineConfig, devices } = require('@playwright/test');
 
-const devBaseUrl = 'http://localhost:8080';
-
 module.exports = defineConfig({
   testDir: './e2e',
   /* Run tests in files in parallel */
@@ -24,7 +22,7 @@ module.exports = defineConfig({
   outputDir: './playwright/output',
 
   use: {
-    baseURL: devBaseUrl,
+    baseURL: process.env.BASE_URL || 'http://localhost:8080',
     ...devices['Desktop Chrome'],
     /* Collect trace when retrying the failed test */
     trace: 'on-first-retry',


### PR DESCRIPTION

## Summary
This PR replaces hardcoded URLs in Playwright tests with relative paths using the Playwright baseURL configuration.

## Changes
- Added baseURL configuration in Playwright config
- Replaced hardcoded URLs like http://localhost:8080 with relative paths
- Tests now use `/signin`, `/`, etc.

## Benefits
- Tests can run against different environments
- Improved maintainability
- Cleaner Playwright configuration

