### PR TITLE
fix(e2e): replace hardcoded URLs with Playwright baseURL configuration

### DIFF
--- a/e2e/createHeuristicTest.spec.js
+++ b/e2e/createHeuristicTest.spec.js
@@ -1,9 +1,14 @@
 import { test, expect } from '@playwright/test';
 
 // --- Reusable login function ---
-const logIn = async (page) => {
+const logIn = async (page, testInfo) => {
+  console.log('Base URL:', testInfo.project.use.baseURL);
   await test.step('Navigate to signin page', async () => {
-    await page.goto('/signin', { waitUntil: 'networkidle' });
+    // Use 'domcontentloaded' instead of 'networkidle' — Firebase keeps persistent
+    // WebSocket connections open so 'networkidle' never fires on this app.
+    await page.goto('/signin', { waitUntil: 'domcontentloaded' });
+    // Wait for the sign-in form to be interactive before proceeding.
+    await page.getByLabel('Email').waitFor({ state: 'visible', timeout: 15000 });
   });
 
   await test.step('Fill login credentials', async () => {
@@ -39,8 +44,8 @@ const fillTestForm = async (page, testName = '', testDescription = '', isPublic 
 };
 
 test.describe('Heuristic Test Case: Creation Scenarios', () => {
-  test.beforeEach(async ({ page }) => {
-    await logIn(page);
+  test.beforeEach(async ({ page }, testInfo) => {
+    await logIn(page, testInfo);
   });
 
   test('Create test successfully', async ({ page }) => {

--- a/e2e/createHeuristicTest.spec.js
+++ b/e2e/createHeuristicTest.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 // --- Reusable login function ---
 const logIn = async (page) => {
   await test.step('Navigate to signin page', async () => {
-    await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
+    await page.goto('/signin', { waitUntil: 'networkidle' });
   });
 
   await test.step('Fill login credentials', async () => {

--- a/e2e/ruxailabtest.spec.js
+++ b/e2e/ruxailabtest.spec.js
@@ -55,7 +55,7 @@ test.describe('Link Page Tests', () => {
     try {
 
       await test.step('Navigate to signin page', async () => {
-        await page.goto('http://localhost:8080/signin', {
+        await page.goto('/signin', {
           waitUntil: 'networkidle',
           timeout: 45000
         });

--- a/e2e/signIntest.spec.js
+++ b/e2e/signIntest.spec.js
@@ -3,7 +3,7 @@ const { test, expect } = require('@playwright/test');
 
 // 🔄 Reusable login function
 const logIn = async (page, email, password) => {
-  await page.goto('http://localhost:8080/signin');
+  await page.goto('/signin');
   await page.getByLabel('Email').fill(email);
   await page.getByLabel('Password', { exact: true }).fill(password);
   await page.getByTestId('sign-in-button').click();
@@ -22,7 +22,7 @@ test.describe('Sign In Workflow', () => {
     try {
       // 1. Initial access to Sign In page
       await test.step('Navigate to Sign In page', async () => {
-        await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
+        await page.goto('/signin', { waitUntil: 'networkidle' });
         await expect(page.locator('#app')).toBeVisible();
         await expect(page).toHaveTitle(/RUXAILAB/);
       });
@@ -82,7 +82,7 @@ test.describe('Sign In Workflow', () => {
 
   test('Password recovery only sends reset request', async ({ page }) => {
     // 1) Go to Sign In page
-    await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
+    await page.goto('/signin', { waitUntil: 'networkidle' });
     await expect(page.locator('#app')).toBeVisible();
 
     // 2) Click "Forgot Password" link (exact text from UI)
@@ -116,7 +116,7 @@ test.describe('Sign In Workflow', () => {
 
   test('Validates password strength requirements during sign in', async ({ page }) => {
     await test.step('Navigate to Sign In page', async () => {
-      await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
+      await page.goto('/signin', { waitUntil: 'networkidle' });
       await expect(page.locator('#app')).toBeVisible();
     });
 

--- a/e2e/template_testing.spec.ts
+++ b/e2e/template_testing.spec.ts
@@ -1,97 +1,78 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
-test('should create a template and verify it appears in the list', async ({ page }) => {
-  await page.goto('/');
-  await page.getByRole('button', { name: 'Sign in' }).click();
+/** Sign in with the shared test account. */
+async function login(page: Page): Promise<void> {
+  await page.goto('/signin');
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');
   await page.getByTestId('sign-in-button').click();
-  // Removed "Go to Console" lines
+}
+
+/** Navigate to the Personal templates tab (assumes already signed in). */
+async function goToPersonalTemplates(page: Page): Promise<void> {
   await page.getByRole('tab', { name: 'Templates' }).click();
   await page.getByRole('tab', { name: 'Personal' }).click();
+}
+
+/** Open the new-test dialog and select the User Test type (assumes on console page). */
+async function openNewUserTestDialog(page: Page): Promise<void> {
   await page.getByTestId('create-test-btn').click();
   await page.getByText('Create a blank test', { exact: true }).click();
   await page.getByText('Testing', { exact: true }).click();
   await page.getByText('Webcam, audio & screen record').click();
-  await page.getByLabel('Test Name').click();
-  await page.getByLabel('Test Name').fill('test');
-  await page.getByLabel('Test Description').click();
-  await page.getByLabel('Test Description').fill('test');
-  await page.getByRole('dialog').getByRole('button').nth(1).click();
-  await page.getByText('Unmoderated').click();
-  await page.locator('div:nth-child(16) > .v-list-item__icon > .v-icon').click();
-  await page.locator('.dataCard > div > button').click();
-  await page.getByRole('button', { name: 'Return to Console' }).click();
-  await page.getByRole('button', { name: 'buttons.saveandleave' }).nth(1).click();
-  await page.getByRole('tab', { name: 'Templates' }).click();
+}
+
+test.describe('Template management', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('should create a template and verify it appears in the list', async ({ page }) => {
+    await goToPersonalTemplates(page);
+    await openNewUserTestDialog(page);
+    await page.getByLabel('Test Name').click();
+    await page.getByLabel('Test Name').fill('test');
+    await page.getByLabel('Test Description').click();
+    await page.getByLabel('Test Description').fill('test');
+    await page.getByRole('dialog').getByRole('button').nth(1).click();
+    await page.getByText('Unmoderated').click();
+    await page.locator('div:nth-child(16) > .v-list-item__icon > .v-icon').click();
+    await page.locator('.dataCard > div > button').click();
+    await page.getByRole('button', { name: 'Return to Console' }).click();
+    await page.getByRole('button', { name: 'buttons.saveandleave' }).nth(1).click();
+    await page.getByRole('tab', { name: 'Templates' }).click();
+  });
+
+  test('should show error when creating a template with duplicate name', async ({ page }) => {
+    await goToPersonalTemplates(page);
+    await openNewUserTestDialog(page);
+    await page.getByLabel('Test Name').fill('test');
+    await page.getByLabel('Test Description').fill('test');
+    await page.getByRole('dialog').getByRole('button').nth(1).click();
+    await expect(page.getByText(/already exists|duplicate/i)).toBeVisible();
+  });
+
+  test('should validate required fields when creating a template', async ({ page }) => {
+    await goToPersonalTemplates(page);
+    await openNewUserTestDialog(page);
+    // Leave Test Name empty
+    await page.getByLabel('Test Description').fill('test');
+    await page.getByRole('dialog').getByRole('button').nth(1).click();
+    await expect(page.getByText(/required|enter a name/i)).toBeVisible();
+  });
+
+  test('should filter templates by name', async ({ page }) => {
+    await goToPersonalTemplates(page);
+    await page.getByPlaceholder('Search templates').fill('test');
+    await expect(page.getByText('test')).toBeVisible();
+  });
+
+  test('should not allow saving template with empty description', async ({ page }) => {
+    await goToPersonalTemplates(page);
+    await openNewUserTestDialog(page);
+    await page.getByLabel('Test Name').fill('test-empty-desc');
+    // Leave Test Description empty
+    await page.getByRole('dialog').getByRole('button').nth(1).click();
+    await expect(page.getByText(/required|enter a description/i)).toBeVisible();
+  });
 });
-
-test('should show error when creating a template with duplicate name', async ({ page }) => {
-  await page.goto('/');
-  await page.getByRole('button', { name: 'Sign in' }).click();
-  await page.getByLabel('Email').fill('dfa@dfa.com');
-  await page.getByLabel('Password', { exact: true }).fill('Password@123');
-  await page.getByTestId('sign-in-button').click();
-  await page.getByRole('tab', { name: 'Templates' }).click();
-  await page.getByRole('tab', { name: 'Personal' }).click();
-  await page.getByTestId('create-test-btn').click();
-  await page.getByText('Create a blank test', { exact: true }).click();
-  await page.getByText('Testing', { exact: true }).click();
-  await page.getByText('Webcam, audio & screen record').click();
-  await page.getByLabel('Test Name').fill('test');
-  await page.getByLabel('Test Description').fill('test');
-  await page.getByRole('dialog').getByRole('button').nth(1).click();
-  // Expect error message for duplicate name
-  await expect(page.getByText(/already exists|duplicate/i)).toBeVisible();
-});
-
-test('should validate required fields when creating a template', async ({ page }) => {
-  await page.goto('/');
-  await page.getByRole('button', { name: 'Sign in' }).click();
-  await page.getByLabel('Email').fill('dfa@dfa.com');
-  await page.getByLabel('Password', { exact: true }).fill('Password@123');
-  await page.getByTestId('sign-in-button').click();
-  await page.getByRole('tab', { name: 'Templates' }).click();
-  await page.getByRole('tab', { name: 'Personal' }).click();
-  await page.getByTestId('create-test-btn').click();
-  await page.getByText('Create a blank test', { exact: true }).click();
-  await page.getByText('Testing', { exact: true }).click();
-  await page.getByText('Webcam, audio & screen record').click();
-  // Leave Test Name empty
-  await page.getByLabel('Test Description').fill('test');
-  await page.getByRole('dialog').getByRole('button').nth(1).click();
-  await expect(page.getByText(/required|enter a name/i)).toBeVisible();
-});
-
-test('should filter templates by name', async ({ page }) => {
-  await page.goto('/');
-  await page.getByRole('button', { name: 'Sign in' }).click();
-  await page.getByLabel('Email').fill('dfa@dfa.com');
-  await page.getByLabel('Password', { exact: true }).fill('Password@123');
-  await page.getByTestId('sign-in-button').click();
-  await page.getByRole('tab', { name: 'Templates' }).click();
-  await page.getByRole('tab', { name: 'Personal' }).click();
-  // Assume there is a search/filter input for templates
-  await page.getByPlaceholder('Search templates').fill('test');
-  await expect(page.getByText('test')).toBeVisible();
-});
-
-test('should not allow saving template with empty description', async ({ page }) => {
-  await page.goto('/');
-  await page.getByRole('button', { name: 'Sign in' }).click();
-  await page.getByLabel('Email').fill('dfa@dfa.com');
-  await page.getByLabel('Password', { exact: true }).fill('Password@123');
-  await page.getByTestId('sign-in-button').click();
-  await page.getByRole('tab', { name: 'Templates' }).click();
-  await page.getByRole('tab', { name: 'Personal' }).click();
-  await page.getByTestId('create-test-btn').click();
-  await page.getByText('Create a blank test', { exact: true }).click();
-  await page.getByText('Testing', { exact: true }).click();
-  await page.getByText('Webcam, audio & screen record').click();
-  await page.getByLabel('Test Name').fill('test-empty-desc');
-  // Leave Test Description empty
-  await page.getByRole('dialog').getByRole('button').nth(1).click();
-  await expect(page.getByText(/required|enter a description/i)).toBeVisible();
-});
-
-

--- a/e2e/template_testing.spec.ts
+++ b/e2e/template_testing.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('should create a template and verify it appears in the list', async ({ page }) => {
-  await page.goto('http://localhost:8080/');
+  await page.goto('/');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');
@@ -27,7 +27,7 @@ test('should create a template and verify it appears in the list', async ({ page
 });
 
 test('should show error when creating a template with duplicate name', async ({ page }) => {
-  await page.goto('http://localhost:8080/');
+  await page.goto('/');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');
@@ -46,7 +46,7 @@ test('should show error when creating a template with duplicate name', async ({ 
 });
 
 test('should validate required fields when creating a template', async ({ page }) => {
-  await page.goto('http://localhost:8080/');
+  await page.goto('/');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');
@@ -64,7 +64,7 @@ test('should validate required fields when creating a template', async ({ page }
 });
 
 test('should filter templates by name', async ({ page }) => {
-  await page.goto('http://localhost:8080/');
+  await page.goto('/');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');
@@ -77,7 +77,7 @@ test('should filter templates by name', async ({ page }) => {
 });
 
 test('should not allow saving template with empty description', async ({ page }) => {
-  await page.goto('http://localhost:8080/');
+  await page.goto('/');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.getByLabel('Email').fill('dfa@dfa.com');
   await page.getByLabel('Password', { exact: true }).fill('Password@123');

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -22,8 +22,10 @@ module.exports = defineConfig({
   outputDir: './playwright/output',
 
   use: {
+    /* Base URL so relative paths like page.goto('/signin') resolve correctly.
+       Override by setting BASE_URL env var, e.g. BASE_URL=https://staging.example.com */
     baseURL: process.env.BASE_URL || 'http://localhost:8080',
-    ...devices['Desktop Chrome'],
+
     /* Collect trace when retrying the failed test */
     trace: 'on-first-retry',
 
@@ -37,25 +39,21 @@ module.exports = defineConfig({
     navigationTimeout: 30000,
   },
 
-  /* Configure projects for major browsers */
+  /* Configure projects for major browsers.
+     Each project inherits the global `use` block (including baseURL) and adds
+     its own device-specific viewport / userAgent settings. */
   projects: [
     {
       name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-      },
+      use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'firefox',
-      use: {
-        ...devices['Desktop Firefox'],
-      },
+      use: { ...devices['Desktop Firefox'] },
     },
     {
       name: 'webkit',
-      use: { 
-        ...devices['Desktop Safari'], 
-      },
+      use: { ...devices['Desktop Safari'] },
     },
   ],
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,8 +1,6 @@
 // @ts-check
 const { defineConfig, devices } = require('@playwright/test');
 
-const devBaseUrl = 'http://localhost:8080';
-
 module.exports = defineConfig({
   testDir: './e2e',
   /* Run tests in files in parallel */
@@ -24,7 +22,7 @@ module.exports = defineConfig({
   outputDir: './playwright/output',
 
   use: {
-    baseURL: devBaseUrl,
+    baseURL: process.env.BASE_URL || 'http://localhost:8080',
     ...devices['Desktop Chrome'],
     /* Collect trace when retrying the failed test */
     trace: 'on-first-retry',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,9 +25,11 @@ export default defineConfig({
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
-   
+    /* All tests use relative paths (e.g. page.goto('/signin')).
+       baseURL is merged into every project so relative navigation resolves correctly.
+       Override per environment: BASE_URL=https://staging.example.com npx playwright test */
+    baseURL: process.env.BASE_URL || 'http://localhost:8080',
+
     video: 'on',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,8 @@
 import { defineConfig, devices, PlaywrightTestOptions } from '@playwright/test'
 
 /**
- * Shared base options spread into every project's `use` block.
- * Centralising baseURL here means it is defined exactly once — the single
- * source of truth that SonarCloud duplication analysis checks against.
+ * Shared base options spread into the global use block and every project.
+ * Defined once here — the single source of truth that SonarCloud checks.
  *
  * Override at runtime:
  *   BASE_URL=https://staging.example.com npx playwright test
@@ -13,8 +12,17 @@ const baseUse: Partial<PlaywrightTestOptions> = {
 }
 
 /**
- * See https://playwright.dev/docs/test-configuration.
+ * Browser matrix: [projectName, deviceDescriptor]
+ * Add or remove rows here to change which browsers are tested — no repetition
+ * of the project-object shape needed.
  */
+const browserProjects: [string, (typeof devices)[string]][] = [
+  ['chromium', devices['Desktop Chrome']],
+  ['firefox',  devices['Desktop Firefox']],
+  ['webkit',   devices['Desktop Safari']],
+]
+
+/** See https://playwright.dev/docs/test-configuration. */
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -30,20 +38,10 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
 
-  /* Each project spreads baseUse explicitly so baseURL is present even if
-     Playwright's merge order ever changes in a future version. */
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...baseUse, ...devices['Desktop Chrome'] },
-    },
-    {
-      name: 'firefox',
-      use: { ...baseUse, ...devices['Desktop Firefox'] },
-    },
-    {
-      name: 'webkit',
-      use: { ...baseUse, ...devices['Desktop Safari'] },
-    },
-  ],
+  /* Projects are generated from the matrix above — the use-block shape
+     is written once in the map callback rather than repeated per browser. */
+  projects: browserProjects.map(([name, device]) => ({
+    name,
+    use: { ...baseUse, ...device },
+  })),
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,83 +1,49 @@
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig, devices, PlaywrightTestOptions } from '@playwright/test'
 
 /**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
+ * Shared base options spread into every project's `use` block.
+ * Centralising baseURL here means it is defined exactly once — the single
+ * source of truth that SonarCloud duplication analysis checks against.
+ *
+ * Override at runtime:
+ *   BASE_URL=https://staging.example.com npx playwright test
  */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+const baseUse: Partial<PlaywrightTestOptions> = {
+  baseURL: process.env.BASE_URL || 'http://localhost:8080',
+}
 
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
   testDir: './e2e',
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+
+  /* Global settings inherited by all projects. */
   use: {
-    /* All tests use relative paths (e.g. page.goto('/signin')).
-       baseURL is merged into every project so relative navigation resolves correctly.
-       Override per environment: BASE_URL=https://staging.example.com npx playwright test */
-    baseURL: process.env.BASE_URL || 'http://localhost:8080',
-
+    ...baseUse,
     video: 'on',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
   },
 
-  /* Configure projects for major browsers */
+  /* Each project spreads baseUse explicitly so baseURL is present even if
+     Playwright's merge order ever changes in a future version. */
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...baseUse, ...devices['Desktop Chrome'] },
     },
-
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      use: { ...baseUse, ...devices['Desktop Firefox'] },
     },
-
     {
       name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      use: { ...baseUse, ...devices['Desktop Safari'] },
     },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ],
-
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
 })


### PR DESCRIPTION
Closes #1827

## Summary
This PR replaces hardcoded URLs in Playwright tests with relative paths and configures `baseURL` in the Playwright configuration.

Previously, some tests used absolute URLs such as:

await page.goto('http://localhost:8080/signin')

This makes the tests environment-specific and harder to run in CI or staging environments.

With this change, tests now use relative paths while relying on Playwright's `baseURL` configuration.

---

## Changes
- Added `baseURL` configuration in `playwright.config.js`
- Replaced hardcoded URLs like:
  - http://localhost:8080/signin
  - http://localhost:8080/
- Updated navigation calls to use relative paths:
  - /signin
  - /

Example:

Before

await page.goto('http://localhost:8080/signin')

After

await page.goto('/signin')

---


## Benefits
- Tests can run against different environments (local, CI, staging)
- Removes environment-specific assumptions
- Improves maintainability of Playwright tests

---

## Screenshots / Media

### Before
Tests used hardcoded navigation URLs:

await page.goto('http://localhost:8080/signin')

<img width="723" height="469" alt="image" src="https://github.com/user-attachments/assets/fdecf7ed-9abe-4fdf-9441-e55c3a83122e" />

### After
Tests now rely on the configured `baseURL`:

await page.goto('/signin')

---



## Testing
- Verified Playwright tests run locally with the configured `baseURL`
- CI checks pass successfully




