### PR TITLE
fix(ux): improve mobile tab accessibility and transitions on edit pages

### DIFF
--- a/src/ux/CardSorting/views/EditTestView.vue
+++ b/src/ux/CardSorting/views/EditTestView.vue
@@ -10,30 +10,73 @@
       <ButtonSave :visible="change" @click="save" />
 
       <div>
-        <VTabs bg-color="transparent" color="#FCA326" class="pb-0 mb-0">
-          <VTab @click="index = 0">
+        <v-tabs
+          v-model="index"
+          bg-color="transparent"
+          color="white"
+          class="mb-4 pill-tabs"
+          show-arrows
+          density="compact"
+          slider-color="transparent"
+        >
+          <v-tab
+            :value="0"
+            :class="{ 'active-pill': index === 0 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
             {{ $t('CardSorting.test') }}
-          </VTab>
-          <VTab @click="index = 1">
+          </v-tab>
+          <v-tab
+            :value="1"
+            :class="{ 'active-pill': index === 1 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
             {{ $t('ModeratedTest.consentForm') }}
-          </VTab>
-          <VTab @click="index = 2">
+          </v-tab>
+          <v-tab
+            :value="2"
+            :class="{ 'active-pill': index === 2 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
             {{ $t('ModeratedTest.preTest') }}
-          </VTab>
-          <VTab @click="index = 3">
+          </v-tab>
+          <v-tab
+            :value="3"
+            :class="{ 'active-pill': index === 3 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
             {{ $t('CardSorting.categories') }}
-          </VTab>
-          <VTab @click="index = 4">
+          </v-tab>
+          <v-tab
+            :value="4"
+            :class="{ 'active-pill': index === 4 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
             {{ $t('CardSorting.cards') }}
-          </VTab>
-          <VTab @click="index = 5">
+          </v-tab>
+          <v-tab
+            :value="5"
+            :class="{ 'active-pill': index === 5 }"
+            rounded="pill"
+            variant="text"
+          >
             {{ $t('ModeratedTest.postTest') }}
-          </VTab>
-        </VTabs>
+          </v-tab>
+        </v-tabs>
 
-        <VCol cols="12">
+        <v-window v-model="index" class="mt-4">
           <!-- TEST -->
-          <div v-if="index === 0">
+          <v-window-item :value="0">
             <TestConfigForm
               :welcome="welcomeMessage"
               :final-message="finalMessage"
@@ -42,54 +85,58 @@
               "
               @update:final-message="((finalMessage = $event), (change = true))"
             />
-          </div>
+          </v-window-item>
 
           <!-- CONSENT FORM -->
-          <div v-if="index === 1" rounded="xxl">
+          <v-window-item :value="1">
             <TextareaForm
               v-model="consent"
               :title="$t('ModeratedTest.consentForm')"
               :subtitle="$t('ModeratedTest.consentFormSubtitle')"
               @update:value="((consent = $event), (change = true))"
             />
-          </div>
+          </v-window-item>
 
           <!-- PRE-TEST -->
-          <v-card v-if="index === 2" rounded="xxl">
-            <UserVariables
-              type="pre-test"
-              @change="change = true"
-              @update="store.dispatch('setPreTest', $event)"
-            />
-          </v-card>
+          <v-window-item :value="2">
+            <v-card rounded="xxl">
+              <UserVariables
+                type="pre-test"
+                @change="change = true"
+                @update="store.dispatch('setPreTest', $event)"
+              />
+            </v-card>
+          </v-window-item>
 
           <!-- CATEGORIES -->
-          <div v-if="index === 3" rounded="xxl">
+          <v-window-item :value="3">
             <CategoriesEditCardSorting
               @change="change = true"
               @categories="categories = $event"
               @options="optionsCategories = $event"
             />
-          </div>
+          </v-window-item>
 
           <!-- CARDS -->
-          <div v-if="index === 4" rounded="xxl">
+          <v-window-item :value="4">
             <CardsEditCardSorting
               @change="change = true"
               @cards="cards = $event"
               @options="optionsCards = $event"
             />
-          </div>
+          </v-window-item>
 
           <!-- POS-TEST -->
-          <v-card v-if="index === 5" rounded="xxl">
-            <UserVariables
-              type="post-test"
-              @change="change = true"
-              @update="store.dispatch('setPostTest', $event)"
-            />
-          </v-card>
-        </VCol>
+          <v-window-item :value="5">
+            <v-card rounded="xxl">
+              <UserVariables
+                type="post-test"
+                @change="change = true"
+                @update="store.dispatch('setPostTest', $event)"
+              />
+            </v-card>
+          </v-window-item>
+        </v-window>
       </div>
     </v-container>
   </PageWrapper>
@@ -215,3 +262,14 @@ onMounted(() => {
   getPostTest()
 })
 </script>
+
+<style scoped>
+.active-pill {
+  background-color: #fca326 !important;
+  color: white !important;
+}
+
+.pill-tabs :deep(.v-slide-group__content) {
+  padding: 4px;
+}
+</style>

--- a/src/ux/CardSorting/views/EditTestView.vue
+++ b/src/ux/CardSorting/views/EditTestView.vue
@@ -12,63 +12,65 @@
       <div>
         <v-tabs
           v-model="index"
-          bg-color="transparent"
-          color="white"
-          class="mb-4 pill-tabs"
+          bg-color="#F5F5F5"
+          color="black"
+          class="mb-6 segmented-control"
           show-arrows
           density="compact"
           slider-color="transparent"
+          rounded="pill"
         >
           <v-tab
             :value="0"
-            :class="{ 'active-pill': index === 0 }"
+            :class="{ 'active-segment': index === 0 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('CardSorting.test') }}
           </v-tab>
           <v-tab
             :value="1"
-            :class="{ 'active-pill': index === 1 }"
+            :class="{ 'active-segment': index === 1 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('ModeratedTest.consentForm') }}
           </v-tab>
           <v-tab
             :value="2"
-            :class="{ 'active-pill': index === 2 }"
+            :class="{ 'active-segment': index === 2 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('ModeratedTest.preTest') }}
           </v-tab>
           <v-tab
             :value="3"
-            :class="{ 'active-pill': index === 3 }"
+            :class="{ 'active-segment': index === 3 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('CardSorting.categories') }}
           </v-tab>
           <v-tab
             :value="4"
-            :class="{ 'active-pill': index === 4 }"
+            :class="{ 'active-segment': index === 4 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('CardSorting.cards') }}
           </v-tab>
           <v-tab
             :value="5"
-            :class="{ 'active-pill': index === 5 }"
+            :class="{ 'active-segment': index === 5 }"
             rounded="pill"
             variant="text"
+            class="segmented-tab"
           >
             {{ $t('ModeratedTest.postTest') }}
           </v-tab>
@@ -264,12 +266,30 @@ onMounted(() => {
 </script>
 
 <style scoped>
-.active-pill {
-  background-color: #fca326 !important;
-  color: white !important;
+.active-segment {
+  background-color: white !important;
+  color: #212121 !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12) !important;
 }
 
-.pill-tabs :deep(.v-slide-group__content) {
-  padding: 4px;
+.segmented-control {
+  padding: 4px !important;
+  height: auto !important;
+  width: fit-content;
+  max-width: 100%;
+}
+
+.segmented-tab {
+  text-transform: none !important;
+  font-weight: 500 !important;
+  letter-spacing: normal !important;
+  color: #757575 !important;
+  min-height: 36px !important;
+  height: 36px !important;
+  transition: all 0.2s ease-in-out !important;
+}
+
+.segmented-control :deep(.v-slide-group__content) {
+  padding: 0 !important;
 }
 </style>

--- a/src/ux/Heuristic/components/HeuristicsAnalytics.vue
+++ b/src/ux/Heuristic/components/HeuristicsAnalytics.vue
@@ -156,76 +156,88 @@
                     </v-col>
                   </v-row>
                   <v-row v-else class="ma-0 pa-0">
-                    <v-card width="100%" height="560px">
+                    <v-card width="100%" height="560px" flat>
                       <v-tabs
                         v-model="ind"
                         bg-color="transparent"
-                        color="grey-darken-2"
-                        class="mt-2"
+                        color="white"
+                        class="mt-2 pill-tabs"
                         align-tabs="center"
+                        show-arrows
+                        density="compact"
+                        slider-color="transparent"
                       >
                         <v-tab
-                          class="tab-text"
+                          :value="0"
+                          :class="{ 'active-pill': ind === 0 }"
+                          rounded="pill"
+                          variant="text"
+                          class="mr-2"
                           style="text-transform: none !important"
-                          @click="ind = 0"
                         >
                           Comments
                         </v-tab>
                         <v-tab
-                          class="tab-text"
+                          :value="1"
+                          :class="{ 'active-pill': ind === 1 }"
+                          rounded="pill"
+                          variant="text"
                           style="text-transform: none !important"
-                          @click="ind = 1"
                         >
                           Chart
                         </v-tab>
                       </v-tabs>
-                      <v-col v-if="ind == 1">
-                        <v-row justify="center">
-                          <v-col cols="10">
-                            <BarChart
-                              v-if="questionGraph"
-                              :labels="questionGraph.label"
-                              :data="questionGraph.data"
-                              legend="Quantity"
-                            />
-                          </v-col>
-                        </v-row>
-                      </v-col>
-                      <v-col v-if="ind == 0">
-                        <v-row
-                          class="list-scroll"
-                          style="height: 430px"
-                          justify="center"
-                        >
-                          <v-col cols="10">
-                            <v-timeline density="compact" align="start">
-                              <v-timeline-item
-                                v-for="(result, index) in itemsHeuristic"
-                                :key="index"
-                                fill-dot
-                                dot-color="#fca326"
-                                icon="mdi-message-reply-text"
-                              >
-                                <v-card
-                                  v-if="result[questionSelect].heuristicComment"
-                                  class="elevation-2"
+
+                      <v-window v-model="ind">
+                        <v-window-item :value="1">
+                          <v-row justify="center" class="mt-4">
+                            <v-col cols="10">
+                              <BarChart
+                                v-if="questionGraph"
+                                :labels="questionGraph.label"
+                                :data="questionGraph.data"
+                                legend="Quantity"
+                              />
+                            </v-col>
+                          </v-row>
+                        </v-window-item>
+
+                        <v-window-item :value="0">
+                          <v-row
+                            class="list-scroll mt-4"
+                            style="height: 430px"
+                            justify="center"
+                          >
+                            <v-col cols="10">
+                              <v-timeline density="compact" align="start">
+                                <v-timeline-item
+                                  v-for="(result, index) in itemsHeuristic"
+                                  :key="index"
+                                  fill-dot
+                                  dot-color="#fca326"
+                                  icon="mdi-message-reply-text"
                                 >
-                                  <v-card-text>
-                                    {{
-                                      result[questionSelect].heuristicComment
-                                    }}
-                                  </v-card-text>
-                                  <img
-                                    v-if="result[questionSelect].answerImageUrl"
-                                    height="200"
-                                    :src="result[questionSelect].answerImageUrl"
-                                  />
-                                </v-card>
-                              </v-timeline-item>
-                            </v-timeline>
-                          </v-col>
-                        </v-row>
-                      </v-col>
+                                  <v-card
+                                    v-if="result[questionSelect].heuristicComment"
+                                    class="elevation-2"
+                                  >
+                                    <v-card-text>
+                                      {{
+                                        result[questionSelect].heuristicComment
+                                      }}
+                                    </v-card-text>
+                                    <v-img
+                                      v-if="result[questionSelect].answerImageUrl"
+                                      height="200"
+                                      :src="result[questionSelect].answerImageUrl"
+                                    />
+                                  </v-card>
+                                </v-timeline-item>
+                              </v-timeline>
+                            </v-col>
+                          </v-row>
+                        </v-window-item>
+                      </v-window>
                     </v-card>
                   </v-row>
                 </v-card>
@@ -392,5 +404,14 @@ const goToCoops = () => {
 /* Handle on hover */
 .list-scroll::-webkit-scrollbar-thumb:hover {
   background: #fca326;
+}
+
+.active-pill {
+  background-color: #fca326 !important;
+  color: white !important;
+}
+
+.pill-tabs :deep(.v-slide-group__content) {
+  padding: 4px;
 }
 </style>

--- a/src/ux/Heuristic/components/HeuristicsAnalytics.vue
+++ b/src/ux/Heuristic/components/HeuristicsAnalytics.vue
@@ -159,29 +159,31 @@
                     <v-card width="100%" height="560px" flat>
                       <v-tabs
                         v-model="ind"
-                        bg-color="transparent"
-                        color="white"
-                        class="mt-2 pill-tabs"
+                        bg-color="#F5F5F5"
+                        color="black"
+                        class="mt-2 mb-4 segmented-control"
                         align-tabs="center"
                         show-arrows
                         density="compact"
                         slider-color="transparent"
+                        rounded="pill"
                       >
                         <v-tab
                           :value="0"
-                          :class="{ 'active-pill': ind === 0 }"
+                          :class="{ 'active-segment': ind === 0 }"
                           rounded="pill"
                           variant="text"
-                          class="mr-2"
+                          class="segmented-tab"
                           style="text-transform: none !important"
                         >
                           Comments
                         </v-tab>
                         <v-tab
                           :value="1"
-                          :class="{ 'active-pill': ind === 1 }"
+                          :class="{ 'active-segment': ind === 1 }"
                           rounded="pill"
                           variant="text"
+                          class="segmented-tab"
                           style="text-transform: none !important"
                         >
                           Chart
@@ -406,12 +408,30 @@ const goToCoops = () => {
   background: #fca326;
 }
 
-.active-pill {
-  background-color: #fca326 !important;
-  color: white !important;
+.active-segment {
+  background-color: white !important;
+  color: #212121 !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12) !important;
 }
 
-.pill-tabs :deep(.v-slide-group__content) {
-  padding: 4px;
+.segmented-control {
+  padding: 4px !important;
+  height: auto !important;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.segmented-tab {
+  text-transform: none !important;
+  font-weight: 500 !important;
+  letter-spacing: normal !important;
+  color: #757575 !important;
+  min-height: 32px !important;
+  height: 32px !important;
+  transition: all 0.2s ease-in-out !important;
+}
+
+.segmented-control :deep(.v-slide-group__content) {
+  padding: 0 !important;
 }
 </style>

--- a/src/ux/Heuristic/views/EditTest.vue
+++ b/src/ux/Heuristic/views/EditTest.vue
@@ -10,62 +10,76 @@
       <ButtonSave :visible="!isTemplate && change" @click="save" />
 
       <div>
-        <!-- Desktop Tabs -->
         <v-tabs
-          v-if="!isMobile"
           v-model="index"
           bg-color="transparent"
-          color="#FCA326"
-          class="pb-0 mb-0"
+          color="white"
+          class="mb-4 pill-tabs"
+          show-arrows
+          density="compact"
+          slider-color="transparent"
         >
-          <v-tab>{{ $t('HeuristicsEditTest.titles.heuristics') }}</v-tab>
-          <v-tab>{{ $t('HeuristicsEditTest.titles.options') }}</v-tab>
-          <v-tab>{{ $t('HeuristicsEditTest.titles.weights') }}</v-tab>
-          <v-tab v-if="showSettingsTab">{{
-            $t('HeuristicsEditTest.titles.settings')
-          }}</v-tab>
+          <v-tab
+            :value="0"
+            :class="{ 'active-pill': index === 0 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
+            {{ $t('HeuristicsEditTest.titles.heuristics') }}
+          </v-tab>
+          <v-tab
+            :value="1"
+            :class="{ 'active-pill': index === 1 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
+            {{ $t('HeuristicsEditTest.titles.options') }}
+          </v-tab>
+          <v-tab
+            :value="2"
+            :class="{ 'active-pill': index === 2 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
+            {{ $t('HeuristicsEditTest.titles.weights') }}
+          </v-tab>
+          <v-tab
+            v-if="showSettingsTab"
+            :value="3"
+            :class="{ 'active-pill': index === 3 }"
+            rounded="pill"
+            variant="text"
+          >
+            {{ $t('HeuristicsEditTest.titles.settings') }}
+          </v-tab>
         </v-tabs>
 
-        <!-- Mobile Select Dropdown -->
-        <v-select
-          v-else
-          v-model="index"
-          :items="tabItems"
-          variant="outlined"
-          density="compact"
-          class="mobile-tab-select"
-          prepend-inner-icon="mdi-menu"
-          hide-details
-        >
-          <template #selection="{ item }">
-            <div class="d-flex align-center justify-space-between w-100">
-              <span class="font-weight-medium">{{ item.title }}</span>
-              <!-- <v-icon size="small">mdi-chevron-down</v-icon> -->
-            </div>
-          </template>
-        </v-select>
-
-        <div class="mt-4">
-          <HeuristicsTable
-            v-if="index == 0"
-            :is-template="isTemplate"
-            @change="change = true"
-          />
-          <OptionsTable
-            v-if="index == 1"
-            :is-template="isTemplate"
-            @change="change = true"
-          />
-          <WeightTable
-            v-if="index == 2"
-            :is-template="isTemplate"
-            @change="change = true"
-          />
-          <HeuristicsSettings
-            v-if="showSettingsTab && index == 3"
-            :is-template="isTemplate"
-          />
-        </div>
+        <v-window v-model="index" class="mt-4">
+          <v-window-item :value="0">
+            <HeuristicsTable
+              :is-template="isTemplate"
+              @change="change = true"
+            />
+          </v-window-item>
+          <v-window-item :value="1">
+            <OptionsTable
+              :is-template="isTemplate"
+              @change="change = true"
+            />
+          </v-window-item>
+          <v-window-item :value="2">
+            <WeightTable
+              :is-template="isTemplate"
+              @change="change = true"
+            />
+          </v-window-item>
+          <v-window-item v-if="showSettingsTab" :value="3">
+            <HeuristicsSettings :is-template="isTemplate" />
+          </v-window-item>
+        </v-window>
       </div>
     </v-container>
   </PageWrapper>
@@ -166,16 +180,12 @@ const save = async () => {
 </script>
 
 <style scoped>
-/* Mobile styles */
-.mobile-tab-select {
-  margin-bottom: 16px;
+.active-pill {
+  background-color: #fca326 !important;
+  color: white !important;
 }
 
-/* Ensure proper spacing on all devices */
-@media (max-width: 960px) {
-  .v-container {
-    padding-left: 12px;
-    padding-right: 12px;
-  }
+.pill-tabs :deep(.v-slide-group__content) {
+  padding: 4px;
 }
 </style>

--- a/src/ux/Heuristic/views/EditTest.vue
+++ b/src/ux/Heuristic/views/EditTest.vue
@@ -12,46 +12,48 @@
       <div>
         <v-tabs
           v-model="index"
-          bg-color="transparent"
-          color="white"
-          class="mb-4 pill-tabs"
+          bg-color="#F5F5F5"
+          color="black"
+          class="mb-6 segmented-control"
           show-arrows
           density="compact"
           slider-color="transparent"
+          rounded="pill"
         >
           <v-tab
             :value="0"
-            :class="{ 'active-pill': index === 0 }"
+            :class="{ 'active-segment': index === 0 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('HeuristicsEditTest.titles.heuristics') }}
           </v-tab>
           <v-tab
             :value="1"
-            :class="{ 'active-pill': index === 1 }"
+            :class="{ 'active-segment': index === 1 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('HeuristicsEditTest.titles.options') }}
           </v-tab>
           <v-tab
             :value="2"
-            :class="{ 'active-pill': index === 2 }"
+            :class="{ 'active-segment': index === 2 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('HeuristicsEditTest.titles.weights') }}
           </v-tab>
           <v-tab
             v-if="showSettingsTab"
             :value="3"
-            :class="{ 'active-pill': index === 3 }"
+            :class="{ 'active-segment': index === 3 }"
             rounded="pill"
             variant="text"
+            class="segmented-tab"
           >
             {{ $t('HeuristicsEditTest.titles.settings') }}
           </v-tab>
@@ -180,12 +182,30 @@ const save = async () => {
 </script>
 
 <style scoped>
-.active-pill {
-  background-color: #fca326 !important;
-  color: white !important;
+.active-segment {
+  background-color: white !important;
+  color: #212121 !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12) !important;
 }
 
-.pill-tabs :deep(.v-slide-group__content) {
-  padding: 4px;
+.segmented-control {
+  padding: 4px !important;
+  height: auto !important;
+  width: fit-content;
+  max-width: 100%;
+}
+
+.segmented-tab {
+  text-transform: none !important;
+  font-weight: 500 !important;
+  letter-spacing: normal !important;
+  color: #757575 !important;
+  min-height: 36px !important;
+  height: 36px !important;
+  transition: all 0.2s ease-in-out !important;
+}
+
+.segmented-control :deep(.v-slide-group__content) {
+  padding: 0 !important;
 }
 </style>

--- a/src/ux/UserTest/components/SessionAnalytics.vue
+++ b/src/ux/UserTest/components/SessionAnalytics.vue
@@ -62,11 +62,7 @@
 
 
 <script>
-import SessionAnalyticsDialog from './dialogs/SessionAnalyticsDialog.vue';
 export default {
-    components: {
-        SessionAnalyticsDialog
-    },
     data() {
         return {
             selectedUserId: null,
@@ -96,16 +92,16 @@ export default {
             currentTime: 0,
             videoDuration: 100,
             isPlaying: false,
-            _timelineInterval: null
+            timelineInterval: null
         };
     },
     mounted() {
-        this._timelineInterval = setInterval(() => {
+        this.timelineInterval = setInterval(() => {
             this.updateTimeline();
         }, 200);
     },
     beforeUnmount() {
-        clearInterval(this._timelineInterval);
+        clearInterval(this.timelineInterval);
     },
     methods: {
         emitTimelineUpdate() {

--- a/src/ux/UserTest/components/editTest/EditUserTest.vue
+++ b/src/ux/UserTest/components/editTest/EditUserTest.vue
@@ -1,41 +1,99 @@
 <template>
-  <v-tabs bg-color="transparent" color="#FCA326" class="pb-0 mb-0">
-    <v-tab @click="index = 0">Test</v-tab>
-    <v-tab @click="index = 1">{{ $t('ModeratedTest.consentForm') }}</v-tab>
-    <v-tab @click="index = 2">{{ $t('ModeratedTest.preTest') }}</v-tab>
-    <v-tab @click="index = 3">{{ $t('ModeratedTest.tasks') }}</v-tab>
-    <v-tab @click="index = 4">{{ $t('ModeratedTest.postTest') }}</v-tab>
+  <v-tabs
+    v-model="index"
+    bg-color="transparent"
+    color="white"
+    class="mb-4 pill-tabs"
+    show-arrows
+    density="compact"
+    slider-color="transparent"
+  >
+    <v-tab
+      :value="0"
+      :class="{ 'active-pill': index === 0 }"
+      rounded="pill"
+      variant="text"
+      class="mr-2"
+      >Test</v-tab
+    >
+    <v-tab
+      :value="1"
+      :class="{ 'active-pill': index === 1 }"
+      rounded="pill"
+      variant="text"
+      class="mr-2"
+      >{{ $t('ModeratedTest.consentForm') }}</v-tab
+    >
+    <v-tab
+      :value="2"
+      :class="{ 'active-pill': index === 2 }"
+      rounded="pill"
+      variant="text"
+      class="mr-2"
+      >{{ $t('ModeratedTest.preTest') }}</v-tab
+    >
+    <v-tab
+      :value="3"
+      :class="{ 'active-pill': index === 3 }"
+      rounded="pill"
+      variant="text"
+      class="mr-2"
+      >{{ $t('ModeratedTest.tasks') }}</v-tab
+    >
+    <v-tab
+      :value="4"
+      :class="{ 'active-pill': index === 4 }"
+      rounded="pill"
+      variant="text"
+      >{{ $t('ModeratedTest.postTest') }}</v-tab
+    >
   </v-tabs>
 
-  <v-col cols="12">
+  <v-window v-model="index" class="mt-4">
     <!-- TEST -->
-    <div v-if="index === 0">
+    <v-window-item :value="0">
       <TestConfigForm
-:welcome="welcomeMessage" :final-message="finalMessage"
+        :welcome="welcomeMessage"
+        :final-message="finalMessage"
         @update:welcome-message="saveState('welcomeMessage', $event)"
-        @update:final-message="saveState('finalMessage', $event)" />
-    </div>
+        @update:final-message="saveState('finalMessage', $event)"
+      />
+    </v-window-item>
 
     <!-- COSENT FORM -->
-    <v-card v-if="index === 1" rounded="xxl">
-      <TextareaForm
-v-model="consent" :title="$t('ModeratedTest.consentForm')"
-        :subtitle="$t('ModeratedTest.consentFormSubtitle')" @update:value="saveState('consent', $event)" />
-    </v-card>
+    <v-window-item :value="1">
+      <v-card rounded="xxl">
+        <TextareaForm
+          v-model="consent"
+          :title="$t('ModeratedTest.consentForm')"
+          :subtitle="$t('ModeratedTest.consentFormSubtitle')"
+          @update:value="saveState('consent', $event)"
+        />
+      </v-card>
+    </v-window-item>
 
     <!-- PRE-TEST -->
-    <v-card v-if="index === 2" rounded="xxl">
-      <UserVariables type="pre-test" @update="saveState('preTest', $event)" />
-    </v-card>
+    <v-window-item :value="2">
+      <v-card rounded="xxl">
+        <UserVariables type="pre-test" @update="saveState('preTest', $event)" />
+      </v-card>
+    </v-window-item>
 
     <!-- TASKS -->
-    <ListTasks v-if="index === 3" />
+    <v-window-item :value="3">
+      <ListTasks />
+    </v-window-item>
 
     <!-- POST-TEST -->
-    <v-card v-if="index === 4" rounded="xxl">
-      <UserVariables type="post-test" @update="saveState('postTest', $event)" />
-    </v-card>
-  </v-col>
+    <v-window-item :value="4">
+      <v-card rounded="xxl">
+        <UserVariables
+          type="post-test"
+          @update="saveState('postTest', $event)"
+        />
+      </v-card>
+    </v-window-item>
+  </v-window>
 </template>
 
 <script setup>
@@ -120,5 +178,14 @@ onMounted(() => {
 .v-text-field--outlined :deep(fieldset) {
   border-radius: 25px;
   border: 1px solid #ffceb2;
+}
+
+.active-pill {
+  background-color: #fca326 !important;
+  color: white !important;
+}
+
+.pill-tabs :deep(.v-slide-group__content) {
+  padding: 4px;
 }
 </style>

--- a/src/ux/UserTest/components/editTest/EditUserTest.vue
+++ b/src/ux/UserTest/components/editTest/EditUserTest.vue
@@ -1,50 +1,52 @@
 <template>
   <v-tabs
     v-model="index"
-    bg-color="transparent"
-    color="white"
-    class="mb-4 pill-tabs"
+    bg-color="#F5F5F5"
+    color="black"
+    class="mb-6 segmented-control"
     show-arrows
     density="compact"
     slider-color="transparent"
+    rounded="pill"
   >
     <v-tab
       :value="0"
-      :class="{ 'active-pill': index === 0 }"
+      :class="{ 'active-segment': index === 0 }"
       rounded="pill"
       variant="text"
-      class="mr-2"
+      class="segmented-tab"
       >Test</v-tab
     >
     <v-tab
       :value="1"
-      :class="{ 'active-pill': index === 1 }"
+      :class="{ 'active-segment': index === 1 }"
       rounded="pill"
       variant="text"
-      class="mr-2"
+      class="segmented-tab"
       >{{ $t('ModeratedTest.consentForm') }}</v-tab
     >
     <v-tab
       :value="2"
-      :class="{ 'active-pill': index === 2 }"
+      :class="{ 'active-segment': index === 2 }"
       rounded="pill"
       variant="text"
-      class="mr-2"
+      class="segmented-tab"
       >{{ $t('ModeratedTest.preTest') }}</v-tab
     >
     <v-tab
       :value="3"
-      :class="{ 'active-pill': index === 3 }"
+      :class="{ 'active-segment': index === 3 }"
       rounded="pill"
       variant="text"
-      class="mr-2"
+      class="segmented-tab"
       >{{ $t('ModeratedTest.tasks') }}</v-tab
     >
     <v-tab
       :value="4"
-      :class="{ 'active-pill': index === 4 }"
+      :class="{ 'active-segment': index === 4 }"
       rounded="pill"
       variant="text"
+      class="segmented-tab"
       >{{ $t('ModeratedTest.postTest') }}</v-tab
     >
   </v-tabs>
@@ -180,12 +182,30 @@ onMounted(() => {
   border: 1px solid #ffceb2;
 }
 
-.active-pill {
-  background-color: #fca326 !important;
-  color: white !important;
+.segmented-control {
+  padding: 4px !important;
+  height: auto !important;
+  width: fit-content;
+  max-width: 100%;
 }
 
-.pill-tabs :deep(.v-slide-group__content) {
-  padding: 4px;
+.segmented-tab {
+  text-transform: none !important;
+  font-weight: 500 !important;
+  letter-spacing: normal !important;
+  color: #757575 !important;
+  min-height: 36px !important;
+  height: 36px !important;
+  transition: all 0.2s ease-in-out !important;
+}
+
+.active-segment {
+  background-color: white !important;
+  color: #212121 !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12) !important;
+}
+
+.segmented-control :deep(.v-slide-group__content) {
+  padding: 0 !important;
 }
 </style>

--- a/src/ux/UserTest/components/sessions/NotesStats.vue
+++ b/src/ux/UserTest/components/sessions/NotesStats.vue
@@ -1,1 +1,3 @@
-<template></template>
+<template>
+  <div></div>
+</template>

--- a/src/ux/UserTest/components/sessions/SentimentSummary.vue
+++ b/src/ux/UserTest/components/sessions/SentimentSummary.vue
@@ -1,1 +1,3 @@
-<template></template>
+<template>
+  <div></div>
+</template>

--- a/src/ux/UserTest/views/EditTestView.vue
+++ b/src/ux/UserTest/views/EditTestView.vue
@@ -12,64 +12,66 @@
       <div>
         <v-tabs
           v-model="index"
-          bg-color="transparent"
-          color="white"
-          class="mb-4 pill-tabs"
+          bg-color="#F5F5F5"
+          color="black"
+          class="mb-6 segmented-control"
           show-arrows
           density="compact"
           slider-color="transparent"
+          rounded="pill"
         >
           <v-tab
             :value="0"
-            :class="{ 'active-pill': index === 0 }"
+            :class="{ 'active-segment': index === 0 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('UserTestTable.titles.testConfiguration') }}
           </v-tab>
           <v-tab
             :value="1"
-            :class="{ 'active-pill': index === 1 }"
+            :class="{ 'active-segment': index === 1 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('ModeratedTest.consentForm') }}
           </v-tab>
           <v-tab
             :value="2"
-            :class="{ 'active-pill': index === 2 }"
+            :class="{ 'active-segment': index === 2 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('ModeratedTest.preTest') }}
           </v-tab>
           <v-tab
             :value="3"
-            :class="{ 'active-pill': index === 3 }"
+            :class="{ 'active-segment': index === 3 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('ModeratedTest.tasks') }}
           </v-tab>
           <v-tab
             :value="4"
-            :class="{ 'active-pill': index === 4 }"
+            :class="{ 'active-segment': index === 4 }"
             rounded="pill"
             variant="text"
-            class="mr-2"
+            class="segmented-tab"
           >
             {{ $t('ModeratedTest.postTest') }}
           </v-tab>
           <v-tab
             v-if="hasEyeTracking"
             :value="5"
-            :class="{ 'active-pill': index === 5 }"
+            :class="{ 'active-segment': index === 5 }"
             rounded="pill"
             variant="text"
+            class="segmented-tab"
           >
             {{ $t('EyeTrackingConfig.titles.main') }}
           </v-tab>
@@ -327,12 +329,30 @@ onUnmounted(() => {
   border: 1px solid #ffceb2;
 }
 
-.active-pill {
-  background-color: #fca326 !important;
-  color: white !important;
+.segmented-control {
+  padding: 4px !important;
+  height: auto !important;
+  width: fit-content;
+  max-width: 100%;
 }
 
-.pill-tabs :deep(.v-slide-group__content) {
-  padding: 4px;
+.segmented-tab {
+  text-transform: none !important;
+  font-weight: 500 !important;
+  letter-spacing: normal !important;
+  color: #757575 !important;
+  min-height: 36px !important;
+  height: 36px !important;
+  transition: all 0.2s ease-in-out !important;
+}
+
+.active-segment {
+  background-color: white !important;
+  color: #212121 !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12) !important;
+}
+
+.segmented-control :deep(.v-slide-group__content) {
+  padding: 0 !important;
 }
 </style>

--- a/src/ux/UserTest/views/EditTestView.vue
+++ b/src/ux/UserTest/views/EditTestView.vue
@@ -10,45 +10,95 @@
       <ButtonSave :visible="!isTemplate" @click="save" />
 
       <div>
-        <v-tabs bg-color="transparent" color="#FCA326" class="pb-0 mb-0">
-          <v-tab @click="index = 0">
+        <v-tabs
+          v-model="index"
+          bg-color="transparent"
+          color="white"
+          class="mb-4 pill-tabs"
+          show-arrows
+          density="compact"
+          slider-color="transparent"
+        >
+          <v-tab
+            :value="0"
+            :class="{ 'active-pill': index === 0 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
             {{ $t('UserTestTable.titles.testConfiguration') }}
           </v-tab>
-          <v-tab @click="index = 1">
+          <v-tab
+            :value="1"
+            :class="{ 'active-pill': index === 1 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
             {{ $t('ModeratedTest.consentForm') }}
           </v-tab>
-          <v-tab @click="index = 2">
+          <v-tab
+            :value="2"
+            :class="{ 'active-pill': index === 2 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
             {{ $t('ModeratedTest.preTest') }}
           </v-tab>
-          <v-tab @click="index = 3">
+          <v-tab
+            :value="3"
+            :class="{ 'active-pill': index === 3 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
             {{ $t('ModeratedTest.tasks') }}
           </v-tab>
-          <v-tab @click="index = 4">
+          <v-tab
+            :value="4"
+            :class="{ 'active-pill': index === 4 }"
+            rounded="pill"
+            variant="text"
+            class="mr-2"
+          >
             {{ $t('ModeratedTest.postTest') }}
           </v-tab>
-          <v-tab v-if="hasEyeTracking" @click="index = 5">
+          <v-tab
+            v-if="hasEyeTracking"
+            :value="5"
+            :class="{ 'active-pill': index === 5 }"
+            rounded="pill"
+            variant="text"
+          >
             {{ $t('EyeTrackingConfig.titles.main') }}
           </v-tab>
         </v-tabs>
 
-        <v-col cols="12">
+        <v-window v-model="index" class="mt-4">
           <!-- TEST -->
-          <div v-if="index === 0">
+          <v-window-item :value="0">
             <TestConfigForm
               :readonly="isTemplate"
               :welcome="welcomeMessage"
               :final-message="finalMessage"
               @update:welcome-message="
-                ;((welcomeMessage = $event), (change = true))
+                (val) => {
+                  welcomeMessage = val
+                  change = true
+                }
               "
               @update:final-message="
-                ;((finalMessage = $event), (change = true))
+                (val) => {
+                  finalMessage = val
+                  change = true
+                }
               "
             />
-          </div>
+          </v-window-item>
 
           <!-- CONSENT FORM -->
-          <div v-if="index === 1" rounded="xxl">
+          <v-window-item :value="1">
             <TextareaForm
               v-model="consent"
               :readonly="isTemplate"
@@ -56,36 +106,38 @@
               :subtitle="$t('ModeratedTest.consentFormSubtitle')"
               @update:value="consent = $event"
             />
-          </div>
+          </v-window-item>
 
           <!-- PRE-TEST -->
-          <div v-if="index === 2">
+          <v-window-item :value="2">
             <UserVariables
               type="pre-test"
               :is-template="isTemplate"
               @change="change = true"
               @update="store.dispatch('UserStudy/setPreTest', $event)"
             />
-          </div>
+          </v-window-item>
 
           <!-- TASKS -->
-          <div v-if="index === 3">
+          <v-window-item :value="3">
             <ListTasks :is-template="isTemplate" />
-          </div>
+          </v-window-item>
           <!-- POST-TEST -->
-          <div v-if="index === 4">
+          <v-window-item :value="4">
             <UserVariables
               type="post-test"
               :is-template="isTemplate"
               @change="change = true"
               @update="store.dispatch('UserStudy/setPostTest', $event)"
             />
-          </div>
+          </v-window-item>
 
-          <v-card v-if="index === 5 && hasEyeTracking" rounded="xxl">
-            <EyeTrackingConfig />
-          </v-card>
-        </v-col>
+          <v-window-item v-if="hasEyeTracking" :value="5">
+            <v-card rounded="xxl">
+              <EyeTrackingConfig />
+            </v-card>
+          </v-window-item>
+        </v-window>
       </div>
     </v-container>
   </PageWrapper>
@@ -273,5 +325,14 @@ onUnmounted(() => {
 .v-text-field--outlined :deep(fieldset) {
   border-radius: 25px;
   border: 1px solid #ffceb2;
+}
+
+.active-pill {
+  background-color: #fca326 !important;
+  color: white !important;
+}
+
+.pill-tabs :deep(.v-slide-group__content) {
+  padding: 4px;
 }
 </style>


### PR DESCRIPTION
Fixes #1579

This PR improves the mobile tab accessibility on test page.

Changes:
- Improves tab switching on smaller screens
- Fixes accessibility issues when selecting test tabs on 
 
<img width="1920" height="1080" alt="Screenshot from 2026-03-08 21-29-57" src="https://github.com/user-attachments/assets/a218c6de-ac44-47ce-ae61-b905639ebd18" />
