### PR TITLE
fix(statistics): add safety guards and type consistency to statistics.js

### DIFF
--- a/src/ux/Heuristic/utils/statistics.js
+++ b/src/ux/Heuristic/utils/statistics.js
@@ -11,10 +11,12 @@ const testData = {
 }
 
 function percentage(value, result) {
+  if (result === 0) return 0
   return (value * 100) / result
 }
 
 function standardDeviation(array) {
+  if (!Array.isArray(array) || array.length === 0) return 0
   const average = array.reduce(
     (total, value) => total + value / array.length,
     0,
@@ -52,7 +54,7 @@ function calcFinalResult(array) {
   const test = store.getters.test
   if (!test || !Array.isArray(test.testOptions)) {
     console.warn('calcFinalResult: test or testOptions is not available', test)
-    return '0.00' // Return a default value to prevent errors
+    return 0
   }
 
   const maxOption = Math.max(...test.testOptions.map((item) => item.value))
@@ -70,8 +72,8 @@ function calcFinalResult(array) {
 
   const perfectResult = (qtdQuestion - qtdNoAplication) * maxOption
   return perfectResult === 0
-    ? '0.00'
-    : ((result * 100) / perfectResult).toFixed(2)
+    ? 0
+    : parseFloat(((result * 100) / perfectResult).toFixed(2))
 }
 
 function answers() {


### PR DESCRIPTION
## Summary

Fixes division-by-zero, NaN cascade, and type inconsistency bugs in heuristic statistics calculations. These caused the Manager Dashboard to display `NaN%` or `Infinity%` when evaluators had no answers or empty heuristic sets.

## Changes

### `percentage(value, result)` — Division by zero guard
- **Before:** `return (value * 100) / result` → returns `Infinity` when `result === 0`
- **After:** Added `if (result === 0) return 0` before the division

### `standardDeviation(array)` — Empty array guard
- **Before:** Immediate `.reduce()` on empty array → `NaN`
- **After:** Added `if (!Array.isArray(array) || array.length === 0) return 0`

### `calcFinalResult(array)` — Return type consistency
- **Before:** Early exits returned `'0.00'` (string), normal path returned `.toFixed(2)` (string)
- **After:** All paths return `number` — early exits return `0`, normal path returns `parseFloat(...toFixed(2))`

![Screenshot_9-3-2026_162440_github com](https://github.com/user-attachments/assets/cfb74b53-7c3c-4f53-9d35-e6c2fa580a07)


## Impact

- No function signatures changed
- No downstream breakage — `finalResult()` already used `parseInt(value.result)` guard
- Manager Dashboard: eliminates `NaN%` and `Infinity%` display bugs
- Statistics cards: consistent numeric types prevent silent string+number coercion

## Testing

- Manual: Verified all 4 changes against develop baseline via `git diff`
- Needs unit tests for: `percentage(0,0)`, `standardDeviation([])`, `typeof calcFinalResult([])`

closes #1848 