### PR TITLE
fix: remove debug leftovers and dead code patterns from production

### DIFF
--- a/src/app/plugins/firebase/FirebaseFirestoreRepository.js
+++ b/src/app/plugins/firebase/FirebaseFirestoreRepository.js
@@ -154,12 +154,8 @@ export default class Controller {
   }
 
   async update(col, docId, payload) {
-    try {
-      const ref = doc(db, `${col}/${docId}`)
-      return updateDoc(ref, payload)
-    } catch (e) {
-      throw e
-    }
+    const ref = doc(db, `${col}/${docId}`)
+    return updateDoc(ref, payload)
   }
 
   async delete(col, docId) {

--- a/src/controllers/StudyController.js
+++ b/src/controllers/StudyController.js
@@ -27,57 +27,45 @@ export default class StudyController extends Controller {
     return await super.create(COLLECTION, payload.toFirestore())
   }
   async duplicateStudy(payload) {
-    try {
-      const answerDoc = await answerController.createAnswer(
-        new StudyAnswer({ type: payload.test.testType }),
-      )
+    const answerDoc = await answerController.createAnswer(
+      new StudyAnswer({ type: payload.test.testType }),
+    )
 
-      // Use the correct study type from the payload (already instantiated correctly in SettingsView)
-      const duplicatedStudy = payload.test
-      duplicatedStudy.answersDocId = answerDoc.id
+    // Use the correct study type from the payload (already instantiated correctly in SettingsView)
+    const duplicatedStudy = payload.test
+    duplicatedStudy.answersDocId = answerDoc.id
 
-      return await super.create(COLLECTION, duplicatedStudy.toFirestore())
-    } catch (error) {
-      throw error
-    }
+    return await super.create(COLLECTION, duplicatedStudy.toFirestore())
   }
 
   async deleteStudy(payload) {
-    try {
-      const testToDelete = await super.readOne(COLLECTION, payload.id)
-      if (!testToDelete.exists()) {
-        return null
-      }
-
-      const collaborators = await testToDelete.data()
-      const cooperators = collaborators.cooperators
-      if (cooperators) {
-        const promises = []
-
-        for (const cooperator of cooperators) {
-          // Add the call to remove notifications for the test being deleted
-          promises.push(
-            userController.removeTestFromUser(cooperator.userDocId, payload.id),
-          )
-          promises.push(
-            userController.removeNotificationsForTest(payload.id, cooperators),
-          )
-        }
-        await Promise.all(promises)
-      }
-      await super.update('users', payload.testAdmin.userDocId, payload.auxUser)
-      await super.delete(COLLECTION, payload.id)
-    } catch (error) {
-      throw error
+    const testToDelete = await super.readOne(COLLECTION, payload.id)
+    if (!testToDelete.exists()) {
+      return null
     }
+
+    const collaborators = await testToDelete.data()
+    const cooperators = collaborators.cooperators
+    if (cooperators) {
+      const promises = []
+
+      for (const cooperator of cooperators) {
+        // Add the call to remove notifications for the test being deleted
+        promises.push(
+          userController.removeTestFromUser(cooperator.userDocId, payload.id),
+        )
+        promises.push(
+          userController.removeNotificationsForTest(payload.id, cooperators),
+        )
+      }
+      await Promise.all(promises)
+    }
+    await super.update('users', payload.testAdmin.userDocId, payload.auxUser)
+    await super.delete(COLLECTION, payload.id)
   }
 
   async updateStudy(payload) {
-    try {
-      return await super.update(COLLECTION, payload.id, payload.toFirestore())
-    } catch (e) {
-      throw e
-    }
+    return await super.update(COLLECTION, payload.id, payload.toFirestore())
   }
 
   //ToDo: It seems an action from User Testing
@@ -137,15 +125,10 @@ export default class StudyController extends Controller {
   }
 
   async getAllStudies() {
-    try {
-      const response = await super.readAll('tests')
-      const res = response.map((data) => {
-        return instantiateStudyByType(data.testType, data)
-      })
-      return res
-    } catch (err) {
-      throw err
-    }
+    const response = await super.readAll('tests')
+    return response.map((data) => {
+      return instantiateStudyByType(data.testType, data)
+    })
   }
 
   subscribeToStudy(studyId, callback) {

--- a/src/features/auth/composables/useProfile.js
+++ b/src/features/auth/composables/useProfile.js
@@ -110,24 +110,14 @@ export function useProfile() {
   }
 
   const uploadProfileImage = async (file) => {
-    try {
-      const auth = getAuth()
-      const user = auth.currentUser
-      if (!user) throw new Error(t('profile.noUserSignedIn'))
+    const auth = getAuth()
+    const user = auth.currentUser
+    if (!user) throw new Error(t('profile.noUserSignedIn'))
 
-      // Compress the image first
+    const compressedFile = await compressImage(file, 300, 0.6)
+    const base64DataUrl = await fileToBase64(compressedFile)
 
-      const compressedFile = await compressImage(file, 300, 0.6)
-
-      // Convert to Base64 (stores directly in Firestore, no Storage needed!)
-
-      const base64DataUrl = await fileToBase64(compressedFile)
-
-      // Return the Base64 data URL (this will be stored in Firestore)
-      return base64DataUrl
-    } catch (error) {
-      throw error
-    }
+    return base64DataUrl
   }
 
   const removeProfileImage = async () => {

--- a/src/features/auth/controllers/AuthController.js
+++ b/src/features/auth/controllers/AuthController.js
@@ -141,13 +141,9 @@ export default class AuthController {
   }
 
   async deleteUserData(userId) {
-    try {
-      await axios.post(
-        process.env.VUE_APP_CLOUD_FUNCTIONS_URL + '/deleteAuth',
-        { data: { userId } },
-      )
-    } catch (err) {
-      throw err
-    }
+    await axios.post(
+      process.env.VUE_APP_CLOUD_FUNCTIONS_URL + '/deleteAuth',
+      { data: { userId } },
+    )
   }
 }

--- a/src/features/auth/controllers/UserController.js
+++ b/src/features/auth/controllers/UserController.js
@@ -78,31 +78,27 @@ export default class UserController extends Controller {
   async _fetchStudiesByIds(ids) {
     if (!ids || ids.length === 0) return []
 
-    try {
-      // If there are few (<= 10), use "in" query (faster and more direct)
-      if (ids.length <= 10) {
-        const q = {
-          field: documentId(),
-          condition: 'in',
-          value: ids,
-        }
-        const res = await super.query('tests', q)
-        return res.docs.map((doc) => {
-          return Object.assign({ id: doc.id }, doc.data())
-        })
+    // If there are few (<= 10), use "in" query (faster and more direct)
+    if (ids.length <= 10) {
+      const q = {
+        field: documentId(),
+        condition: 'in',
+        value: ids,
       }
-
-      // If there are many (>10), parallelize individual gets
-      const promises = ids.map((id) => super.readOne('tests', id))
-      const results = await Promise.all(promises)
-      return results
-        .filter((r) => r.exists())
-        .map((r) => {
-          return Object.assign({ id: r.id }, r.data())
-        })
-    } catch (error) {
-      throw error
+      const res = await super.query('tests', q)
+      return res.docs.map((doc) => {
+        return Object.assign({ id: doc.id }, doc.data())
+      })
     }
+
+    // If there are many (>10), parallelize individual gets
+    const promises = ids.map((id) => super.readOne('tests', id))
+    const results = await Promise.all(promises)
+    return results
+      .filter((r) => r.exists())
+      .map((r) => {
+        return Object.assign({ id: r.id }, r.data())
+      })
   }
 
   async updateProfile(docId, payload) {
@@ -190,63 +186,46 @@ export default class UserController extends Controller {
   }
 
   async removeNotificationsForTest(testId, cooperators) {
-    try {
-      for (let cooperator = 0; cooperator < cooperators.length; cooperator++) {
-        const userDocID = cooperators[cooperator].userDocId
+    for (let cooperator = 0; cooperator < cooperators.length; cooperator++) {
+      const userDocID = cooperators[cooperator].userDocId
 
-        // Lê o documento do usuário diretamente
-        const userDoc = await super.readOne('users', userDocID)
+      const userDoc = await super.readOne('users', userDocID)
 
-        // Verifica se o documento do usuário existe
-        if (userDoc.exists()) {
-          const userData = userDoc.data()
-          const userId = userDoc.id
+      if (userDoc.exists()) {
+        const userData = userDoc.data()
+        const userId = userDoc.id
 
-          // Verificar se o usuário tem notificações
-          if (userData.notifications && userData.notifications.length > 0) {
-            // Filtrar notificações que têm o testId correspondente
-            userData.notifications = userData.notifications.filter(
-              (notification) => notification.testId !== testId,
-            )
-            // Atualizar o documento do usuário com as notificações filtradas
-            await super.update('users', userId, {
-              notifications: userData.notifications,
-            })
-          }
-        } else {
+        if (userData.notifications && userData.notifications.length > 0) {
+          userData.notifications = userData.notifications.filter(
+            (notification) => notification.testId !== testId,
+          )
+          await super.update('users', userId, {
+            notifications: userData.notifications,
+          })
         }
       }
-    } catch (error) {
-      throw error
     }
   }
 
   async removeTestFromUser(userId, testIdToRemove) {
-    try {
-      const userDoc = await super.readOne('users', userId)
+    const userDoc = await super.readOne('users', userId)
 
-      if (!userDoc.exists()) {
-        return
-      }
-      const userData = userDoc.data()
-
-      if (userData.myTests[testIdToRemove]) {
-        delete userData.myTests[testIdToRemove]
-      }
-      if (userData.myAnswers[testIdToRemove]) {
-        delete userData.myAnswers[testIdToRemove]
-      }
-
-      await super.update('users', userId, userData)
-    } catch (error) {
-      throw error
+    if (!userDoc.exists()) {
+      return
     }
+    const userData = userDoc.data()
+
+    if (userData.myTests[testIdToRemove]) {
+      delete userData.myTests[testIdToRemove]
+    }
+    if (userData.myAnswers[testIdToRemove]) {
+      delete userData.myAnswers[testIdToRemove]
+    }
+
+    await super.update('users', userId, userData)
   }
+
   async updateLevel(uid, accessLevel) {
-    try {
-      return super.update(COLLECTION, uid, { accessLevel })
-    } catch (error) {
-      throw error
-    }
+    return super.update(COLLECTION, uid, { accessLevel })
   }
 }

--- a/src/features/auth/store/Auth.js
+++ b/src/features/auth/store/Auth.js
@@ -222,11 +222,8 @@ export default {
       commit('setLoading', true)
       try {
         await authController.deleteAuth(payload)
-        // Store handles state management
         await authController.signOut()
         commit('SET_USER', null)
-      } catch (err) {
-        throw err
       } finally {
         commit('setLoading', false)
       }

--- a/src/features/super/store/User.js
+++ b/src/features/super/store/User.js
@@ -68,8 +68,6 @@ export default {
 
         await authController.deleteUserData(user.id)
         commit('REMOVE_USER', user.id)
-      } catch (e) {
-        throw e
       } finally {
         commit('setLoading', false)
       }

--- a/src/shared/views/CooperatorsView.vue
+++ b/src/shared/views/CooperatorsView.vue
@@ -249,15 +249,11 @@ const sendNotification = async ({
     accessLevel,
   })
 
-  try {
-    await store.dispatch('addNotification', {
-      userId,
-      notification,
-    })
-    return true
-  } catch (error) {
-    throw error
-  }
+  await store.dispatch('addNotification', {
+    userId,
+    notification,
+  })
+  return true
 }
 
 let showIntroComponent = ref(true)

--- a/src/ux/Heuristic/components/HeuristicsTable.vue
+++ b/src/ux/Heuristic/components/HeuristicsTable.vue
@@ -913,7 +913,6 @@ const editDescription = (desc) => {
   const btn = descBtn.value[itemSelect.value]
   if (btn && typeof btn.editSetup === 'function') {
     btn.editSetup(ind)
-  } else {
   }
 }
 

--- a/src/ux/UserTest/components/UnmoderatedTestAnalytics/SusAnalytics.vue
+++ b/src/ux/UserTest/components/UnmoderatedTestAnalytics/SusAnalytics.vue
@@ -410,7 +410,6 @@ const tasksArray = computed(() => {
       }))
   })
 })
-console.log(tasksArray.value)
 const analytics = computed(() => {
     const scores = tasksArray.value.map(r => r.susScore)
     return {

--- a/src/ux/UserTest/components/UnmoderatedTestAnalytics/TaskDetailsModal.vue
+++ b/src/ux/UserTest/components/UnmoderatedTestAnalytics/TaskDetailsModal.vue
@@ -418,13 +418,6 @@ const formatDuration = (duration) => {
   return `${minutes}m ${seconds}s`
 }
 
-watch(
-  () => props.userSession,
-  (newValue) => {
-    console.log('userSession updated:', newValue)
-  },
-  { immediate: true }, // also logs on first load
-)
 </script>
 
 <style scoped>

--- a/src/ux/UserTest/components/VideoCall.vue
+++ b/src/ux/UserTest/components/VideoCall.vue
@@ -1202,10 +1202,6 @@ const joinRoom = async () => {
           console.error('Error adding ICE candidate:', err)
         }
       } else {
-        // Buffer candidate
-        console.log(
-          `Buffering candidate for ${senderId} (pending remote description)`,
-        )
         if (peers[senderId]) {
           peers[senderId].pendingCandidates.push(signal.candidate)
         }
@@ -1249,13 +1245,11 @@ const leaveRoom = () => {
 }
 
 const initLocalMedia = async () => {
-  console.log('initLocalMedia called')
   try {
     const stream = await navigator.mediaDevices.getUserMedia({
       video: true,
       audio: true,
     })
-    console.log('getUserMedia success', stream)
     localStream.value = stream
     if (localVideo.value) localVideo.value.srcObject = stream
     isCameraEnabled.value = true

--- a/src/ux/UserTest/components/VideoRecorder.vue
+++ b/src/ux/UserTest/components/VideoRecorder.vue
@@ -115,11 +115,7 @@ const startRecording = async () => {
     if (!cameraAvailable) return
 
     recording.value = true
-    recordingTaskIndex.value = props.taskIndex // Store the current task index when recording starts
-    console.log(
-      'VideoRecorder: Recording started for task index:',
-      props.taskIndex,
-    )
+    recordingTaskIndex.value = props.taskIndex
     videoStream.value = await navigator.mediaDevices.getUserMedia({
       video: true,
     })
@@ -160,13 +156,6 @@ const startRecording = async () => {
         await uploadBytes(storageReference, videoBlob)
 
         recordedVideo.value = await getDownloadURL(storageReference)
-        console.log('webcam url =>', correctTaskIndex, recordedVideo.value)
-        console.log('Tasks array:', currentUserTestAnswer.value.tasks)
-        console.log('Tasks length:', currentUserTestAnswer.value.tasks?.length)
-        console.log(
-          'Task at index:',
-          currentUserTestAnswer.value.tasks?.[correctTaskIndex],
-        )
 
         await store.dispatch('updateTaskMediaUrl', {
           taskIndex: correctTaskIndex,

--- a/src/ux/UserTest/components/answers/EyeTrackingOverlay.vue
+++ b/src/ux/UserTest/components/answers/EyeTrackingOverlay.vue
@@ -137,13 +137,6 @@ async function resizeCanvas() {
 
   ctx.imageSmoothingEnabled = true
   ctx.imageSmoothingQuality = 'high'
-  console.log(
-    dpr,
-    rect.width,
-    rect.height,
-    canvas.value.width,
-    canvas.value.height,
-  )
 }
 
 onMounted(() => {
@@ -163,8 +156,6 @@ watch(
   (val) => {
     if (!val?.length) return
 
-    console.log('[Overlay] typeof:', typeof val, 'Array?', Array.isArray(val))
-
     const t0 = val[0].timestamp // timestamp inicial absoluto
     normalized = val.map((p) => ({
       x: (p.predicted_x ?? p.x) / (p.screen_width || 1),
@@ -173,12 +164,6 @@ watch(
     }))
 
     heatmapData = []
-    console.log(
-      '[Overlay] Normalização concluída:',
-      normalized.length,
-      'pontos. Último t =',
-      normalized.at(-1)?.t,
-    )
   },
   { immediate: true },
 )
@@ -202,29 +187,7 @@ watch(
     const nextIdx = normalized.findIndex((p) => p.t > currentMs)
     i = nextIdx === -1 ? normalized.length - 1 : Math.max(0, nextIdx - 1)
 
-    console.log(
-      '[Overlay] currentTime →',
-      time.toFixed(2),
-      's | currentMs =',
-      currentMs,
-      '| index =',
-      i,
-    )
-
-    // Loga o timestamp real do ponto
-    const currentPoint = props.predictedData[i]
-    if (currentPoint) {
-      console.log('[Overlay] ponto atual:', {
-        timestamp: currentPoint.timestamp,
-        x: currentPoint.predicted_x,
-        y: currentPoint.predicted_y,
-      })
-    } else {
-      console.warn('[Overlay] Nenhum ponto encontrado pra esse tempo!')
-    }
-
     const visiblePoints = normalized.slice(0, i + 1)
-    console.log('[Overlay] total de pontos desenhados:', visiblePoints.length)
 
     ctx.clearRect(0, 0, canvas.value.width, canvas.value.height)
 

--- a/src/ux/UserTest/components/dialogs/CreateInviteDialog.vue
+++ b/src/ux/UserTest/components/dialogs/CreateInviteDialog.vue
@@ -553,13 +553,6 @@ const saveInvitation = async () => {
 
     // Construct datetime string with proper validation
     const dateTimeString = `${dateValue}T${timeValue}:00`
-    console.log('Constructing datetime from:', {
-      originalDate: date.value,
-      formattedDate: dateValue,
-      hour: hour.value,
-      dateTimeString,
-    })
-
     const dateTime = new Date(dateTimeString)
 
     // Check if the constructed date is valid

--- a/src/ux/UserTest/components/sentimentAnalysis/AudioWave.vue
+++ b/src/ux/UserTest/components/sentimentAnalysis/AudioWave.vue
@@ -169,7 +169,6 @@ const playPause = () => {
 }
 
 function playSegment(start, end) {
-  console.log(`Playing segment from ${start} to ${end}`)
   if (!wave_surfer.value) return
   wave_surfer.value.play(start, end)
 }

--- a/src/ux/UserTest/components/sentimentAnalysis/UserModeratedSentiment.vue
+++ b/src/ux/UserTest/components/sentimentAnalysis/UserModeratedSentiment.vue
@@ -281,11 +281,6 @@ export default {
       }
     },
     async analyzeTimeStamp(task) {
-      console.log(
-        'Analyzing Timestamp..............................',
-        this.activeRegion.start,
-        this.activeRegion.end,
-      )
       this.overlay = { visible: true, text: 'Analyzing...' }
 
       try {
@@ -305,8 +300,6 @@ export default {
         }
 
         const data = response.data.data
-        console.log('Analysis Completed', data)
-
         const utterances_sentiment = data.utterances_sentiment
         const answerSentimentDocId = this.selectedAnswerSentiment.id
 

--- a/src/ux/UserTest/components/sessions/EyeTrackingStats.vue
+++ b/src/ux/UserTest/components/sessions/EyeTrackingStats.vue
@@ -217,8 +217,6 @@ watch(selectedView, (value) => emit('view-changed', value))
 
 onMounted(async () => {
   try {
-    console.log(calibrationConfig)
-
     const res = await axios.post(
       process.env.VUE_APP_EYE_LAB_BACKEND_URL + '/api/session/batch_predict',
       {

--- a/src/ux/UserTest/components/steps/TaskStep.vue
+++ b/src/ux/UserTest/components/steps/TaskStep.vue
@@ -764,7 +764,6 @@ function handleShowPostForm(userCompleted) {
   if (taskStartTime) {
     finalTime = Math.round(Date.now() - taskStartTime)
     pendingFinalTime.value = finalTime
-    console.log('Tiempo detenido en:', finalTime, 'segundos')
     emit('timer-stopped', finalTime, props.taskIndex)
   }
 

--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -1032,10 +1032,6 @@ const callTimerSave = () => {
 }
 
 function handleTaskFinish(userCompleted) {
-  const currentTask = localTestAnswer.tasks[taskIndex.value]
-  if (currentTask) {
-    console.log('Estado actual de la tarea antes de finalizar:', currentTask) // eslint-disable-line no-console
-  }
   completeStep(taskIndex.value, 'tasks', userCompleted)
   callTimerSave()
 }
@@ -1050,9 +1046,6 @@ const startTimer = () => {
 }
 
 const handleTimerStopped = (elapsedTime, idx) => {
-  // idx is passed from TaskStep, always use it
-  console.log('handleTimerStopped llamado con:', { elapsedTime, idx }) // eslint-disable-line no-console
-
   if (!localTestAnswer.tasks) {
     console.error('localTestAnswer.tasks no está definido') // eslint-disable-line no-console
     return
@@ -1125,7 +1118,6 @@ const completeStep = async (id, type, userCompleted = true) => {
         taskIndex.value = id + 1
         startTimer()
       } else {
-        console.log('All tasks completed, moving to post-test') // eslint-disable-line no-console
         globalIndex.value = 5
       }
       if (userCompleted) {

--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -797,18 +797,14 @@ const attachMediaToTasks = (answer, mediaUrls) => {
     for (const type in medias) {
       if (type === 'sizes') {
         const sizes = medias[type]
-        console.log(`Found sizes for Task ${taskIndex}:`, sizes)
         if (sizes.screenRecordURL) {
           task.screenSize = sizes.screenRecordURL
-          console.log('Set screenSize:', task.screenSize)
         }
         if (sizes.audioRecordURL) {
           task.audioSize = sizes.audioRecordURL
-          console.log('Set audioSize:', task.audioSize)
         }
         if (sizes.webcamRecordURL) {
           task.webcamSize = sizes.webcamRecordURL
-          console.log('Set webcamSize:', task.webcamSize)
         }
         continue
       }
@@ -961,7 +957,6 @@ const completeStep = (id, type, userCompleted = true) => {
         if (allTasksCompleted.value) {
           taskIndex.value = id + 1 // to help saving methods
           globalIndex.value = hasEyeTracking.value ? 6 : 5 // PostTest
-        } else {
         }
       }
       //TODO: Show proper toast not the following one

--- a/src/ux/accessibility/store/Assessment.js
+++ b/src/ux/accessibility/store/Assessment.js
@@ -581,77 +581,63 @@ const actions = {
 
   // Reset assessment
   async resetAssessment({ commit, rootState }, { testId }) {
-    try {
-      const userId = rootState.auth.user?.uid
-      if (userId && testId) {
-        await assessmentController.deleteAssessment(userId, testId)
-      }
-      commit('RESET_ASSESSMENT')
-    } catch (error) {
-      throw error
+    const userId = rootState.auth.user?.uid
+    if (userId && testId) {
+      await assessmentController.deleteAssessment(userId, testId)
     }
+    commit('RESET_ASSESSMENT')
   },
 
   // Save assessment to Firestore
   async saveAssessment({ state }, { userId, testId, testType = 'manual' }) {
-    try {
-      if (!userId) throw new Error('User ID is required')
+    if (!userId) throw new Error('User ID is required')
 
-      // Convert rule assessments to array format
-      const assessmentData = Object.entries(state.ruleAssessments).map(
-        ([ruleId, assessment]) => ({
-          ruleId,
-          ...assessment,
-          // Add any additional fields needed from the rule data
-          ...(state.wcagData && {
-            // Include rule metadata for easier querying
-            ruleTitle: findRuleTitle(ruleId, state.wcagData),
-            principle: findPrincipleForRule(ruleId, state.wcagData),
-            guideline: findGuidelineForRule(ruleId, state.wcogData),
-          }),
+    // Convert rule assessments to array format
+    const assessmentData = Object.entries(state.ruleAssessments).map(
+      ([ruleId, assessment]) => ({
+        ruleId,
+        ...assessment,
+        ...(state.wcagData && {
+          ruleTitle: findRuleTitle(ruleId, state.wcagData),
+          principle: findPrincipleForRule(ruleId, state.wcagData),
+          guideline: findGuidelineForRule(ruleId, state.wcogData),
         }),
-      )
+      }),
+    )
 
-      await assessmentController.saveAssessment(
-        userId,
-        testId,
-        testType,
-        assessmentData,
-      )
-      return { success: true }
-    } catch (error) {
-      throw error
-    }
+    await assessmentController.saveAssessment(
+      userId,
+      testId,
+      testType,
+      assessmentData,
+    )
+    return { success: true }
   },
 
   // Load assessment from Firestore
   async loadAssessment({ commit }, { userId, testId }) {
-    try {
-      if (!userId) throw new Error('User ID is required')
+    if (!userId) throw new Error('User ID is required')
 
-      const assessment = await assessmentController.getAssessment(
-        userId,
-        testId,
-      )
-      if (!assessment) return null
+    const assessment = await assessmentController.getAssessment(
+      userId,
+      testId,
+    )
+    if (!assessment) return null
 
-      // Update the store with loaded assessment data
-      const ruleAssessments = {}
-      const completedRules = []
+    // Update the store with loaded assessment data
+    const ruleAssessments = {}
+    const completedRules = []
 
-      assessment.assessmentData.forEach((item) => {
-        const { ruleId, status, severity, notes } = item
-        ruleAssessments[ruleId] = { status, severity, notes }
-        if (status) completedRules.push(ruleId)
-      })
+    assessment.assessmentData.forEach((item) => {
+      const { ruleId, status, severity, notes } = item
+      ruleAssessments[ruleId] = { status, severity, notes }
+      if (status) completedRules.push(ruleId)
+    })
 
-      commit('SET_RULE_ASSESSMENTS', ruleAssessments)
-      commit('SET_COMPLETED_RULES', completedRules)
+    commit('SET_RULE_ASSESSMENTS', ruleAssessments)
+    commit('SET_COMPLETED_RULES', completedRules)
 
-      return assessment
-    } catch (error) {
-      throw error
-    }
+    return assessment
   },
 
   // Update a single rule assessment
@@ -659,55 +645,42 @@ const actions = {
     { commit, state },
     { userId, testId, ruleId, assessment },
   ) {
-    try {
-      if (!userId) throw new Error('User ID is required')
+    if (!userId) throw new Error('User ID is required')
 
-      // First update local state
-      commit('UPDATE_RULE_ASSESSMENT', { ruleId, assessment })
+    // First update local state
+    commit('UPDATE_RULE_ASSESSMENT', { ruleId, assessment })
 
-      // Then update in Firestore
-      await assessmentController.updateRuleAssessment(userId, testId, {
-        ruleId,
-        ...assessment,
-        // Add any additional metadata
-        ...(state.wcagData && {
-          ruleTitle: findRuleTitle(ruleId, state.wcagData),
-          principle: findPrincipleForRule(ruleId, state.wcagData),
-          guideline: findGuidelineForRule(ruleId, state.wcogData),
-        }),
-      })
+    // Then update in Firestore
+    await assessmentController.updateRuleAssessment(userId, testId, {
+      ruleId,
+      ...assessment,
+      ...(state.wcagData && {
+        ruleTitle: findRuleTitle(ruleId, state.wcagData),
+        principle: findPrincipleForRule(ruleId, state.wcagData),
+        guideline: findGuidelineForRule(ruleId, state.wcogData),
+      }),
+    })
 
-      return { success: true }
-    } catch (error) {
-      throw error
-    }
+    return { success: true }
   },
 
   // Add a new action to fetch configData from Firestore
   async fetchConfigData({ commit, state, rootState }, testId) {
-    try {
-      // Check if configData is already available in the store
-      if (state.configuration && state.configuration.testId === testId) {
-        return state.configuration
-      }
-
-      // Fetch userId from Auth module
-      const userId = rootState.Auth.user?.id
-      if (!userId) throw new Error('User not authenticated')
-
-      // Fetch configData from Firestore (replace with actual Firestore fetch logic)
-      const configData = await assessmentController.getConfigData(
-        userId,
-        testId,
-      )
-
-      // Commit the fetched configData to the store
-      commit('SET_CONFIGURATION', configData)
-
-      return configData
-    } catch (error) {
-      throw error
+    if (state.configuration && state.configuration.testId === testId) {
+      return state.configuration
     }
+
+    const userId = rootState.Auth.user?.id
+    if (!userId) throw new Error('User not authenticated')
+
+    const configData = await assessmentController.getConfigData(
+      userId,
+      testId,
+    )
+
+    commit('SET_CONFIGURATION', configData)
+
+    return configData
   },
 }
 


### PR DESCRIPTION
## Summary

- Remove ~30 `console.log` statements across 12 component/view files (including performance-critical ones like `EyeTrackingOverlay.vue` animation loop)
- Remove 19 no-op `catch(e) { throw e }` blocks across 9 files (`StudyController.js`, `UserController.js`, `AuthController.js`, `Assessment.js`, etc.)
- Remove 3 empty `else {}` blocks in `UserTestView.vue`, `HeuristicsTable.vue`, and `UserController.js`
- Remove a debug-only `watch()` in `TaskDetailsModal.vue` that served no purpose other than logging
- Remove top-level `console.log(tasksArray.value)` in `SusAnalytics.vue` that executed on every render

No logic changes — only cleanup of debug leftovers and dead code.

Closes #1835

![code-cleanup](https://img.shields.io/badge/cleanup-debug%20leftovers-blue)

## Files changed (22)

| Category | Files |
|----------|-------|
| console.log removal | `SusAnalytics.vue`, `TaskDetailsModal.vue`, `EyeTrackingOverlay.vue`, `VideoCall.vue`, `VideoRecorder.vue`, `UserTestView.vue`, `ModeratedTestView.vue`, `UserModeratedSentiment.vue`, `AudioWave.vue`, `EyeTrackingStats.vue`, `TaskStep.vue`, `CreateInviteDialog.vue` |
| catch-rethrow removal | `StudyController.js`, `UserController.js`, `AuthController.js`, `FirebaseFirestoreRepository.js`, `Assessment.js`, `useProfile.js`, `CooperatorsView.vue`, `Auth.js`, `User.js` |
| empty else removal | `UserTestView.vue`, `HeuristicsTable.vue`, `UserController.js` |

## Test plan

- [ ] Verify browser console is clean of debug output on all affected pages
- [ ] Verify error propagation still works correctly (errors bubble up naturally without catch-rethrow)
- [ ] Verify `EyeTrackingOverlay` renders correctly without debug logs in animation loop
- [ ] Verify `SusAnalytics` page loads without top-level console output