### PR TITLE
fix(heuristic): replace hardcoded 75% usability with real calculation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,9 @@ module.exports = {
   preset: '@vue/cli-plugin-unit-jest',
   transform: {
     '^.+\\.vue$': '@vue/vue3-jest',
-    '^.+\\.js$': 'babel-jest'
+    '^.+\\.js$': 'babel-jest',
   },
+  transformIgnorePatterns: ['/node_modules/(?!axios)'],
   testMatch: ['**/*.spec.js'],
   testPathIgnorePatterns: ['/e2e/'],
   setupFilesAfterEnv: ['./tests/mocks/firebase.js'],

--- a/src/ux/Heuristic/components/manager/UsabilityResults.vue
+++ b/src/ux/Heuristic/components/manager/UsabilityResults.vue
@@ -57,6 +57,7 @@
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useStore } from 'vuex'
 
 const props = defineProps({
   test: {
@@ -67,6 +68,7 @@ const props = defineProps({
 
 const router = useRouter()
 const { t } = useI18n()
+const store = useStore()
 
 // Navigate to answers section
 const navigateToAnswers = () => {
@@ -77,9 +79,46 @@ const navigateToAnswers = () => {
 
 // Computed properties
 const usabilityPercentage = computed(() => {
-  // Por ahora devolvemos 75% como solicitado
-  // En el futuro esto se calculará basado en las respuestas reales
-  return 75
+  const testAnswerDocument = store.getters.testAnswerDocument
+  if (!testAnswerDocument?.heuristicAnswers) return 0
+
+  const testOptions = props.test?.testOptions
+  if (!Array.isArray(testOptions) || testOptions.length === 0) return 0
+
+  const maxOption = Math.max(...testOptions.map((o) => o.value))
+  if (maxOption <= 0) return 0
+
+  const evaluators = Object.values(testAnswerDocument.heuristicAnswers)
+  if (evaluators.length === 0) return 0
+
+  const evaluatorResults = evaluators.map((evaluator) => {
+    let sumResult = 0
+    let totalQuestions = 0
+    let totalNA = 0
+
+    const heuristicGroups = evaluator.heuristicQuestions || []
+    heuristicGroups.forEach((heuristic) => {
+      const questions = heuristic.heuristicQuestions || []
+      questions.forEach((question) => {
+        const answer = question.heuristicAnswer
+        // Answer may be {value, text} object (after getter transform) or raw number
+        const value = typeof answer === 'object' ? answer?.value : answer
+        totalQuestions++
+        if (value === -1) {
+          totalNA++
+        } else if (value !== null && value !== undefined) {
+          sumResult += value
+        }
+      })
+    })
+
+    const perfectScore = (totalQuestions - totalNA) * maxOption
+    return perfectScore === 0 ? 0 : (sumResult * 100) / perfectScore
+  })
+
+  const average =
+    evaluatorResults.reduce((sum, r) => sum + r, 0) / evaluatorResults.length
+  return parseFloat(average.toFixed(2))
 })
 
 const participantsCount = computed(() => {

--- a/src/ux/Heuristic/components/manager/UsabilityResults.vue
+++ b/src/ux/Heuristic/components/manager/UsabilityResults.vue
@@ -85,7 +85,10 @@ const usabilityPercentage = computed(() => {
   const testOptions = props.test?.testOptions
   if (!Array.isArray(testOptions) || testOptions.length === 0) return 0
 
-  const maxOption = Math.max(...testOptions.map((o) => o.value))
+  const finiteValues = testOptions
+    .map((o) => Number(o.value))
+    .filter(Number.isFinite)
+  const maxOption = finiteValues.length > 0 ? Math.max(...finiteValues) : 0
   if (maxOption <= 0) return 0
 
   const evaluators = Object.values(testAnswerDocument.heuristicAnswers)
@@ -102,11 +105,12 @@ const usabilityPercentage = computed(() => {
       questions.forEach((question) => {
         const answer = question.heuristicAnswer
         // Answer may be {value, text} object (after getter transform) or raw number
-        const value = typeof answer === 'object' ? answer?.value : answer
+        const rawValue = typeof answer === 'object' ? answer?.value : answer
+        const value = Number.isFinite(rawValue) ? rawValue : null
         totalQuestions++
-        if (value === -1) {
+        if (value === null || value === -1) {
           totalNA++
-        } else if (value !== null && value !== undefined) {
+        } else {
           sumResult += value
         }
       })

--- a/tests/unit/heuristic/UsabilityResults.spec.js
+++ b/tests/unit/heuristic/UsabilityResults.spec.js
@@ -133,4 +133,41 @@ describe('UsabilityResults.vue', () => {
     expect(text).not.toContain('NaN')
     expect(text).not.toContain('Infinity')
   })
+
+  it('treats null answers as N/A', () => {
+    // 3 questions: value 5, null (N/A), value 3 → perfectScore = 2*5 = 10, sum = 8 → 80%
+    const wrapper = mountComponent({
+      testAnswerDocument: buildDocument({
+        evaluator1: evaluatorFromAnswers([{ value: 5 }, null, { value: 3 }]),
+      }),
+    })
+
+    expect(wrapper.text()).toContain('80%')
+  })
+
+  it('treats undefined answers as N/A', () => {
+    // 3 questions: value 4, undefined (N/A), value 2 → perfectScore = 2*5 = 10, sum = 6 → 60%
+    const wrapper = mountComponent({
+      testAnswerDocument: buildDocument({
+        evaluator1: evaluatorFromAnswers([
+          { value: 4 },
+          undefined,
+          { value: 2 },
+        ]),
+      }),
+    })
+
+    expect(wrapper.text()).toContain('60%')
+  })
+
+  it('handles mixed null, undefined, and -1 as N/A correctly', () => {
+    // 4 questions: value 5, null (N/A), undefined (N/A), -1 (N/A) → perfectScore = 1*5 = 5, sum = 5 → 100%
+    const wrapper = mountComponent({
+      testAnswerDocument: buildDocument({
+        evaluator1: evaluatorFromAnswers([{ value: 5 }, null, undefined, -1]),
+      }),
+    })
+
+    expect(wrapper.text()).toContain('100%')
+  })
 })

--- a/tests/unit/heuristic/UsabilityResults.spec.js
+++ b/tests/unit/heuristic/UsabilityResults.spec.js
@@ -1,0 +1,136 @@
+jest.mock('vue-router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+jest.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key) => key }),
+}))
+
+import { shallowMount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import UsabilityResults from '@/ux/Heuristic/components/manager/UsabilityResults.vue'
+
+const baseTest = {
+  id: 'test-1',
+  cooperators: [{ id: 'c1' }],
+  testOptions: [{ value: 1 }, { value: 5 }],
+}
+
+const buildDocument = (evaluatorAnswers) => ({
+  heuristicAnswers: evaluatorAnswers,
+})
+
+const evaluatorFromAnswers = (answers) => ({
+  heuristicQuestions: [
+    {
+      heuristicQuestions: answers.map((answer) => ({
+        heuristicAnswer: answer,
+      })),
+    },
+  ],
+})
+
+const mountComponent = ({
+  testAnswerDocument = null,
+  testProp = baseTest,
+} = {}) => {
+  const store = createStore({
+    getters: {
+      testAnswerDocument: () => testAnswerDocument,
+      test: () => ({ testOptions: testProp?.testOptions || [] }),
+    },
+  })
+
+  return shallowMount(UsabilityResults, {
+    props: { test: testProp },
+    global: {
+      plugins: [store],
+      mocks: {
+        $t: (key) => key,
+      },
+      stubs: {
+        'v-card': { template: '<div><slot /></div>' },
+        'v-card-title': { template: '<div><slot /></div>' },
+        'v-icon': { template: '<span><slot /></span>' },
+        'v-progress-circular': {
+          props: ['modelValue'],
+          template: '<div><slot /></div>',
+        },
+      },
+    },
+  })
+}
+
+describe('UsabilityResults.vue', () => {
+  it('shows 0% when testAnswerDocument is missing', () => {
+    const wrapper = mountComponent({ testAnswerDocument: null })
+
+    expect(wrapper.text()).toContain('0%')
+  })
+
+  it('shows 0% when heuristicAnswers is empty', () => {
+    const wrapper = mountComponent({
+      testAnswerDocument: buildDocument({}),
+    })
+
+    expect(wrapper.text()).toContain('0%')
+  })
+
+  it('shows 0% when testOptions is missing', () => {
+    const wrapper = mountComponent({
+      testAnswerDocument: buildDocument({
+        evaluator1: evaluatorFromAnswers([{ value: 5 }, { value: 4 }]),
+      }),
+      testProp: {
+        id: 'test-1',
+        cooperators: [],
+      },
+    })
+
+    expect(wrapper.text()).toContain('0%')
+  })
+
+  it('shows the correct calculated percentage for valid evaluator data', () => {
+    const wrapper = mountComponent({
+      testAnswerDocument: buildDocument({
+        evaluator1: evaluatorFromAnswers([
+          { value: 5 },
+          { value: 4 },
+          { value: 3 },
+          { value: 2 },
+        ]),
+      }),
+    })
+
+    expect(wrapper.text()).toContain('70%')
+  })
+
+  it('shows the correct average for mixed evaluators with N/A values', () => {
+    const wrapper = mountComponent({
+      testAnswerDocument: buildDocument({
+        evaluator1: evaluatorFromAnswers([
+          { value: 5 },
+          { value: -1 },
+          { value: 3 },
+        ]),
+        evaluator2: evaluatorFromAnswers([2, 2, 2]),
+      }),
+    })
+
+    expect(wrapper.text()).toContain('60%')
+  })
+
+  it('shows 0% when all answers are N/A and avoids NaN/Infinity', () => {
+    const wrapper = mountComponent({
+      testAnswerDocument: buildDocument({
+        evaluator1: evaluatorFromAnswers([{ value: -1 }, { value: -1 }]),
+        evaluator2: evaluatorFromAnswers([-1]),
+      }),
+    })
+
+    const text = wrapper.text()
+    expect(text).toContain('0%')
+    expect(text).not.toContain('NaN')
+    expect(text).not.toContain('Infinity')
+  })
+})


### PR DESCRIPTION
## Description

Closes #1852

The `UsabilityResults.vue` dashboard card always displayed a hardcoded **75%** usability score regardless of actual evaluator responses. This PR replaces the placeholder with a real calculation that reads answer data from the Vuex store and computes the true usability percentage.

## What changed

### `src/ux/Heuristic/components/manager/UsabilityResults.vue`
- Added `useStore()` from Vuex to access answer data via `store.getters.testAnswerDocument`
- Replaced `return 75` in `usabilityPercentage` computed property with real logic:
  - Reads each evaluator's answers from `heuristicAnswers`
  - Computes `maxOption` from `props.test.testOptions`
  - Handles both `{value, text}` object answers and raw number answers
  - Skips N/A answers (`value === -1`)
  - Calculates per-evaluator percentage: `(sum × 100) / ((totalQ − totalNA) × maxOption)`
  - Returns the average across all evaluators

### `tests/unit/heuristic/UsabilityResults.spec.js` *(new file)*
- 6 unit tests covering all edge cases:
  1. No `testAnswerDocument` → `0%`
  2. Empty `heuristicAnswers` → `0%`
  3. Missing `testOptions` → `0%`
  4. Valid evaluator data → correct calculated percentage
  5. Mixed evaluators (some N/A, some valid) → correct average
  6. All N/A answers → `0%` (no `NaN` or `Infinity`)

## Screenshot
![Screenshot_11-3-2026_162243_github com](https://github.com/user-attachments/assets/0b7dad37-ae20-45ad-bf5d-f6b79f2b5fd0)

## Edge cases handled
- `testAnswerDocument` is `null` or missing `heuristicAnswers`
- `testOptions` is `null`, `undefined`, or empty array
- `maxOption` is `0` or negative
- `0` evaluators in `heuristicAnswers`
- All answers are N/A (`-1`) — prevents division by zero
- Answers in mixed formats (object `{value, text}` vs raw number)

## Validation
| Gate | Result |
|------|--------|
| `npm test` | ✅ 11 suites, 99 tests, 0 failures |
| `npx eslint UsabilityResults.vue` | ✅ 0 errors |
| `npm run build-prod` | ✅ Build succeeded |

## Files changed
- `src/ux/Heuristic/components/manager/UsabilityResults.vue` — 45 insertions, 3 deletions
- `tests/unit/heuristic/UsabilityResults.spec.js` — 136 insertions (new file)