### PR TITLE
fix/fixed the card spacing issue in smaller formfactor devices

### DIFF
--- a/src/ux/UserTest/components/manager/StudyOverview.vue
+++ b/src/ux/UserTest/components/manager/StudyOverview.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row>
     <!-- Total Users -->
-    <v-col cols="12" md="6" class="py-0">
+    <v-col cols="12" sm="6">
       <v-card class="study-card study-card-primary-blur" elevation="8">
         <v-card-text class="pa-4">
           <div class="d-flex justify-space-between align-center">
@@ -20,7 +20,7 @@
     </v-col>
 
     <!-- Completed Tests -->
-    <v-col cols="12" md="6" class="py-0">
+    <v-col cols="12" sm="6">
       <v-card class="study-card study-card-primary-blur" elevation="8">
         <v-card-text class="pa-4">
           <div class="d-flex justify-space-between align-center">
@@ -46,7 +46,7 @@
     </v-col>
 
     <!-- In Progress -->
-    <v-col cols="12" md="6" m>
+    <v-col cols="12" sm="6">
       <v-card class="study-card study-card-primary-blur" elevation="8">
         <v-card-text class="pa-4">
           <div class="d-flex justify-space-between align-center">
@@ -72,7 +72,7 @@
     </v-col>
 
     <!-- Average Completion Time -->
-    <v-col cols="12" md="6">
+    <v-col cols="12" sm="6">
       <v-card class="study-card study-card-primary-blur" elevation="8">
         <v-card-text class="pa-4">
           <div class="d-flex justify-space-between align-center">


### PR DESCRIPTION
This PR fixes an issue where the cards (Total Participants, Completed, In Progress, Average Time) on the Manager page had uneven vertical and horizontal spacing when viewed on smaller screens (tablets and mobile).

Changes
   - Even padding: Removed inconsistent padding.
   - Improved Responsiveness: Changed the column breakpoint from md="6" to sm="6". This allows the cards to maintain a clean 2x2 grid layout on tablet-sized screens before stacking into a single column on mobile, rather than jumping straight from 2 columns to 1.
   - Fixed typo: Resolved a typo in the "In Progress" column.

before:
mobile
<img width="496" height="899" alt="Screenshot from 2026-03-11 22-03-51" src="https://github.com/user-attachments/assets/99815894-cc5e-43da-9a06-8830be9997f6" />

tablets
<img width="1027" height="906" alt="Screenshot from 2026-03-11 22-30-44" src="https://github.com/user-attachments/assets/9a326732-9521-4ff6-911b-5db2ff026c44" />


changes:
mobile
<img width="476" height="906" alt="Screenshot from 2026-03-11 22-34-41" src="https://github.com/user-attachments/assets/7d3a4a59-a56b-42ad-b36d-dd68445db806" />

tablets
<img width="1027" height="906" alt="Screenshot from 2026-03-11 22-33-40" src="https://github.com/user-attachments/assets/cd820995-a544-47cf-8301-75187a51c755" />
