### PR TITLE
fix: use answersDocId instead of testDocId when deleting answer document

### DIFF
--- a/src/shared/controllers/AnswerController.js
+++ b/src/shared/controllers/AnswerController.js
@@ -40,7 +40,7 @@ export default class AnswerController extends Controller {
 
     // Delete answers document
     const answerDocumentId =
-      userToUpdate.myAnswers[`${payload.testDocId}`].testDocId
+      userToUpdate.myAnswers[`${payload.testDocId}`].answersDocId
     await super.delete(COLLECTION, answerDocumentId)
 
     // Remove it from user


### PR DESCRIPTION
Fixes #1861

### Problem
The `removeUserAnswer` method in `AnswerController` was deleting the wrong Firestore document.
The code previously used:
`userToUpdate.myAnswers[payload.testDocId].testDocId`

However, `testDocId` represents the **study identifier**, not the **Firestore document ID of the answer**.
The `UserAnswer` model stores two fields:
- `testDocId` → study identifier
- `answersDocId` → Firestore document ID in the `answers` collection

Because of this mismatch, the system attempted to delete: `answers/{testDocId}`
instead of the actual answer document: `answers/{answersDocId}`
This left orphaned answer documents in Firestore when a cooperator was removed.
### Solution
The deletion now uses `answersDocId` instead of `testDocId`:
```js
const answerDocumentId =
  userToUpdate.myAnswers[payload.testDocId].answersDocId
```
This ensures the correct document in the answers collection is deleted.

### Impact

- Prevents orphaned answer documents in Firestore
- Ensures cooperator removal cleans up associated answer data correctly
- Maintains data integrity for analytics and reporting

**Files Changed:** src/shared/controllers/AnswerController.js