### PR TITLE
Add Playwright E2E test for heuristic study creation (inspection category)

### DIFF
--- a/e2e/createStudy.spec.js
+++ b/e2e/createStudy.spec.js
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+//creating a heuristic study
+
+const studyName = `test-study-${Date.now()}`;
+
+const login = async (page)=>{
+  await test.step('Navigate to signin page', async () => {
+    await page.goto('http://localhost:8080/signin', { waitUntil: 'networkidle' });
+  });
+
+  await test.step('Fill login credentials', async () => {
+    await page.getByLabel('Email').fill('dfa@dfa.com');
+    await page.getByLabel('Password', { exact: true }).fill('Password@123');
+  });
+
+  await test.step('Click "Sign In" button', async () => {
+    await page.getByTestId('sign-in-button').click();
+    await expect(page).toHaveURL(/admin/);
+  });
+}
+//3.--study type--
+const studyType = async (page) => {
+  await page.locator('text=Start with Blank Study').click();//update by adding TestId
+}
+//4.--details--
+const fillDetails = async (page) => {
+  //update by adding TestId
+  await page.getByLabel('Study Title').fill(studyName);
+  await page.getByLabel('Study Description').fill('success');
+
+  await page.getByRole('button',{ name: /Create Study/}).click();
+}
+
+const verifyStudy = async (page) => {
+    await expect(page.getByRole('heading',{ name: studyName })).toBeVisible({ timeout: 7000 });
+}
+
+test.describe('Study Creation',() => {
+
+    test.use({//lock viewport to ensure consistent dektop layout ,and to avoid(menu/create study) for smaller viewports
+        viewport: { width: 1280, height: 720 }
+    })
+
+    test.beforeEach(async ({page}) => {
+        await login(page);
+    })
+
+    //category-Inspection
+    test('admin can create an Heuristic Study',async ({page}) => {
+        await test.step('Verify and click create-new-study button',async () => {
+            await page.locator('button:has-text("Create new study")').first().click();
+        });
+
+        await test.step('1.choosing Category',async () => {
+            await page.locator('text=Inspection').click();//update by adding TestId
+        });
+
+        await test.step('2.choosing Methods',async () => {
+            await page.locator('text=Heuristic Evaluation').click();//update by adding TestId
+        });
+
+        await test.step('3.choosing Study Type',async () => {
+            await studyType(page);
+        });
+
+        await test.step('4.Filling Study Details',async () => {
+            await fillDetails(page);
+        });
+
+        await test.step('verifying created study',async () => {
+            await verifyStudy(page);
+        });
+
+    })
+})


### PR DESCRIPTION
## Description
This PR adds an end-to-end Playwright test covering the heuristic study creation flow in RUXAILAB.
The test validates the current study creation workflow for the **Inspection(category) → Heuristic Evaluation** .
(also used existing e2e tests as reference)
## What this test covers
The following user flow is tested:
1. Admin login
2. Create new study
3. Select category: **Inspection**
4. Select method: **Heuristic Evaluation**
5. Select study type: **Start with Blank Study**
6. Fill study details
7. Create study
8. Verify the created study appears on the dashboard
## Impact
Some existing E2E tests appear to reference the older **test creation** workflow.  Since the UI now represents these as **studies**, those tests may fail due to the updated interface.
This test reflects the **current study-based workflow**.
## Local testing
The test was executed locally:
- Ran this test - Verified successful execution across **Chromium and Firefox**
- <img width="1366" height="768" alt="Screenshot from 2026-03-12 17-17-38" src="https://github.com/user-attachments/assets/90865556-e0f4-412e-b767-a0bc7eedbade" />
## Future improvements
Next planned tests:
- Testing category study creation flow (one method)- Additional coverage for other study creation flows
Happy to extend coverage for all study flows(following this pattern) if preferred.

## Related Issue
Closes #1869 