### PR TITLE
fix(profile): correct deleteAuth payload and remove duplicate deletion logic

### DIFF
--- a/src/features/auth/composables/useDeleteAccount.js
+++ b/src/features/auth/composables/useDeleteAccount.js
@@ -6,10 +6,7 @@ import {
   EmailAuthProvider,
   reauthenticateWithPopup,
   GoogleAuthProvider,
-  deleteUser,
 } from 'firebase/auth'
-import { doc, deleteDoc } from 'firebase/firestore'
-import { db } from '@/app/plugins/firebase'
 import { showError, showSuccess } from '../../../shared/utils/toast'
 
 const SHARED_ERRORS = {
@@ -44,18 +41,9 @@ export function useDeleteAccount() {
     showError(messageKey)
   }
 
-  const deleteAccount = async (user) => {
+  const deleteAccount = async (user, password) => {
     try {
-      const userDocRef = doc(db, 'users', user.uid)
-      await deleteDoc(userDocRef)
-
-      try {
-        await store.dispatch('deleteAuth', user.uid)
-      } catch (storeError) {
-        return storeError
-      }
-
-      await deleteUser(user)
+      await store.dispatch('deleteAuth', { user, password })
 
       showSuccess('profile.accountDeletedSuccess')
 
@@ -63,15 +51,6 @@ export function useDeleteAccount() {
     } catch (error) {
       if (error.code === 'permission-denied') {
         showError('profile.permissionDenied')
-      } else if (error.code === 'not-found') {
-        try {
-          await deleteUser(user)
-          showSuccess('profile.accountDeletedSuccess')
-          await signOut()
-        } catch (authError) {
-          showError('profile.accountDeletionFailed')
-          throw authError
-        }
       } else {
         showError('profile.accountDeletionFailed')
         throw error
@@ -112,7 +91,7 @@ export function useDeleteAccount() {
     try {
       isDeleting.value = true
       await reauthenticateWithPopup(user, new GoogleAuthProvider())
-      await deleteAccount(user)
+      await deleteAccount(user, null)
     } catch (error) {
       handleAuthError(error, GOOGLE_ERRORS)
     } finally {
@@ -140,7 +119,7 @@ export function useDeleteAccount() {
       const cred = EmailAuthProvider.credential(user.email, userPassword.value)
       await reauthenticateWithCredential(user, cred)
 
-      await deleteAccount(user)
+      await deleteAccount(user, userPassword.value)
     } catch (error) {
       handleAuthError(error, EMAIL_ERRORS)
     } finally {

--- a/src/features/auth/controllers/AuthController.js
+++ b/src/features/auth/controllers/AuthController.js
@@ -8,9 +8,6 @@ import {
   setPersistence,
   browserLocalPersistence,
   browserSessionPersistence,
-  reauthenticateWithCredential,
-  reauthenticateWithPopup,
-  EmailAuthProvider,
 } from 'firebase/auth'
 import { auth } from '@/app/plugins/firebase'
 import axios from 'axios'
@@ -114,20 +111,7 @@ export default class AuthController {
     const { user, password } = payload
 
     if (!user) throw new Error('No user provided')
-
-    const hasGoogle = user.providerData.some(
-      (p) => p.providerId === 'google.com',
-    )
-
-    // Reauthenticate based on provider
-    if (hasGoogle) {
-      await reauthenticateWithPopup(user, new GoogleAuthProvider())
-    } else {
-      if (!password) throw new Error('Password required')
-      const cred = EmailAuthProvider.credential(user.email, password)
-      await reauthenticateWithCredential(user, cred)
-    }
-
+      
     // Delete user from Firebase Auth
     await user.delete()
 

--- a/src/features/auth/controllers/AuthController.js
+++ b/src/features/auth/controllers/AuthController.js
@@ -101,12 +101,13 @@ export default class AuthController {
   }
 
   /**
-   * Delete user account - consolidated method
+   * Deletes the authenticated user account and cleans up backend data.
+   * @precondition Caller must reauthenticate the user before invoking 
+   * this method. This is handled by useDeleteAccount.js composable.
    * @param {Object} payload - Deletion payload
-   * @param {Object} payload.user - Firebase auth user
-   * @param {string} payload.password - User password for reauthentication (optional)
+   * @param {Object} payload.user - Firebase auth user (already reauthenticated)
    * @returns {Promise}
-   */
+  */
   async deleteAuth(payload) {
     const { user } = payload
 

--- a/src/features/auth/controllers/AuthController.js
+++ b/src/features/auth/controllers/AuthController.js
@@ -108,10 +108,10 @@ export default class AuthController {
    * @returns {Promise}
    */
   async deleteAuth(payload) {
-    const { user, password } = payload
+    const { user } = payload
 
     if (!user) throw new Error('No user provided')
-      
+
     // Delete user from Firebase Auth
     await user.delete()
 


### PR DESCRIPTION
## What does this PR do?
Fixes two bugs in the account deletion flow from the profile UI that caused deletion to fail silently and attempt multiple redundant operations.

## Related Issue
Closes #1872

## Root Cause Analysis
**Bug 1 - Wrong payload to 'deleteAuth'**
'useDeleteAccount.js' was dispatching:
```js
await store.dispatch('deleteAuth', user.uid) // raw UID string
```
But 'AuthController.deleteAuth()' destructures its payload as an object:
```js
const { user, password } = payload
if (!user) throw new Error('No user provided') // always threw
```
This caused every deletion attempt to fail immediately.

**Bug 2 - Triple deletion**
The composable was executing deletion in three separate place:
- 'deleteDoc(userDocRef)' - manual Firestore deletion
- 'store.dispatch('deleteAuth', ...)' - controller calls `user.delete()` + `deleteUserData()`
- `deleteUser(user)` — redundant Firebase Auth deletion

**Bug 3 - Double reauthentication**
The composable reauthenticates the user before calling `deleteAccount()`, but `AuthController.deleteAuth()` was also reauthenticating internally, causing redundant popup/credential prompts.

## Changes Made
**`useDeleteAccount.js`**
- Fixed dispatch payload from `user.uid` to `{ user, password }`
- Added `password` parameter to `deleteAccount()` and passed it through from both `handleDeleteAccount` and `handleDeleteConfirmText`
- Removed `deleteDoc(userDocRef)` - backend cleanup is handled by controller
- Removed redundant `deleteUser(user)` call
- Removed unused imports: `deleteUser`, `doc`, `deleteDoc`, `db`

**`AuthController.js`**
- Removed internal reauthentication block - composable handles this before dispatching, so controller only needs to execute deletion
- Removed unused imports: `reauthenticateWithCredential`, `reauthenticateWithPopup`, `EmailAuthProvider`

## Deletion Flow After Fix
```
handleDeleteAccount / handleDeleteConfirmText
  → reauthenticate (once, in composable)
  → store.dispatch('deleteAuth', { user, password })
      → user.delete()           (Firebase Auth removal)
      → deleteUserData(user.uid) (backend cleanup, best-effort)
  → showSuccess()
  → signOut() → redirect to /signin
```

## Testing
- [x] Email account deletion: correct password → account deleted, redirected to /signin
- [x] Email account deletion: wrong password → shows `errors.incorrectPassword`
- [x] Google account deletion: popup accepted → account deleted, redirected to /signin  
- [x] Google account deletion: popup closed → shows `errors.authenticationCancelled`
- [x] Firebase Auth console: user removed after deletion
- [x] Firestore console: user document removed after deletion

## Demo
**Before:** Deletion fails silently, user remains in Firebase Auth

**After:**
Email signup deletion flow
https://github.com/user-attachments/assets/ed8e3304-1a51-43dc-85e8-32c1467d687b

Google account signup deletion flow

https://github.com/user-attachments/assets/4c174364-3be2-4276-87ff-4938fb4b25d2