### PR TITLE
fix(auth): handle Google sign-in popup dismissal gracefully

### DIFF
--- a/src/features/auth/store/Auth.js
+++ b/src/features/auth/store/Auth.js
@@ -170,14 +170,19 @@ export default {
           type: 'success',
         })
       } catch (err) {
-        if (err.message === 'EMAIL_NOT_VERIFIED') {
-          throw err
+        const silentErrors = [
+          'auth/popup-closed-by-user',
+          'auth/cancelled-popup-request',
+        ]
+        if (!silentErrors.includes(err.code)) {
+          commit('SET_TOAST', {
+            message: i18n.global.t('errors.globalError'),
+            type: 'error',
+          })
         }
-        commit('SET_TOAST', {
-          message: i18n.global.t('errors.globalError'),
-          type: 'error',
-        })
         throw err
+      } finally {
+        commit('setLoading', false)
       }
     },
 

--- a/src/features/auth/views/SignInView.vue
+++ b/src/features/auth/views/SignInView.vue
@@ -198,7 +198,7 @@ const onGoogleSignInSuccess = async () => {
 
 const onGoogleSignInError = (error) => {
   loadingType.value = ''
-  store.dispatch('setLoading', false)
+  store.commit('setLoading', false)
   return error
 }
 </script>


### PR DESCRIPTION
## What does this PR do?
Fixes a bug where closing the Google sign-in popup mid-flow caused the sign-in page to freeze completely, requiring a full page reload to recover.

## Related Issue
Closes #1877

## Root Cause Analysis
**Bug 1 - `SignInView.vue`: wrong method to reset loading state** `onGoogleSignInError` was calling:
```js
store.dispatch('setLoading', false) // dispatch is for actions
```
But `setLoading` is a **mutation**, not an action. `dispatch` silently fails, leaving `loading = true` forever - freezing all buttons.

**Bug 2 - `Auth.js`: no `finally` block in `signInWithGoogle`** Every other action (`signin`, `logout`, `resetPassword`) resets loading in a `finally` block. `signInWithGoogle` had no `finally`, so any error left loading stuck even if Bug 1 was fixed.

**Bug 3 - `Auth.js`: popup close treated as a real error** `auth/popup-closed-by-user` is a deliberate user action, not an error. It was being caught and shown as a generic error toast.

## Changes Made
**`src/features/auth/views/SignInView.vue`**
- Changed `store.dispatch('setLoading', false)` → `store.commit('setLoading', false)` in `onGoogleSignInError`

**`src/features/auth/store/Auth.js`**
- Added `finally` block to `signInWithGoogle` to always reset loading state
- Added silent error handling for `auth/popup-closed-by-user` and `auth/cancelled-popup-request` these are intentional user actions and should not show an error toast

## Fix Flow
```
User closes Google popup
  → Firebase throws auth/popup-closed-by-user
  → silentErrors check: skip toast ✓
  → finally: commit('setLoading', false) ✓
  → onGoogleSignInError: store.commit('setLoading', false) ✓
  → loadingType reset to '' ✓
  → Page fully interactive again ✓
```

## Testing
- [x] Close Google popup → no error toast, page remains interactive
- [x] Close Google popup → can immediately retry Google sign-in
- [x] Close Google popup → can immediately use email sign-in
- [x] Successful Google sign-in → redirects to /admin correctly
- [x] Wrong email/password → still shows correct error message
- [x] Normal email sign-in unaffected by these changes

## Demo
**Before:** Throws error and the page freezes

**After:** No error thrown and the page is responsive.

https://github.com/user-attachments/assets/ea6f460d-8804-4864-80d0-8c0fe3941d97