### PR TITLE
fix(profile): correct deleteAuth payload and remove duplicate deletion

### DIFF
--- a/src/features/auth/composables/useDeleteAccount.js
+++ b/src/features/auth/composables/useDeleteAccount.js
@@ -44,51 +44,22 @@ export function useDeleteAccount() {
     showError(messageKey)
   }
 
-  const deleteAccount = async (user) => {
+  const deleteAccount = async (user, password) => {
     try {
-      const userDocRef = doc(db, 'users', user.uid)
-      await deleteDoc(userDocRef)
-
-      try {
-        await store.dispatch('deleteAuth', user.uid)
-      } catch (storeError) {
-        return storeError
-      }
-
-      await deleteUser(user)
+      await store.dispatch('deleteAuth', { user, password })
 
       showSuccess('profile.accountDeletedSuccess')
-
       await signOut()
     } catch (error) {
-      if (error.code === 'permission-denied') {
-        showError('profile.permissionDenied')
-      } else if (error.code === 'not-found') {
-        try {
-          await deleteUser(user)
-          showSuccess('profile.accountDeletedSuccess')
-          await signOut()
-        } catch (authError) {
-          showError('profile.accountDeletionFailed')
-          throw authError
-        }
-      } else {
-        showError('profile.accountDeletionFailed')
-        throw error
-      }
+      showError('profile.accountDeletionFailed')
+      throw error
     }
   }
 
   const signOut = async () => {
-    try {
-      await store.dispatch('logout', { silent: true })
-      setTimeout(() => {
-        globalThis.location.href = '/signin'
-      }, 500)
-    } catch (error) {
+    setTimeout(() => {
       globalThis.location.href = '/signin'
-      return error
-    }
+    }, 500)
   }
 
   const handleDeleteConfirmText = async () => {
@@ -111,7 +82,6 @@ export function useDeleteAccount() {
 
     try {
       isDeleting.value = true
-      await reauthenticateWithPopup(user, new GoogleAuthProvider())
       await deleteAccount(user)
     } catch (error) {
       handleAuthError(error, GOOGLE_ERRORS)
@@ -136,11 +106,7 @@ export function useDeleteAccount() {
 
     try {
       isDeleting.value = true
-
-      const cred = EmailAuthProvider.credential(user.email, userPassword.value)
-      await reauthenticateWithCredential(user, cred)
-
-      await deleteAccount(user)
+      await deleteAccount(user, userPassword.value)
     } catch (error) {
       handleAuthError(error, EMAIL_ERRORS)
     } finally {

--- a/src/features/auth/composables/useDeleteAccount.js
+++ b/src/features/auth/composables/useDeleteAccount.js
@@ -1,15 +1,6 @@
 import { ref } from 'vue'
 import { useStore } from 'vuex'
-import {
-  getAuth,
-  reauthenticateWithCredential,
-  EmailAuthProvider,
-  reauthenticateWithPopup,
-  GoogleAuthProvider,
-  deleteUser,
-} from 'firebase/auth'
-import { doc, deleteDoc } from 'firebase/firestore'
-import { db } from '@/app/plugins/firebase'
+import { getAuth } from 'firebase/auth'
 import { showError, showSuccess } from '../../../shared/utils/toast'
 
 const SHARED_ERRORS = {


### PR DESCRIPTION
Fixes #1872
### Summary
Fixes the profile account deletion flow by sending the correct payload to the `deleteAuth` store action and removing redundant deletion logic from the composable.

### Problem
The profile deletion flow dispatched `deleteAuth` with a UID string:
```js
await store.dispatch('deleteAuth', user.uid)
```
However, the controller expects the payload in the following format:
`{ user, password }`
Because of this mismatch, the controller failed with: `Error: No user provided.`
Additionally, the composable also deleted the Firestore document and Firebase user locally before dispatching deleteAuth, which could lead to duplicate deletion attempts and inconsistent cleanup.
### Changes
- Pass `{user, password}` payload to `deleteAuth`
- Remove local Firestore document deletion from the composable
- Remove redundant `deleteUser()` call
- Keep account deletion centralized in the auth controller
### Result
The deletion flow now follows a single responsibility path. The profile UI calls `deleteAuth` through the store, which triggers `AuthController.deleteAuth`. The controller then handles the Firebase Auth deletion and backend user data cleanup, avoiding duplicate deletion logic.
### Before Changes
https://github.com/user-attachments/assets/921ff145-4192-4845-bcda-8c73d6797e26
### After Changes
https://github.com/user-attachments/assets/caf72657-b948-4985-83ef-64b6e20620a7



