### PR TITLE
fix(auth): prevent infinite recursion in VerifyEmailView logout handler

### DIFF
--- a/src/features/auth/views/VerifyEmailView.vue
+++ b/src/features/auth/views/VerifyEmailView.vue
@@ -118,7 +118,10 @@ export default {
   },
 
   methods: {
-    ...mapActions(['sendVerificationEmail', 'logout']),
+    ...mapActions({
+      sendVerificationEmail: 'sendVerificationEmail',
+      logoutAction: 'logout',
+    }),
 
     async checkEmailVerificationStatus() {
       try {
@@ -178,7 +181,7 @@ export default {
 
     async logout() {
       try {
-        await this.logout()
+        await this.logoutAction()
         this.$router.push('/signin')
       } catch {}
     },


### PR DESCRIPTION
Closes #1881
### Summary

This PR fixes an infinite recursion issue in the **VerifyEmailView logout handler** that prevents users from signing out from the email verification page.

The problem occurs because the component maps the Vuex `logout` action using `mapActions`, while also defining a component method named `logout`. The method calls `this.logout()`, which resolves to the same component method instead of the Vuex action, resulting in infinite recursion and eventual stack overflow.

### Root Cause

In `VerifyEmailView.vue`, the Vuex action is mapped as:

```javascript
...mapActions(['sendVerificationEmail', 'logout'])
```

Later, a method with the same name overrides the mapped action:

```javascript
async logout() {
  await this.logout()
}
```

Execution flow becomes:

```
logout()
 └── this.logout()
      └── logout()
           └── this.logout()
                ...
```

This causes **infinite recursion** and prevents the logout process from completing.

### Fix

The Vuex logout action is aliased to `logoutAction` to avoid the naming collision with the component method.

Updated mapping:

```javascript
...mapActions({
  sendVerificationEmail: 'sendVerificationEmail',
  logoutAction: 'logout'
})
```

Updated method:

```javascript
async logout() {
  try {
    await this.logoutAction()
    this.$router.push('/signin')
  } catch (error) {
    console.error('Logout failed:', error)
  }
}
```

This ensures the component method calls the correct Vuex action.

### Before Fix

Console output repeatedly logs:

```
logout called
logout called
logout called
RangeError: Maximum call stack size exceeded
```

The page becomes unresponsive and the user cannot log out.

https://github.com/user-attachments/assets/08702716-4bbd-45c1-8bb2-05adec2e077b



### After Fix

* The Vuex logout action is executed correctly.
* The user is signed out.
* The application redirects to `/signin`.

https://github.com/user-attachments/assets/011c379d-b4ca-439b-a364-aca9fda5d68e



### Files Changed

```
src/features/auth/views/VerifyEmailView.vue
```

### Testing
Verified locally by:
* Navigating to `/verify-email`
* Clicking **Sign Out**
* Confirming successful logout and redirect to `/signin`
* Confirming no recursion or console errors occur
