### PR TITLE
added benchmark result storage and retrieval endpoints

### DIFF
--- a/functions/src/https/eyeTracking.js
+++ b/functions/src/https/eyeTracking.js
@@ -100,3 +100,91 @@ export const getCalibrationConfig = functions.onRequest({
     }
   },
 })
+
+export const storeBenchmarkResult = functions.onRequest({
+  handler: async (req, res) => {
+    if (req.method !== 'POST') {
+      return res.status(405).send('Method Not Allowed')
+    }
+
+    try {
+      const { session_id, benchmark_results } = req.body
+
+      if (!session_id) {
+        return res.status(400).json({ error: 'session_id is required' })
+      }
+
+      if (!benchmark_results) {
+        return res.status(400).json({ error: 'benchmark_results is required' })
+      }
+
+      const db = admin.firestore()
+
+      const benchmarkRef = db.collection('benchmarks').doc(session_id)
+      const existingDoc = await benchmarkRef.get()
+
+      const benchmarkData = {
+        session_id,
+        benchmark_results,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }
+
+      if (!existingDoc.exists) {
+        benchmarkData.createdAt = admin.firestore.FieldValue.serverTimestamp()
+      }
+
+      await benchmarkRef.set(benchmarkData, { merge: true })
+
+      logger.info('Benchmark result stored successfully', { session_id })
+
+      return res.status(200).json({
+        message: 'Benchmark result stored successfully',
+        session_id,
+        benchmark_results,
+      })
+    } catch (error) {
+      logger.error('Error storing benchmark result:', { error })
+      return res.status(500).json({ error: error.message })
+    }
+  },
+})
+
+export const getSessionBenchmark = functions.onRequest({
+  handler: async (req, res) => {
+    if (req.method !== 'GET') {
+      return res.status(405).send('Method Not Allowed')
+    }
+
+    try {
+      const { session_id } = req.query
+
+      if (!session_id) {
+        return res.status(400).json({ error: 'session_id is required' })
+      }
+
+      const db = admin.firestore()
+
+      const benchmarkRef = db.collection('benchmarks').doc(session_id)
+      const benchmarkDoc = await benchmarkRef.get()
+
+      if (!benchmarkDoc.exists) {
+        return res.status(404).json({
+          error: 'No benchmark results found for this session',
+          session_id,
+        })
+      }
+
+      const benchmarkData = benchmarkDoc.data()
+
+      return res.status(200).json({
+        session_id,
+        benchmark_results: benchmarkData.benchmark_results,
+        createdAt: benchmarkData.createdAt,
+        updatedAt: benchmarkData.updatedAt,
+      })
+    } catch (error) {
+      logger.error('Error retrieving benchmark result:', { error })
+      return res.status(500).json({ error: error.message })
+    }
+  },
+})


### PR DESCRIPTION
Fixes Issue #34

## Summary

This PR adds benchmark persistence using Firebase Cloud Functions and Firestore. Benchmark results are now stored per session and can be retrieved later, enabling reliable storage and analysis of benchmarking data.

## C.hanges Made

### Added

* Two new Firebase Cloud Functions in `eyeTracking.js`:

#### `storeBenchmarkResult` (POST)

* Accepts `session_id` and `benchmark_results` in the request body
* Writes data to `benchmarks/{session_id}` in Firestore using `merge: true` (upsert)
* Sets `createdAt` on the first write
* Always updates `updatedAt`
* Returns:
  * `400` if required fields are missing
  * `405` for non-POST requests
  * `200` on successful write

#### `getSessionBenchmark` (GET)

* Accepts `session_id` as a query parameter
* Retrieves benchmark data from `benchmarks/{session_id}`
* Returns:
  * `404` if no benchmark exists for the session
  * `400` if `session_id` is missing
  * `405` for non-GET requests
  * `200` with benchmark data on success


## Firestore Data Model

New collection: `benchmarks` (document ID = `session_id`)

```json
{
  "session_id": "abc-123",
  "benchmark_results": {
    "overall": { "accuracy": 0.95, "precision": 0.89, "data_quality": 0.92 },
    "per_target": [
      { "target_id": "t1", "accuracy": 0.97, "precision": 0.91 }
    ]
  },
  "createdAt": "<server timestamp>",
  "updatedAt": "<server timestamp>"
}