### PR TITLE
fix: implement missing error snackbars in UserTestView

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -939,9 +939,17 @@ const handleTimerStopped = (elapsedTime, idx) => {
       localTestAnswer.tasks[idx].taskTime = timeToSave
     } else {
       //TODO: Add error snackbar
+      store.commit('SET_TOAST', {
+        message: 'An error occurred while loading the evaluation.',
+        type: 'error',
+      })
     }
   } else {
     //TODO: Add error snackbar
+    store.commit('SET_TOAST', {
+      message: 'Failed to save progress. Please try again.',
+      type: 'error',
+    })
   }
 }
 


### PR DESCRIPTION
I have implemented the missing error snackbars in UserTestView.vue as identified by the TODO comments. This change ensures that when an evaluation fails to load or progress is not saved, the user receives a visual alert via the global SET_TOAST store commit. This improves the UX by providing immediate feedback. Closes #1887
<img width="1919" height="1026" alt="image" src="https://github.com/user-attachments/assets/1edd5310-c9dd-497e-ae1e-47c47e0ca696" />
