### PR TITLE
fix: implement missing error snackbars in UserTestView

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -939,9 +939,17 @@ const handleTimerStopped = (elapsedTime, idx) => {
       localTestAnswer.tasks[idx].taskTime = timeToSave
     } else {
       //TODO: Add error snackbar
+      store.commit('SET_TOAST', {
+        message: 'An error occurred while loading the evaluation.',
+        type: 'error',
+      })
     }
   } else {
     //TODO: Add error snackbar
+    store.commit('SET_TOAST', {
+      message: 'Failed to save progress. Please try again.',
+      type: 'error',
+    })
   }
 }
 


### PR DESCRIPTION
I have implemented the missing error snackbars in UserTestView.vue as identified by the TODO comments. This change ensures that when an evaluation fails to load or progress is not saved, the user receives a visual alert via the global SET_TOAST store commit. This improves the UX by providing immediate feedback. Closes https://github.com/ruxailab/RUXAILAB/issues/1887