### PR TITLE
UX Improvement: Scroll Reset & Form Validation in Study Creation Flow

### DIFF
--- a/src/features/ux_creation/ChooseStudyMethods.vue
+++ b/src/features/ux_creation/ChooseStudyMethods.vue
@@ -185,6 +185,7 @@ const goBack = () => {
 }
 
 onMounted(() => {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
   if (!currentCategory.value) {
     router.push({ name: 'study-create-step1' })
   }

--- a/src/features/ux_creation/ChooseStudyType.vue
+++ b/src/features/ux_creation/ChooseStudyType.vue
@@ -153,6 +153,7 @@ const goBack = () => {
 }
 
 onMounted(() => {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
   selectedOption.value = store.state.Tests.studyType || ''
 })
 </script>

--- a/src/features/ux_creation/StudyDetailsForm.vue
+++ b/src/features/ux_creation/StudyDetailsForm.vue
@@ -252,6 +252,7 @@
                         color="success"
                         size="large"
                         :loading="isLoading"
+                        :disabled="!isFormValid || isLoading"
                         prepend-icon="mdi-plus"
                         block
                         @click="validate"
@@ -271,7 +272,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 import { useI18n } from 'vue-i18n'
@@ -315,6 +316,14 @@ const steps = computed(() => [
   { value: 3, title: t('studyCreation.steps.studyType'), complete: true },
   { value: 4, title: t('studyCreation.steps.details'), complete: false },
 ])
+
+const isFormValid = computed(() => {
+  return (
+    test.value.title &&
+    test.value.title.length <= 200 &&
+    test.value.description.length <= 600
+  )
+})
 
 watch(
   selectedTemplate,
@@ -497,6 +506,10 @@ const submitAccessibility = async () => {
 const goBack = () => {
   router.push({ name: 'study-create-step3' })
 }
+
+onMounted(() => {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
###  Overview

This PR improves the user experience of the **Study Creation Flow** by addressing two usability issues observed while navigating between steps.

The goal is to make the study creation process feel more structured, predictable, and safe by ensuring proper viewport positioning and preventing premature study submission.

---

### 🎯 Problem

While exploring the study lifecycle, I noticed the following UX gaps:

1. When navigating between study creation steps (Study Type → Methods → Details), the scroll position was preserved.
   This sometimes caused users to land mid-page, making it harder to understand the new step context.

2. The **"Create Study"** button remained clickable even when required form fields (like Study Title) were empty or invalid.
   This could lead to confusion or accidental submission attempts.

---

### ✅ Solution Implemented

#### 🔹 Scroll Position Reset on Step Navigation

Added an `onMounted()` lifecycle hook in the following components:

* `ChooseStudyType.vue`
* `ChooseStudyMethods.vue`
* `StudyDetailsForm.vue`

This ensures that whenever a user navigates to a new step, the page automatically scrolls to the top.

```js
onMounted(() => {
  window.scrollTo({ top: 0, behavior: 'smooth' })
})
```

This improves spatial orientation and makes each step feel like a fresh view.

---

#### 🔹 Disable "Create Study" Button Until Form is Valid

Introduced a computed property in `StudyDetailsForm.vue`:

```js
const isFormValid = computed(() => {
  return test.value.title && test.value.title.length <= 200 
})
```

Then updated the button:

```vue<br> <v-btn<br> :disabled="!isFormValid"<br> >
 Create Study<br> </v-btn>
```

This ensures:
- Required fields must be completed before submission 
- Prevents accidental or confusing interactions 
- Aligns with expected form UX behavior 
---
<img width="1353" height="215" alt="image" src="https://github.com/user-attachments/assets/3111a139-4ef5-4bd9-b497-cbcafb7cadfd" />



Fixed issue #1892 

