### PR TITLE
fix storage usage after delete

### DIFF
--- a/functions/src/triggers/index.js
+++ b/functions/src/triggers/index.js
@@ -1,3 +1,4 @@
 export { onTestCreate } from './onTestCreate.js'
 export { onTestUpdate } from './onTestUpdate.js'
 export { onStorageUpdate } from './onStorageUpdate.js'
+export { onStorageDelete } from './onStorageUpdate.js'

--- a/functions/src/triggers/onStorageUpdate.js
+++ b/functions/src/triggers/onStorageUpdate.js
@@ -2,62 +2,75 @@ import { admin, functions } from "../f.firebase.js";
 import logger from "../utils/logger.js";
 
 /**
- * Cloud Function triggered on Firebase Storage file write (create/update/delete).
+ * Recalculates storage usage for every user that owns the changed test.
+ */
+const updateStorageUsageForPath = async (filePath) => {
+  try {
+    const match = filePath?.match(/^tests\/([^\/]+)/);
+    if (!match) {
+      logger.info("File path does not match expected pattern:", { filePath });
+      return null;
+    }
+
+    const testId = match[1];
+    const db = admin.firestore();
+    const usersRef = db.collection('users');
+    const querySnapshot = await usersRef
+      .where(`myTests.${testId}`, '!=', null)
+      .get();
+
+    if (querySnapshot.empty) {
+      logger.info(`No users found with testId: ${testId}`);
+      return null;
+    }
+
+    const bucket = admin.storage().bucket();
+    const batch = db.batch();
+
+    for (const doc of querySnapshot.docs) {
+      const userData = doc.data();
+      const userTestIds = Object.keys(userData.myTests || {});
+
+      const filePromises = userTestIds.map((tid) =>
+        bucket.getFiles({ prefix: `tests/${tid}` }),
+      );
+      const fileResults = await Promise.all(filePromises);
+
+      let totalBytes = 0;
+      for (const [testFiles] of fileResults) {
+        for (const file of testFiles) {
+          totalBytes += Number(file.metadata.size || 0);
+        }
+      }
+
+      batch.update(doc.ref, {
+        storageUsageMB: parseFloat((totalBytes / (1024 * 1024)).toFixed(2)),
+      });
+    }
+
+    await batch.commit();
+    logger.info(`Updated storage usage for testId: ${testId}`);
+    return null;
+  } catch (error) {
+    logger.error("Error updating storage usage:", { error });
+    return null;
+  }
+};
+
+/**
+ * Cloud Function triggered when a file is created or overwritten.
  */
 export const onStorageUpdate = functions.onStorageTrigger({
   event: "finalized",
-  handler: async (event) => {
-    const object = event.data;
-    try {
-      const filePath = object.name;
-      const match = filePath.match(/^tests\/([^\/]+)/);
-      if (!match) {
-        logger.info("File path does not match expected pattern:", { filePath });
-        return null;
-      }
-      const testId = match[1];
+  handler: async (event) => updateStorageUsageForPath(event.data?.name),
+});
 
-      const db = admin.firestore();
-      const usersRef = db.collection('users');
-      const querySnapshot = await usersRef
-        .where(`myTests.${testId}`, '!=', null)
-        .get();
-
-      if (querySnapshot.empty) {
-        logger.info(`No users found with testId: ${testId}`);
-        return null;
-      }
-
-      const bucket = admin.storage().bucket();
-
-      const batch = db.batch();
-      for (const doc of querySnapshot.docs) {
-        const userData = doc.data();
-        const userTestIds = Object.keys(userData.myTests || {});
-
-        // Parallelize file fetching for all test IDs
-        const filePromises = userTestIds.map(tid =>
-          bucket.getFiles({ prefix: `tests/${tid}` })
-        );
-        const fileResults = await Promise.all(filePromises);
-
-        let totalBytes = 0;
-        for (const [testFiles] of fileResults) {
-          for (const file of testFiles) {
-            totalBytes += Number(file.metadata.size || 0);
-          }
-        }
-        const totalSizeMB = (totalBytes / (1024 * 1024)).toFixed(2);
-
-        batch.update(doc.ref, { storageUsageMB: parseFloat(totalSizeMB) });
-      }
-
-      await batch.commit();
-      logger.info(`Updated storage usage for testId: ${testId}`);
-    } catch (error) {
-      logger.error("Error updating storage usage:", { error });
-    }
-  }
+/**
+ * Cloud Function triggered when a file is deleted.
+ */
+export const onStorageDelete = functions.onStorageTrigger({
+  event: "deleted",
+  handler: async (event) => updateStorageUsageForPath(event.data?.name),
 });
 
 /**

--- a/functions/tests/onStorageUpdate.spec.js
+++ b/functions/tests/onStorageUpdate.spec.js
@@ -38,7 +38,11 @@ jest.unstable_mockModule('../src/f.firebase.js', () => ({
   },
 }));
 
-const { onStorageUpdate, calculateStorageUsage } = await import('../src/triggers/onStorageUpdate.js');
+const {
+  onStorageUpdate,
+  onStorageDelete,
+  calculateStorageUsage,
+} = await import('../src/triggers/onStorageUpdate.js');
 
 describe('onStorageUpdate.js', () => {
   beforeEach(() => {
@@ -93,6 +97,31 @@ describe('onStorageUpdate.js', () => {
 
       await onStorageUpdate(event);
       expect(mockGetFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onStorageDelete', () => {
+    it('recalculates storage usage after a file deletion', async () => {
+      const event = { data: { name: 'tests/test1234/file.jpg' } };
+
+      mockGet.mockResolvedValueOnce({
+        empty: false,
+        docs: [
+          {
+            ref: 'mock-doc-ref',
+            data: () => ({ myTests: { test1234: true } }),
+          },
+        ],
+      });
+
+      mockGetFiles.mockResolvedValueOnce([[{ metadata: { size: 1048576 } }]]);
+
+      await onStorageDelete(event);
+
+      expect(mockUpdate).toHaveBeenCalledWith('mock-doc-ref', {
+        storageUsageMB: 1,
+      });
+      expect(mockCommit).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## what this fix do
this makes storage usage update when a file gets deleted too. before this, we only handled storage `finalized` event, so after delete the `storageUsageMB` could stay old and look wrong.

## what changed
- pulled storage recalculation into one shared helper
- kept existing finalize trigger
- added delete trigger for storage delete events
- added regression test for delete path

## why this matter
if user deletes recordings or other test files, dashboard/storage numbers should not stay stale. right now that can happen.

## issue
fixes ruxailab/RUXAILAB#1900

## test
- `npm test -- --runInBand` (inside `functions/`)
- all functions tests passing: 27/27