### PR TITLE
Implement route leave guard for unsaved changes (Fixes #1875)

### DIFF
--- a/src/ux/Heuristic/views/EditTest.vue
+++ b/src/ux/Heuristic/views/EditTest.vue
@@ -72,6 +72,7 @@
 </template>
 
 <script setup>
+import { useRoute, onBeforeRouteLeave } from 'vue-router'
 import ButtonSave from '@/shared/components/buttons/ButtonSave.vue'
 import PageWrapper from '@/shared/views/template/PageWrapper.vue'
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
@@ -80,7 +81,6 @@ import OptionsTable from '../components/OptionsTable.vue'
 import WeightTable from '../components/weights_evaluation/WeightTable.vue'
 import HeuristicsSettings from '../components/HeuristicsSettings.vue'
 import { useStore } from 'vuex'
-import { useRoute } from 'vue-router'
 import { instantiateStudyByType } from '@/shared/constants/methodDefinitions'
 import { useI18n } from 'vue-i18n'
 
@@ -163,6 +163,15 @@ const save = async () => {
   await store.dispatch('updateStudy', study)
   await store.dispatch('getStudy', { id: route.params.id })
 }
+onBeforeRouteLeave((to, from, next) => {
+  // check if navigating to preview page
+  if (change.value && to.path.includes('testview')) {
+    alert('Please save changes before previewing.')
+    return next(false)
+  }
+
+  next()
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
Fixes #1875

## 🐛 Problem
While configuring a heuristic study, newly added heuristics and questions were not reflected on the Preview page unless the user manually saved the changes.

This caused confusion, as the Preview page displayed:
> "Configuration Error: This test has no heuristics configured."

even when heuristics had already been added in the editor.

---

##  Solution
- Added a route navigation guard using `onBeforeRouteLeave`
- Prevents users from navigating to the Preview page when there are unsaved changes
- Displays a warning message prompting the user to save before previewing

---

##  Changes Made
- Introduced navigation guard in `EditTest.vue`
- Used existing `change` state to detect unsaved modifications
- Blocked navigation to preview (`testview`) if changes are not saved
- Added alert message: *"Please save changes before previewing."*

---

##  Benefits
- Ensures Preview always reflects the latest saved configuration
- Prevents user confusion caused by unsaved state
- Improves overall UX and workflow clarity
- Maintains data consistency between editor and preview

---

##  Testing
- ✅ Added heuristics → navigation to preview is blocked
- ✅ Saved changes → preview loads correctly
- ✅ Modified again → navigation blocked until saved

---

##  Result
Users are now guided to save their changes before previewing, ensuring accurate and expected behavior in the Preview page.