### PR TITLE
docs: add npm install step for functions/ directory in setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ To calculate heuristic weights, run:
 
 ```bash
 # Run locally
+ cd functions
+ npm install
+ cd ..
  firebase init functions
  firebase use weight_function
  firebase emulators:start --only functions


### PR DESCRIPTION
Fixes #1543

Added missing `cd functions && npm install` step in the local setup 
guide before running Firebase commands. Without this step, 
functions fail to run locally.

Before:
<img width="554" height="134" alt="image" src="https://github.com/user-attachments/assets/20e0bc12-e3a0-4101-ba09-a8b1c93b0e64" />



After:
<img width="689" height="242" alt="image" src="https://github.com/user-attachments/assets/ccd4a319-eab0-4035-b7a0-91c374c48cd8" />

