### PR TITLE
docs: add npm install step for functions/ directory in setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ To calculate heuristic weights, run:
 
 ```bash
 # Run locally
+ cd functions
+ npm install
+ cd ..
  firebase init functions
  firebase use weight_function
  firebase emulators:start --only functions


### PR DESCRIPTION
Fixes #1543

Added missing `cd functions && npm install` step before Firebase 
commands in the local setup guide.

Before:
<img width="550" height="144" alt="image" src="https://github.com/user-attachments/assets/15b15d7e-32b4-44f7-80e6-374d890216c3" />

After:
<img width="601" height="236" alt="image" src="https://github.com/user-attachments/assets/9031fb30-2984-4607-8dd7-57b4fde0a8ff" />

