### PR TITLE
fix: replace Spanish error messages with English in ModeratedTestView

### DIFF
--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -1058,10 +1058,10 @@ const startTimer = () => {
 
 const handleTimerStopped = (elapsedTime, idx) => {
   // idx is passed from TaskStep, always use it
-  console.log('handleTimerStopped llamado con:', { elapsedTime, idx }) // eslint-disable-line no-console
+  console.log('handleTimerStopped called with:', { elapsedTime, idx }) // eslint-disable-line no-console
 
   if (!localTestAnswer.tasks) {
-    console.error('localTestAnswer.tasks no está definido') // eslint-disable-line no-console
+    console.error('localTestAnswer.tasks is not defined') // eslint-disable-line no-console
     return
   }
 
@@ -1076,10 +1076,10 @@ const handleTimerStopped = (elapsedTime, idx) => {
     if (!isNaN(timeToSave)) {
       localTestAnswer.tasks[idx].taskTime = timeToSave
     } else {
-      console.error('Tiempo no válido:', elapsedTime) // eslint-disable-line no-console
+      console.error('Invalid time value:', elapsedTime) // eslint-disable-line no-console
     }
   } else {
-    console.error('No se pudo guardar el tiempo para la tarea', idx) // eslint-disable-line no-console
+    cconsole.error('Could not save time for task', idx) // eslint-disable-line no-console
   }
 }
 


### PR DESCRIPTION
Fixes #1908

Replaced hardcoded Spanish error/log messages with English 
equivalents in ModeratedTestView.vue for language consistency.

Changes:
- 'handleTimerStopped llamado con' → 'handleTimerStopped called with'
- 'localTestAnswer.tasks no está definido' → 'localTestAnswer.tasks is not defined'
- 'Tiempo no válido' → 'Invalid time value'
- 'No se pudo guardar el tiempo para la tarea' → 'Could not save time for task'

Before - 
<img width="1673" height="606" alt="image" src="https://github.com/user-attachments/assets/0275754e-9de1-42c2-99c1-30176723a572" />

After - 
<img width="1431" height="842" alt="Screenshot 2026-03-17 210314" src="https://github.com/user-attachments/assets/8d544cb0-15fc-4c64-8292-6f893e937770" />
