### PR TITLE
Accessibility: Add aria-labels to icon-only buttons

### DIFF
--- a/src/features/language/components/LocaleChanger.vue
+++ b/src/features/language/components/LocaleChanger.vue
@@ -21,7 +21,13 @@
     >
       <v-menu>
         <template #activator="{ props }">
-          <v-btn size="small" color="primary" icon v-bind="props">
+          <v-btn
+            size="small"
+            color="primary"
+            icon
+            v-bind="props"
+            :aria-label="$t('language')"
+          >
             <v-icon size="20" color="white"> mdi-translate </v-icon>
           </v-btn>
         </template>

--- a/src/features/navigation/components/GlobalToolbar.vue
+++ b/src/features/navigation/components/GlobalToolbar.vue
@@ -4,6 +4,7 @@
       v-if="user"
       icon
       class="d-flex d-lg-none"
+      :aria-label="$t('navigation.appNavigation')"
       @click="toggleDashboardDrawer"
     >
       <v-icon>mdi-menu</v-icon>
@@ -73,7 +74,13 @@
       {{ $t('auth.SIGNIN.sign-in') }}
     </v-btn>
 
-    <v-btn v-if="!user" icon class="d-flex d-lg-none" @click="goTo('/signin')">
+    <v-btn
+      v-if="!user"
+      icon
+      class="d-flex d-lg-none"
+      :aria-label="$t('auth.SIGNIN.sign-in')"
+      @click="goTo('/signin')"
+    >
       <v-icon :size="iconSize"> mdi-lock </v-icon>
     </v-btn>
 


### PR DESCRIPTION
  This PR improves the accessibility of the platform by adding descriptive aria-label attributes to interactive elements that previously only contained icons it  helps  users relying  on screen readers or other assistive technologies to clearly understand the purpose of these buttons. And it also complies with WCAG(web content accessibility guidelines ) which just mean its helpfull for people with disabilitys to use 
