### PR TITLE
docs: update Node.js and Vue.js version info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ For commercial support, academic collaborations, and answers to common questions
 
 ### Development Environment
 
-- Node.js version: ≤ 24.12.0
-- Vue.js version: 3.5.26
+- Node.js version: ≥ 18.0.0
+- Vue.js version: ^3.5.29
 - Vue CLI version: 5.0.8
 - Vuetify version: 3.11.6
 - Python version: 3.11.8


### PR DESCRIPTION
Fixes #1939 

This PR updates the README to reflect the correct supported versions for the project environment.  

**Changes:**  
- Node.js version updated from `≤ 24.12.0` to `≥ 18.0.0`  
- Vue.js version updated from `3.5.26` to `^3.5.29`  

**Reason:**  
- Node.js upper bound in the current README is overly restrictive; the project works with Node 18+ (including 25).  
- Vue.js version in README did not match the version in `package.json`.  

No code changes are required. This is purely a documentation update.  
