### PR TITLE
docs: update Node.js and Vue.js versions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ For commercial support, academic collaborations, and answers to common questions
 
 ### Development Environment
 
-- Node.js version: ≤ 24.12.0
-- Vue.js version: 3.5.26
+- Node.js version: ≥ 18.0.0
+- Vue.js version: ^3.5.29
 - Vue CLI version: 5.0.8
 - Vuetify version: 3.11.6
 - Python version: 3.11.8


### PR DESCRIPTION
Fixes #1939 

This PR updates the README to reflect the correct supported versions for the project environment.

**Changes:**

Node.js version updated from `≤ 24.12.0` to `≥ 18.0.0`
Vue.js version updated from `3.5.26` to `^3.5.29`

**Reason:**

- Node.js upper bound in the current README is overly restrictive; the project works with Node 18+ (including 25).
- Vue.js version in README did not match the version in package.json.

No code changes are required. This is purely a documentation update.

**snapshot of package.json with vue.js version being ^3.5.29 in the official RUXAILAB README**

<img width="1055" height="440" alt="Screenshot 2026-03-22 at 11 32 42 PM" src="https://github.com/user-attachments/assets/428253b2-fb58-41e6-800a-28a343dad496" />
