### PR TITLE
fix(ux_creation): reset scroll on study creation step navigation #1892

### DIFF
--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -8,6 +8,14 @@ import accessibilityRoutes from '@/ux/accessibility/router.js'
 import UserTestRoutes from '@/ux/UserTest/router.js'
 import store from '@/store'
 
+/** Study creation wizard routes — scroll is reset when moving between steps */
+const STUDY_CREATION_ROUTE_NAMES = new Set([
+  'study-create-step1',
+  'study-create-step2',
+  'study-create-step3',
+  'study-create-step4',
+])
+
 const routes = [
   ...Public,
   ...Admin,
@@ -21,6 +29,25 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
   routes,
+  scrollBehavior(to, _from, _savedPosition) {
+    if (!to.name || !STUDY_CREATION_ROUTE_NAMES.has(to.name)) {
+      return false
+    }
+
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const main = document.querySelector('.v-main')
+          if (main) main.scrollTop = 0
+
+          window.scrollTo({ top: 0, left: 0 })
+          document.documentElement.scrollTop = 0
+          document.body.scrollTop = 0
+          resolve(false)
+        })
+      })
+    })
+  },
 })
 
 router.beforeEach(async (to, from, next) => {


### PR DESCRIPTION
## What changed
This PR improves the study creation navigation experience by resetting scroll position to the top when moving between study creation steps.

## Why
Previously, step transitions could keep the previous scroll position, which made the flow feel disorienting.

## Scope
- Affects only the study creation wizard routes
- No backend changes
- No data model changes

## How to test
1. Start from `/choose`
2. Scroll down
3. Move to `/methods`, `/createtest`, and `/studydetails`
4. Confirm each step opens at top of page

## Video demo

https://github.com/user-attachments/assets/06a396db-e1bf-4eac-83e9-1cd0cebbcedf


## Related issue
Closes #1892