### PR TITLE
fix(ux_creation): disable create study until form is valid #1892

### DIFF
--- a/src/features/ux_creation/StudyDetailsForm.vue
+++ b/src/features/ux_creation/StudyDetailsForm.vue
@@ -77,7 +77,7 @@
                         class="mb-4"
                         @change="store.commit('SET_LOCAL_CHANGES', true)"
                       />
-                      <div v-if="method == STUDY_TYPES.HEURISTIC">
+                      <div v-if="needsHeuristicWebsiteFields">
                         <v-text-field
                           v-model="websiteDetails.siteName"
                           :rules="[
@@ -252,6 +252,7 @@
                         color="success"
                         size="large"
                         :loading="isLoading"
+                        :disabled="!canCreateStudy || isLoading"
                         prepend-icon="mdi-plus"
                         block
                         @click="validate"
@@ -281,6 +282,7 @@ import BackButton from '@/features/ux_creation/components/BackButton.vue'
 import {
   getMethodManagerView,
   instantiateStudyByType,
+  METHOD_DEFINITIONS,
   normalizeStudyType,
   STUDY_TYPES,
 } from '@/shared/constants/methodDefinitions'
@@ -308,6 +310,36 @@ const method = computed(() => store.state.Tests.studyMethod)
 const studyType = computed(() => store.state.Tests.studyType)
 const selectedTemplate = computed(() => store.state.Tests.selectedTemplate)
 const isLoading = ref(false)
+
+/** Store uses method id `HEURISTICS`, not STUDY_TYPES.HEURISTIC */
+const needsHeuristicWebsiteFields = computed(
+  () => method.value === METHOD_DEFINITIONS.HEURISTICS.id,
+)
+
+function isValidHttpWebsiteUrl(value) {
+  if (!value || value.length > 200) return false
+  try {
+    const url = new URL(value)
+    return ['http:', 'https:'].includes(url.protocol)
+  } catch {
+    return false
+  }
+}
+
+const canCreateStudy = computed(() => {
+  if (!test.value.title || test.value.title.length > 200) return false
+  const description = test.value.description ?? ''
+  if (description.length > 600) return false
+
+  if (needsHeuristicWebsiteFields.value) {
+    const siteName = websiteDetails.value.siteName ?? ''
+    const siteURL = websiteDetails.value.siteURL ?? ''
+    if (!siteName || siteName.length > 200) return false
+    if (!isValidHttpWebsiteUrl(siteURL)) return false
+  }
+
+  return true
+})
 
 const steps = computed(() => [
   { value: 1, title: t('studyCreation.steps.category'), complete: true },
@@ -346,6 +378,36 @@ const validate = () => {
   if (test.value.description.length > 600) {
     showWarning('studyCreation.details.validation.max600Characters')
     return
+  }
+  if (needsHeuristicWebsiteFields.value) {
+    const siteName = websiteDetails.value.siteName ?? ''
+    if (!siteName) {
+      showWarning('studyCreation.details.validation.enterWebsiteName')
+      return
+    }
+    if (siteName.length > 200) {
+      showWarning('studyCreation.details.validation.max200Characters')
+      return
+    }
+    const siteURL = websiteDetails.value.siteURL ?? ''
+    if (!siteURL) {
+      showWarning('studyCreation.details.validation.enterWebsiteUrl')
+      return
+    }
+    if (siteURL.length > 200) {
+      showWarning('studyCreation.details.validation.max200Characters')
+      return
+    }
+    try {
+      const url = new URL(siteURL)
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        showWarning('studyCreation.details.validation.urlProtocol')
+        return
+      }
+    } catch {
+      showWarning('studyCreation.details.validation.validUrl')
+      return
+    }
   }
   handleTestType()
 }


### PR DESCRIPTION
## Summary
Disables the **Create Study** button on the study details step until the same inputs that `validate()` requires are satisfied, so users get proactive feedback instead of warnings only after clicking.

## Changes
- Add `canCreateStudy` computed from title/description rules (max lengths) and, when the heuristic website section is shown, website name + valid `http`/`https` URL.
- Wire **Create Study** with `:disabled="!canCreateStudy || isLoading"`.
- Align `validate()` with those rules for heuristic flows (website name/URL).
- Show heuristic website fields when the selected method is **HEURISTICS** (store id), matching `METHOD_DEFINITIONS.HEURISTICS.id` instead of `STUDY_TYPES.HEURISTIC`.

## How to test
1. **User test path:** Test → method → blank → details. Button stays disabled with empty title; enabled with a valid title and description within limits.
2. **Heuristic path:** Inspection → Heuristic evaluation → blank → details. Button stays disabled until title + website name + valid URL are set.

## Screenshots
<img width="1470" height="692" alt="Screenshot 2026-03-25 at 8 49 44 AM" src="https://github.com/user-attachments/assets/d6f76a3e-e02b-421e-8f59-7d7da2957fe6" />
<img width="1470" height="691" alt="Screenshot 2026-03-25 at 8 50 05 AM" src="https://github.com/user-attachments/assets/d3681123-a520-40ac-a64e-4b9615521dad" />
<img width="1470" height="690" alt="Screenshot 2026-03-25 at 8 52 19 AM" src="https://github.com/user-attachments/assets/fe87d93a-8180-4229-84ac-7ea428614a23" />
<img width="1470" height="690" alt="Screenshot 2026-03-25 at 8 52 42 AM" src="https://github.com/user-attachments/assets/8323c0c6-3188-44df-bc96-1874727b10ed" />


## Scope
Frontend / UX only; no API or study model changes intended.

## Related
Closes #1892 
