### PR TITLE
refactor(heuristic): extract normalizeAnswer() helper in HeuristicQuestionAnswer

### DIFF
--- a/src/ux/Heuristic/models/HeuristicQuestionAnswer.js
+++ b/src/ux/Heuristic/models/HeuristicQuestionAnswer.js
@@ -194,24 +194,37 @@ export default class HeuristicQuestionAnswer {
     }
     return []
   }
-  static toHeuristicQuestionAnswer(data, testOptions) {
-    const instance = new HeuristicQuestionAnswer({
-      // TODO: This needs to be changed urgently, just a hotfix for now
-      ...data,
-      heuristicAnswer: data.heuristicAnswer?.text
-        ? data.heuristicAnswer
-        : {
-            text:
-              testOptions.find((op) => op.value === data.heuristicAnswer)
-                ?.text ?? '',
-            value: data.heuristicAnswer,
-          },
-      comments: Array.isArray(data.comments) ? data.comments : [],
-      images: Array.isArray(data.images) ? data.images : [],
-    })
-    instance.migrateToArrayFormat()
-    return instance
+  /**
+ * Normalizes a heuristicAnswer value into the standard {text, value} shape.
+ * Handles both legacy scalar values and already-normalized objects.
+ * @param {*} answer - Raw answer value (string/number) or {text, value} object.
+ * @param {Array<{text: string, value: *}>} testOptions - Available answer options.
+ * @returns {{text: string, value: *}}
+ */
+static normalizeAnswer(answer, testOptions) {
+  if (answer && typeof answer === 'object' && answer.text) {
+    return answer
   }
+  const match = testOptions.find((op) => op.value === answer)
+  return {
+    text: match?.text ?? '',
+    value: answer ?? null,
+  }
+}
+
+static toHeuristicQuestionAnswer(data, testOptions) {
+  const instance = new HeuristicQuestionAnswer({
+    ...data,
+    heuristicAnswer: HeuristicQuestionAnswer.normalizeAnswer(
+      data.heuristicAnswer,
+      testOptions
+    ),
+    comments: Array.isArray(data.comments) ? data.comments : [],
+    images: Array.isArray(data.images) ? data.images : [],
+  })
+  instance.migrateToArrayFormat()
+  return instance
+}
 
   toFirestore() {
     return {


### PR DESCRIPTION
## What
Resolves the TODO hotfix in `toHeuristicQuestionAnswer()` by extracting 
a dedicated `static normalizeAnswer()` method in `HeuristicQuestionAnswer.js`.

## Why
The inline ternary was marked as a temporary hotfix. This extracts the 
logic into a clean, reusable, and independently testable static method.

## Changes
- Added `static normalizeAnswer(answer, testOptions)` to normalize 
  heuristicAnswer into the standard `{text, value}` shape
- Handles both legacy scalar values and already-normalized objects
- Replaced TODO ternary in `toHeuristicQuestionAnswer()` with the new helper

## No behavior change — fully backward compatible


## Media

### Before

<img width="834" height="419" alt="Screenshot 2026-03-27 184158" src="https://github.com/user-attachments/assets/0c88c444-4dbe-4fb5-b677-79681dadf641" />

### After

<img width="816" height="704" alt="Screenshot 2026-03-27 184225" src="https://github.com/user-attachments/assets/d544b786-a5b0-4448-b252-be32d66b302b" />

## Fixes #1959