### PR TITLE
feat(heuristic): add optional time tracking per heuristic evaluation #1734

### DIFF
--- a/src/app/plugins/locales/ar.json
+++ b/src/app/plugins/locales/ar.json
@@ -703,11 +703,14 @@
   "HeuristicsSettings": {
     "titles": {
       "settings": "الإعدادات",
-      "confirmUpload": "تأكيد التحميل"
+      "confirmUpload": "تأكيد التحميل",
+      "timeTracking": "تتبع الوقت"
     },
     "messages": {
       "acceptCsv": "إذا وافقت، سيتم استبدال جميع الاستدلالات الحالية بتلك الموجودة في ملف CSV.",
-      "noCsvFileSelected": "لم يتم تحديد ملف CSV. \nيرجى تحديد واحد قبل المتابعة."
+      "noCsvFileSelected": "لم يتم تحديد ملف CSV. \nيرجى تحديد واحد قبل المتابعة.",
+      "timeTrackingDescription": "يسجل الوقت الذي يقضيه كل مقيّم في كل معيار إرشادي خلال التقييم.",
+      "settingsSaved": "تم حفظ الإعدادات بنجاح."
     },
     "placeHolders": {
       "importCsv": "قم باستيراد ملف CSV الخاص بك هنا."
@@ -715,6 +718,10 @@
     "actions": {
       "downloadCsvTemplate": "تحميل نموذج CSV",
       "update": "تحديث"
+    },
+    "labels": {
+      "timeTrackingOn": "تتبع الوقت مفعّل",
+      "timeTrackingOff": "تتبع الوقت معطّل"
     }
   },
   "HeuristicsTestView": {
@@ -1672,7 +1679,11 @@
       "SelfTest": {
         "title": "اختبار ذاتي",
         "type": "غير مشرف عليه",
-        "text": ["الإجابة في وقت فراغ", "تحليل متقدم للإجابات", "تخصيص المهمة"]
+        "text": [
+          "الإجابة في وقت فراغ",
+          "تحليل متقدم للإجابات",
+          "تخصيص المهمة"
+        ]
       },
       "LiveTest": {
         "title": "اختبار مباشر",

--- a/src/app/plugins/locales/de.json
+++ b/src/app/plugins/locales/de.json
@@ -705,11 +705,14 @@
   "HeuristicsSettings": {
     "titles": {
       "settings": "Einstellungen",
-      "confirmUpload": "Upload bestätigen"
+      "confirmUpload": "Upload bestätigen",
+      "timeTracking": "Zeiterfassung"
     },
     "messages": {
       "acceptCsv": "Wenn Sie akzeptieren, werden alle Ihre vorhandenen Heuristiken durch die in der .csv-Datei ersetzt.",
-      "noCsvFileSelected": "Keine CSV-Datei ausgewählt. \nBitte wählen Sie eine aus, bevor Sie fortfahren."
+      "noCsvFileSelected": "Keine CSV-Datei ausgewählt. \nBitte wählen Sie eine aus, bevor Sie fortfahren.",
+      "timeTrackingDescription": "Zeichnet die Zeit auf, die jeder Gutachter pro Heuristik während der Bewertung verbringt.",
+      "settingsSaved": "Einstellungen erfolgreich gespeichert."
     },
     "placeHolders": {
       "importCsv": "Importieren Sie Ihre CSV-Testdatei hier."
@@ -717,6 +720,10 @@
     "actions": {
       "downloadCsvTemplate": "CSV-Vorlage herunterladen",
       "update": "Aktualisieren"
+    },
+    "labels": {
+      "timeTrackingOn": "Zeiterfassung aktiviert",
+      "timeTrackingOff": "Zeiterfassung deaktiviert"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -719,11 +719,14 @@
   "HeuristicsSettings": {
     "titles": {
       "settings": "Settings",
-      "confirmUpload": "Confirm Upload"
+      "confirmUpload": "Confirm Upload",
+      "timeTracking": "Time Tracking"
     },
     "messages": {
       "acceptCsv": "If you accept, all your present heuristics will be replaced by the ones in the .csv file",
-      "noCsvFileSelected": "No csv file selected. \nPlease select one before proceeding."
+      "noCsvFileSelected": "No csv file selected. \nPlease select one before proceeding.",
+      "timeTrackingDescription": "Track the time each evaluator spends per heuristic during evaluation.",
+      "settingsSaved": "Settings saved successfully."
     },
     "placeHolders": {
       "importCsv": "Import your CSV testfile here."
@@ -731,6 +734,10 @@
     "actions": {
       "downloadCsvTemplate": "Download CSV template",
       "update": "Update"
+    },
+    "labels": {
+      "timeTrackingOn": "Time tracking enabled",
+      "timeTrackingOff": "Time tracking disabled"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -705,11 +705,14 @@
   "HeuristicsSettings": {
     "titles": {
       "settings": "Configuración",
-      "confirmUpload": "Confirmar carga"
+      "confirmUpload": "Confirmar carga",
+      "timeTracking": "Seguimiento de tiempo"
     },
     "messages": {
       "acceptCsv": "Si aceptas, todas tus heurísticas actuales serán reemplazadas por las del archivo CSV.",
-      "noCsvFileSelected": "No se ha seleccionado ningún archivo CSV. Por favor, selecciona uno antes de continuar."
+      "noCsvFileSelected": "No se ha seleccionado ningún archivo CSV. Por favor, selecciona uno antes de continuar.",
+      "timeTrackingDescription": "Registra el tiempo que cada evaluador dedica por heurística durante la evaluación.",
+      "settingsSaved": "Configuración guardada correctamente."
     },
     "placeHolders": {
       "importCsv": "Importa tu archivo CSV de prueba aquí."
@@ -717,6 +720,10 @@
     "actions": {
       "downloadCsvTemplate": "Descargar plantilla CSV",
       "update": "Actualizar"
+    },
+    "labels": {
+      "timeTrackingOn": "Seguimiento de tiempo activado",
+      "timeTrackingOff": "Seguimiento de tiempo desactivado"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/fr.json
+++ b/src/app/plugins/locales/fr.json
@@ -703,11 +703,14 @@
   "HeuristicsSettings": {
     "titles": {
       "settings": "Paramètres",
-      "confirmUpload": "Confirmer le téléchargement"
+      "confirmUpload": "Confirmer le téléchargement",
+      "timeTracking": "Suivi du temps"
     },
     "messages": {
       "acceptCsv": "Si vous acceptez, toutes vos heuristiques actuelles seront remplacées par celles du fichier .csv.",
-      "noCsvFileSelected": "Aucun fichier CSV sélectionné. \nVeuillez en sélectionner un avant de continuer."
+      "noCsvFileSelected": "Aucun fichier CSV sélectionné. \nVeuillez en sélectionner un avant de continuer.",
+      "timeTrackingDescription": "Enregistre le temps que chaque évaluateur passe par heuristique lors de l'évaluation.",
+      "settingsSaved": "Paramètres enregistrés avec succès."
     },
     "placeHolders": {
       "importCsv": "Importez votre fichier CSV test ici."
@@ -715,6 +718,10 @@
     "actions": {
       "downloadCsvTemplate": "Télécharger le modèle CSV",
       "update": "Mettre à jour"
+    },
+    "labels": {
+      "timeTrackingOn": "Suivi du temps activé",
+      "timeTrackingOff": "Suivi du temps désactivé"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/hi.json
+++ b/src/app/plugins/locales/hi.json
@@ -705,11 +705,14 @@
   "HeuristicsSettings": {
     "titles": {
       "settings": "सेटिंग्स",
-      "confirmUpload": "अपलोड की पुष्टि करें"
+      "confirmUpload": "अपलोड की पुष्टि करें",
+      "timeTracking": "समय ट्रैकिंग"
     },
     "messages": {
       "acceptCsv": "स्वीकार करने पर, आपके सभी वर्तमान हीयुरिस्टिक्स .csv फ़ाइल में दिए गए हीयुरिस्टिक्स से बदल दिए जाएंगे।",
-      "noCsvFileSelected": "कोई CSV फ़ाइल चयनित नहीं है। कृपया आगे बढ़ने से पहले एक चुनें।"
+      "noCsvFileSelected": "कोई CSV फ़ाइल चयनित नहीं है। कृपया आगे बढ़ने से पहले एक चुनें।",
+      "timeTrackingDescription": "मूल्यांकन के दौरान प्रत्येक मूल्यांकनकर्ता द्वारा प्रति हेयुरिस्टिक बिताया गया समय रिकॉर्ड करता है।",
+      "settingsSaved": "सेटिंग्स सफलतापूर्वक सहेजी गईं।"
     },
     "placeHolders": {
       "importCsv": "यहां अपनी परीक्षण CSV फ़ाइल आयात करें।"
@@ -717,6 +720,10 @@
     "actions": {
       "downloadCsvTemplate": "CSV टेम्पलेट डाउनलोड करें",
       "update": "अपडेट करें"
+    },
+    "labels": {
+      "timeTrackingOn": "समय ट्रैकिंग सक्षम",
+      "timeTrackingOff": "समय ट्रैकिंग अक्षम"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/ja.json
+++ b/src/app/plugins/locales/ja.json
@@ -703,11 +703,14 @@
   "HeuristicsSettings": {
     "titles": {
       "settings": "設定",
-      "confirmUpload": "アップロードの確認"
+      "confirmUpload": "アップロードの確認",
+      "timeTracking": "時間追跡"
     },
     "messages": {
       "acceptCsv": "同意すると、現在のヒューリスティックはCSVファイルの内容で置き換えられます。",
-      "noCsvFileSelected": "CSVファイルが選択されていません。続行する前に選択してください。"
+      "noCsvFileSelected": "CSVファイルが選択されていません。続行する前に選択してください。",
+      "timeTrackingDescription": "評価中に各評価者がヒューリスティックごとに費やす時間を記録します。",
+      "settingsSaved": "設定が正常に保存されました。"
     },
     "placeHolders": {
       "importCsv": "ここにCSVテストファイルをインポートしてください。"
@@ -715,6 +718,10 @@
     "actions": {
       "downloadCsvTemplate": "CSVテンプレートをダウンロード",
       "update": "更新"
+    },
+    "labels": {
+      "timeTrackingOn": "時間追跡が有効",
+      "timeTrackingOff": "時間追跡が無効"
     }
   },
   "HeuristicsTestView": {
@@ -1672,7 +1679,11 @@
       "SelfTest": {
         "title": "セルフテスト",
         "type": "非モデレート",
-        "text": ["自分の時間に回答", "高度な回答分析", "タスクのカスタマイズ"]
+        "text": [
+          "自分の時間に回答",
+          "高度な回答分析",
+          "タスクのカスタマイズ"
+        ]
       },
       "LiveTest": {
         "title": "ライブテスト",
@@ -1954,7 +1965,11 @@
       "blank": {
         "title": "空白の研究から開始",
         "description": "完全なカスタマイズでゼロから研究を作成します",
-        "features": ["完全なカスタマイズ", "ゼロから構築", "設定を完全に制御"]
+        "features": [
+          "完全なカスタマイズ",
+          "ゼロから構築",
+          "設定を完全に制御"
+        ]
       },
       "template": {
         "title": "テンプレートから作成",

--- a/src/app/plugins/locales/pt_br.json
+++ b/src/app/plugins/locales/pt_br.json
@@ -705,11 +705,14 @@
   "HeuristicsSettings": {
     "titles": {
       "settings": "Configurações",
-      "confirmUpload": "Confirmar Upload"
+      "confirmUpload": "Confirmar Upload",
+      "timeTracking": "Rastreamento de tempo"
     },
     "messages": {
       "acceptCsv": "Se aceitar, todas as suas heurísticas atuais serão substituídas pelas do arquivo CSV.",
-      "noCsvFileSelected": "Nenhum arquivo CSV selecionado. \nPor favor, selecione um antes de continuar."
+      "noCsvFileSelected": "Nenhum arquivo CSV selecionado. \nPor favor, selecione um antes de continuar.",
+      "timeTrackingDescription": "Registra o tempo que cada avaliador gasta por heurística durante a avaliação.",
+      "settingsSaved": "Configurações salvas com sucesso."
     },
     "placeHolders": {
       "importCsv": "Importe seu arquivo CSV de teste aqui."
@@ -717,6 +720,10 @@
     "actions": {
       "downloadCsvTemplate": "Baixar modelo CSV",
       "update": "Atualizar"
+    },
+    "labels": {
+      "timeTrackingOn": "Rastreamento de tempo ativado",
+      "timeTrackingOff": "Rastreamento de tempo desativado"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/ru.json
+++ b/src/app/plugins/locales/ru.json
@@ -703,11 +703,14 @@
   "HeuristicsSettings": {
     "titles": {
       "settings": "Настройки",
-      "confirmUpload": "Подтвердить загрузку"
+      "confirmUpload": "Подтвердить загрузку",
+      "timeTracking": "Отслеживание времени"
     },
     "messages": {
       "acceptCsv": "Если вы согласны, все ваши текущие эвристики будут заменены теми, что в CSV-файле.",
-      "noCsvFileSelected": "CSV-файл не выбран. \nПожалуйста, выберите один, чтобы продолжить."
+      "noCsvFileSelected": "CSV-файл не выбран. \nПожалуйста, выберите один, чтобы продолжить.",
+      "timeTrackingDescription": "Записывает время, затраченное каждым оценщиком на каждую эвристику в процессе оценки.",
+      "settingsSaved": "Настройки успешно сохранены."
     },
     "placeHolders": {
       "importCsv": "Импортируйте ваш CSV тестовый файл сюда."
@@ -715,6 +718,10 @@
     "actions": {
       "downloadCsvTemplate": "Скачать шаблон CSV",
       "update": "Обновить"
+    },
+    "labels": {
+      "timeTrackingOn": "Отслеживание времени включено",
+      "timeTrackingOff": "Отслеживание времени отключено"
     }
   },
   "HeuristicsTestView": {

--- a/src/app/plugins/locales/zh.json
+++ b/src/app/plugins/locales/zh.json
@@ -703,11 +703,14 @@
   "HeuristicsSettings": {
     "titles": {
       "settings": "设置",
-      "confirmUpload": "确认上传"
+      "confirmUpload": "确认上传",
+      "timeTracking": "时间追踪"
     },
     "messages": {
       "acceptCsv": "如果接受，您当前的启发式将被CSV文件中的内容替换。",
-      "noCsvFileSelected": "未选择CSV文件。\n请选择一个以继续。"
+      "noCsvFileSelected": "未选择CSV文件。\n请选择一个以继续。",
+      "timeTrackingDescription": "记录每位评估者在评估过程中每个启发式上花费的时间。",
+      "settingsSaved": "设置保存成功。"
     },
     "placeHolders": {
       "importCsv": "在此导入您的CSV测试文件。"
@@ -715,6 +718,10 @@
     "actions": {
       "downloadCsvTemplate": "下载CSV模板",
       "update": "更新"
+    },
+    "labels": {
+      "timeTrackingOn": "时间追踪已启用",
+      "timeTrackingOff": "时间追踪已禁用"
     }
   },
   "HeuristicsTestView": {
@@ -1654,7 +1661,11 @@
     "test": "测试",
     "testType_1": {
       "testTitle": "可用性启发式",
-      "text": ["可用性百分比", "最终报告PDF", "邀请专家评估您的应用程序"]
+      "text": [
+        "可用性百分比",
+        "最终报告PDF",
+        "邀请专家评估您的应用程序"
+      ]
     },
     "testType_2": {
       "testTitle": "用户可用性",
@@ -1668,12 +1679,20 @@
       "SelfTest": {
         "title": "自主测试",
         "type": "无主持",
-        "text": ["在空闲时间回答", "增强的答案分析", "任务自定义"]
+        "text": [
+          "在空闲时间回答",
+          "增强的答案分析",
+          "任务自定义"
+        ]
       },
       "LiveTest": {
         "title": "实时测试",
         "type": "有主持",
-        "text": ["摄像头、音频和屏幕录制", "增强的答案分析", "有主持的实时测试"]
+        "text": [
+          "摄像头、音频和屏幕录制",
+          "增强的答案分析",
+          "有主持的实时测试"
+        ]
       }
     }
   },
@@ -1946,12 +1965,20 @@
       "blank": {
         "title": "从空白研究开始",
         "description": "从头开始创建研究，完全可定制",
-        "features": ["完全可定制", "从头构建", "对设置的完全控制"]
+        "features": [
+          "完全可定制",
+          "从头构建",
+          "对设置的完全控制"
+        ]
       },
       "template": {
         "title": "从模板创建",
         "description": "使用预构建的模板快速开始",
-        "features": ["快速设置", "预配置设置", "包含最佳实践"]
+        "features": [
+          "快速设置",
+          "预配置设置",
+          "包含最佳实践"
+        ]
       }
     },
     "details": {

--- a/src/ux/Heuristic/components/HeuristicsSettings.vue
+++ b/src/ux/Heuristic/components/HeuristicsSettings.vue
@@ -20,6 +20,29 @@
         </v-btn>
       </div>
 
+      <!-- Time Tracking Section -->
+      <div class="mb-8">
+        <h2 class="text-h6 font-weight-medium mb-2">
+          {{ $t('HeuristicsSettings.titles.timeTracking') }}
+        </h2>
+        <p class="text-body-2 text-medium-emphasis mb-3">
+          {{ $t('HeuristicsSettings.messages.timeTrackingDescription') }}
+        </p>
+        <v-switch
+          v-model="localTrackTime"
+          color="primary"
+          hide-details
+          :loading="loadingTrackTime"
+          :label="
+            localTrackTime
+              ? $t('HeuristicsSettings.labels.timeTrackingOn')
+              : $t('HeuristicsSettings.labels.timeTrackingOff')
+          "
+        />
+      </div>
+
+      <v-divider class="mb-6" />
+
       <!-- File Upload Section -->
       <div>
         <div class="d-flex align-stretch mb-4 file-upload-container">
@@ -100,7 +123,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { useStore } from 'vuex'
 import { useI18n } from 'vue-i18n'
 import { getStorage, ref as storageRef, getDownloadURL } from 'firebase/storage'
@@ -120,11 +143,28 @@ const loader = ref(null)
 const csvFile = ref(null)
 const myFile = ref(null)
 const loadingUpdate = ref(false)
+const loadingTrackTime = ref(false)
 const errorMessage = ref('')
 const errorVisible = ref(false)
 const confirmDialog = ref(false)
 
 const test = computed(() => store.getters.test)
+
+const localTrackTime = ref(test.value?.trackTime ?? true)
+
+watch(localTrackTime, async (newVal) => {
+  loadingTrackTime.value = true
+  try {
+    store.state.Tests.Test.trackTime = newVal
+    await store.dispatch('updateStudy', test.value)
+    await nextTick()
+    showSuccess(t('HeuristicsSettings.messages.settingsSaved'))
+  } catch (error) {
+    showError(error)
+  } finally {
+    loadingTrackTime.value = false
+  }
+})
 
 const testAnswerDocLength = computed(() => {
   const doc = store.getters.testAnswerDocument

--- a/src/ux/Heuristic/components/HeuristicsTestAnswer.vue
+++ b/src/ux/Heuristic/components/HeuristicsTestAnswer.vue
@@ -57,6 +57,7 @@
               :heuristics-evaluator="heuristicsEvaluator"
               :heuristics-statistics="heuristicsStatistics"
               :time-by-heuristics="timeByHeuristics"
+              :track-time="trackTime"
               :weights-statistics="weightsStatistics"
               :relative="relative"
               :usability-total-fix="usabilityTotalFix"
@@ -333,6 +334,8 @@ const maxValue = computed(() => {
 })
 
 const testAnswerDocument = computed(() => store.state.Answer.testAnswerDocument)
+
+const trackTime = computed(() => store.getters.test?.trackTime !== false)
 
 const answers = computed(() => {
   if (testAnswerDocument.value && testAnswerDocument.value.heuristicAnswers) {

--- a/src/ux/Heuristic/components/statistics/HeuristicsDataCard.vue
+++ b/src/ux/Heuristic/components/statistics/HeuristicsDataCard.vue
@@ -54,6 +54,7 @@
           {{ $t('HeuristicsTestAnswer.heuristics.headers.weights') }}
         </v-tab>
         <v-tab
+          v-if="trackTime"
           class="tab-text"
           style="text-transform: none !important"
           @click="localInd = 4"
@@ -203,7 +204,7 @@
             </v-col>
 
             <!-- Sub-tab 4: Time by Heuristics -->
-            <v-col v-if="localInd == 4" cols="12">
+            <v-col v-if="localInd == 4 && trackTime" cols="12">
               <v-data-table
                 :headers="timeByHeuristics.header"
                 :items="timeByHeuristics.items"
@@ -259,6 +260,10 @@ defineProps({
     type: Object,
     required: true,
     default: () => ({ header: [], items: [] }),
+  },
+  trackTime: {
+    type: Boolean,
+    default: true,
   },
   weightsStatistics: {
     type: Object,

--- a/src/ux/Heuristic/models/HeuristicStudy.js
+++ b/src/ux/Heuristic/models/HeuristicStudy.js
@@ -11,11 +11,13 @@ export default class HeuristicStudy extends Study {
 
     this.testType = STUDY_TYPES.HEURISTIC
     this.testWeights = params.testWeights ?? {}
+    this.trackTime = params.trackTime ?? true
   }
 
   toFirestore() {
     return Object.assign(super.toFirestore(), {
       testWeights: this.testWeights,
+      trackTime: this.trackTime,
     })
   }
 }

--- a/src/ux/Heuristic/views/HeuristicTestView.vue
+++ b/src/ux/Heuristic/views/HeuristicTestView.vue
@@ -637,6 +637,8 @@ const saveStatusColor = ref('primary')
 
 const test = computed(() => store.getters.test)
 
+const trackTimeEnabled = computed(() => test.value?.trackTime !== false)
+
 const testAlreadyStarted = computed(() => {
   return (
     currentUserTestAnswer.value?.testStarted ||
@@ -840,7 +842,7 @@ const startTest = async () => {
   if (currentUserTestAnswer.value) {
     currentUserTestAnswer.value.testStarted = true
     currentUserTestAnswer.value.lastViewedHeuristicIndex = heurisIndex.value
-    startTimer(heurisIndex.value)
+    if (trackTimeEnabled.value) startTimer(heurisIndex.value)
     // Auto-save when test starts
     debouncedAutoSave()
   }
@@ -1258,7 +1260,7 @@ const autoSaveAnswer = async () => {
     return
   }
 
-  snapshotRunningTimer(heurisIndex.value)
+  if (trackTimeEnabled.value) snapshotRunningTimer(heurisIndex.value)
 
   // Update progress and metadata
   currentUserTestAnswer.value.progress = calculatedProgress.value
@@ -1303,7 +1305,7 @@ const manualSaveAnswer = async () => {
     return
   }
 
-  snapshotRunningTimer(heurisIndex.value)
+  if (trackTimeEnabled.value) snapshotRunningTimer(heurisIndex.value)
 
   // Update progress and metadata
   currentUserTestAnswer.value.progress = calculatedProgress.value
@@ -1349,7 +1351,7 @@ const submitAnswer = async () => {
     showError('HeuristicsTestView.errors.noAnswerData')
     return
   }
-  pauseTimer(heurisIndex.value)
+  if (trackTimeEnabled.value) pauseTimer(heurisIndex.value)
   currentUserTestAnswer.value.submitted = true
   autoSaveInProgress.value = true
   updateSaveStatus('Submitting...', 'saving')
@@ -1583,7 +1585,7 @@ const restoreProgress = () => {
 
     // Set test as started
     currentUserTestAnswer.value.testStarted = true
-    startTimer(heurisIndex.value)
+    if (trackTimeEnabled.value) startTimer(heurisIndex.value)
 
     // Update status indicator
     updateSaveStatus('Progress restored', 'success')
@@ -1661,12 +1663,14 @@ watch(heurisIndex, (newIndex, oldIndex) => {
   }
   // Auto-save when navigating between heuristics
   if (!start.value) {
-    if (oldIndex !== undefined && oldIndex !== newIndex) {
-      pauseTimer(oldIndex)
+    if (trackTimeEnabled.value) {
+      if (oldIndex !== undefined && oldIndex !== newIndex) {
+        pauseTimer(oldIndex)
+      }
+      startTimer(newIndex)
     }
 
     currentUserTestAnswer.value.lastViewedHeuristicIndex = heurisIndex.value
-    startTimer(newIndex)
     updateSaveStatus('Saving changes...', 'saving')
     debouncedAutoSave()
   }
@@ -1711,7 +1715,7 @@ onBeforeMount(async () => {
 onUnmounted(() => {
   // Save progress when component is destroyed
   if (calculatedProgress.value > 0 && !currentUserTestAnswer.value?.submitted) {
-    pauseTimer(heurisIndex.value)
+    if (trackTimeEnabled.value) pauseTimer(heurisIndex.value)
     autoSaveAnswer().catch(() => {})
   }
 })


### PR DESCRIPTION
Closes #1734

  -  Inside the study → go to Settings tab → you'll see a new Time Tracking section with a toggle switch (defaults to on)                                                                                             
  - Toggle it off → it auto-saves and shows a success toast → toggle it back on
  - Go to the study's test link → click Start Test                                                                                                                                                                   
  - Answer the heuristic questions, navigating between heuristics using the sidebar (timer runs silently per heuristic in the background)
  - Once all questions are answered → click Submit                                                                                                                                                                   
  - Go back to the study → Answers tab → Heuristics tab → click the "Time by heuristics" sub-tab                                                                                                                     
  - You'll see a table showing each evaluator's time per heuristic with totals, average, and standard deviation                                                                                                      
  - Go back to Settings → toggle Time Tracking OFF → go back to Answers → Heuristics → the "Time by heuristics" sub-tab is now gone                                                                                  
  - Toggle it back on → the tab reappears
  
  
<img width="1512" height="949" alt="image" src="https://github.com/user-attachments/assets/86a53128-afa7-4401-a255-9e3c04a29e2d" />
