### PR TITLE
fix(calibration): correct globalIndex navigation for eye tracking scenarios

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -361,7 +361,7 @@
             v-if="globalIndex === 3 && hasEyeTracking"
             :calibration-in-progress="calibrationInProgress"
             :calibration-completed="calibrationCompleted"
-            @done="globalIndex = 4"
+            @done="globalIndex = hasPreTest ? 4 : 5"
             @close-calibration="closeCalibration()"
             @open-calibration="openCalibration()"
           />
@@ -952,7 +952,8 @@ const completeStep = (id, type, userCompleted = true) => {
       if (hasPreTest.value) {
         globalIndex.value = 2 // PreTest
       } else {
-        globalIndex.value = 4 // Tasks
+        // No pre-test: go to calibration if eye tracking is enabled, otherwise go to tasks
+        globalIndex.value = hasEyeTracking.value ? 3 : 4
         localTestAnswer.preTestCompleted = true
       }
       savePartialAnswer()
@@ -960,12 +961,14 @@ const completeStep = (id, type, userCompleted = true) => {
 
     if (type === 'preTest') {
       localTestAnswer.preTestCompleted = true
-      globalIndex.value = hasEyeTracking.value ? 3 : 3 // se tiver, vai pro PreCalibration
+      // With eye tracking: index 3 = Calibration; without eye tracking: index 3 = PreTasksStep
+      globalIndex.value = 3
       savePartialAnswer()
     }
 
     if (type === 'eyeCalibration') {
-      globalIndex.value = 4 // PreTasks
+      // After calibration: go to PreTasksStep if there was a pre-test, otherwise go directly to tasks
+      globalIndex.value = hasPreTest.value ? 4 : 5
       taskIndex.value = 0
       eyeCalibrationStepDone.value = true
     }


### PR DESCRIPTION
## Summary
- Fixed blank screen when eye tracking is enabled but no pre-test exists
- The `completeStep` function had incorrect `globalIndex` values causing users to land on steps that don't render
- Fixed the `@done` handler on `EyeTrackingCalibrationStep` which was hardcoded to index 4 instead of being conditional

### Root cause
When navigating through the test flow with eye tracking enabled and no pre-test:
- **Consent handler** jumped to index 4 (PreTasksStep) instead of index 3 (Calibration)
- **Calibration handler** always jumped to index 4 (PreTasksStep) even when it doesn't exist without a pre-test — should go to index 5 (Tasks)
- **`@done` template handler** was hardcoded `globalIndex = 4`, bypassing the conditional logic in `completeStep`

All four `hasPreTest × hasEyeTracking` combinations now produce correct navigation.

## Test plan
- [ ] Create a test with eye tracking enabled and **no** pre-test — verify user reaches calibration and then tasks without blank screens
- [ ] Create a test with eye tracking enabled **and** pre-test — verify normal flow still works
- [ ] Create a test without eye tracking — verify no regression

Fixes #1485