### PR TITLE
fix(editor): Identified UI overflow issue in editor and fixed it by improving container constraints and CSS behavior

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,0 +1,14 @@
+/* Fix: Prevent hyperlink popup overflow in Quill editor*/
+.ql-tooltip {
+  max-width: 250px;
+  left: 0 !important;
+  transform: none !important;
+  white-space: normal !important;
+  overflow-wrap: break-word;
+  z-index: 1000;
+}
+
+.ql-tooltip input {
+  width: 100% !important;
+  box-sizing: border-box;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import TextClamp from 'vue3-text-clamp';
 import { quillEditor } from 'vue3-quill'
 import 'vue-toastification/dist/index.css';
 import '@vueup/vue-quill/dist/vue-quill.snow.css'
+import '@/assets/main.css' 
 
 const app = createApp(App);
 


### PR DESCRIPTION
## Description
Fixes an issue where the hyperlink popup in the Quill editor overflows outside its container.

## Changes
- Added global CSS override for `.ql-tooltip`
- Constrained width and ensured proper wrapping
- Prevented input field overflow

## Impact
- Improves usability of hyperlink feature
- Applies consistently across all editor instances
- No changes to editor functionality

## Testing
- Verified in Welcome Message editor
- Verified in Task Description editor
- Tested with long URLs and different screen sizes