### PR TITLE
fix(editor): improve hyperlink tooltip layout and prevent clipping issues #1985

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,14 +1,12 @@
 /* Fix: Prevent hyperlink popup overflow in Quill editor*/
-.ql-tooltip {
+.ql-snow .ql-tooltip {
   max-width: 250px;
-  left: 0 !important;
-  transform: none !important;
   white-space: normal !important;
   overflow-wrap: break-word;
   z-index: 1000;
 }
 
-.ql-tooltip input {
+.ql-snow .ql-tooltip input {
   width: 100% !important;
   box-sizing: border-box;
 }

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,0 +1,14 @@
+/* Fix: Prevent hyperlink popup overflow in Quill editor*/
+.ql-tooltip {
+  max-width: 250px;
+  left: 0 !important;
+  transform: none !important;
+  white-space: normal !important;
+  overflow-wrap: break-word;
+  z-index: 1000;
+}
+
+.ql-tooltip input {
+  width: 100% !important;
+  box-sizing: border-box;
+}

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,12 +1,13 @@
 /* Fix: Prevent hyperlink popup overflow in Quill editor*/
-.ql-snow .ql-tooltip {
+
+.editor-container .ql-snow .ql-tooltip{
   max-width: 250px;
   white-space: normal !important;
   overflow-wrap: break-word;
   z-index: 1000;
 }
 
-.ql-snow .ql-tooltip input {
-  width: 100% !important;
+.editor-container .ql-snow .ql-tooltip input{
+  width: 100%;
   box-sizing: border-box;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,10 +6,10 @@ import vuetify from './app/plugins/vuetify.js';
 import i18n from './app/plugins/i18n';
 import Toast, { useToast } from 'vue-toastification';
 import TextClamp from 'vue3-text-clamp';
-import { quillEditor } from 'vue3-quill'
+import { quillEditor } from 'vue3-quill';
 import 'vue-toastification/dist/index.css';
-import '@vueup/vue-quill/dist/vue-quill.snow.css'
-import '@/assets/main.css'
+import '@vueup/vue-quill/dist/vue-quill.snow.css';
+import '@/assets/main.css';
 
 const app = createApp(App);
 

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import TextClamp from 'vue3-text-clamp';
 import { quillEditor } from 'vue3-quill'
 import 'vue-toastification/dist/index.css';
 import '@vueup/vue-quill/dist/vue-quill.snow.css'
+import '@/assets/main.css' 
 
 const app = createApp(App);
 

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import TextClamp from 'vue3-text-clamp';
 import { quillEditor } from 'vue3-quill'
 import 'vue-toastification/dist/index.css';
 import '@vueup/vue-quill/dist/vue-quill.snow.css'
-import '@/assets/main.css' 
+import '@/assets/main.css'
 
 const app = createApp(App);
 


### PR DESCRIPTION
## Description
Fixes #1985

Improves the layout of the hyperlink tooltip in the Quill editor by preventing text overflow within the tooltip and reducing clipping issues.

## Changes
- Scoped tooltip styles to the editor container
- Removed positioning overrides (`left`, `transform`) to preserve Quill behavior
- Improved text wrapping and input sizing

## Impact
- Improves readability of long URLs in the tooltip
- Preserves Quill’s native positioning behavior
- Reduces risk of global style side effects

## Note
Tooltip positioning near container edges is controlled by Quill and may still result in partial clipping in edge cases.

## Testing
- Tested in Welcome Message editor
- Tested with long URLs
- Verified no regression in tooltip positioning


## Screenshots

### Before
<img src="https://github.com/user-attachments/assets/09874efb-077f-4ed0-a9f1-ed3c5a58b9be" width="600"/>
<img src="https://github.com/user-attachments/assets/a1dd2a9b-b2d1-49bd-811f-c28088938083" width="600"/>

### After
<img src="https://github.com/user-attachments/assets/b1a9ed23-d14a-4925-b917-6607a3d35074" width="600"/>
<img src="https://github.com/user-attachments/assets/814045c3-dce2-42f4-a158-f4204138ad58" width="600"/>