### PR TITLE
fix(eyeTracking): improve eye tracking visualization methods (#1492)

### DIFF
--- a/src/ux/UserTest/components/answers/EyeTrackingOverlay.vue
+++ b/src/ux/UserTest/components/answers/EyeTrackingOverlay.vue
@@ -23,36 +23,52 @@ let resizeObs = null
 let heatmapData = []
 
 const DURATION = 450
+const FREE_TRAIL_LENGTH = 20
+const FADE_WINDOW = 40
 
 function lerp(a, b, t) {
   return a + (b - a) * t
 }
 
-function drawFreeEye(cx, cy) {
+function drawFreeEye(cx, cy, opacity = 1) {
   ctx.beginPath()
   ctx.arc(cx * canvas.value.width, cy * canvas.value.height, 8, 0, 2 * Math.PI)
-  ctx.fillStyle = 'rgba(255,0,0,0.8)'
+  ctx.fillStyle = `rgba(255, 0, 0, ${(opacity * 0.8).toFixed(2)})`
   ctx.fill()
 }
 
 function drawPrecisionPoints(cx, cy) {
-  ctx.lineWidth = 2
-  ctx.strokeStyle = 'rgba(0, 200, 255, 0.6)'
-  ctx.beginPath()
-
+  // Draw path segments with per-segment opacity fade (newer = brighter)
   for (let j = 0; j < i; j++) {
     const a = normalized[j]
     const b = normalized[j + 1] || a
+    const age = i - j
+    const opacity =
+      age <= FADE_WINDOW ? Math.max(0.08, 1 - age / FADE_WINDOW) : 0.08
+    ctx.lineWidth = 2
+    ctx.strokeStyle = `rgba(0, 200, 255, ${opacity.toFixed(2)})`
+    ctx.beginPath()
     ctx.moveTo(a.x * canvas.value.width, a.y * canvas.value.height)
     ctx.lineTo(b.x * canvas.value.width, b.y * canvas.value.height)
+    ctx.stroke()
   }
 
-  const prev = normalized[i]
-  ctx.moveTo(prev.x * canvas.value.width, prev.y * canvas.value.height)
-  ctx.lineTo(cx * canvas.value.width, cy * canvas.value.height)
-  ctx.stroke()
+  // Live segment from last known point to current interpolated position
+  if (normalized[i]) {
+    const prev = normalized[i]
+    ctx.lineWidth = 2
+    ctx.strokeStyle = 'rgba(0, 200, 255, 1.0)'
+    ctx.beginPath()
+    ctx.moveTo(prev.x * canvas.value.width, prev.y * canvas.value.height)
+    ctx.lineTo(cx * canvas.value.width, cy * canvas.value.height)
+    ctx.stroke()
+  }
 
+  // Dots: faded for older points, bright for current
   normalized.slice(0, i + 1).forEach((p, idx) => {
+    const age = i - idx
+    const opacity =
+      age <= FADE_WINDOW ? Math.max(0.15, 1 - age / FADE_WINDOW) : 0.15
     ctx.beginPath()
     ctx.arc(
       p.x * canvas.value.width,
@@ -62,22 +78,26 @@ function drawPrecisionPoints(cx, cy) {
       2 * Math.PI,
     )
     ctx.fillStyle =
-      idx === i ? 'rgba(0, 255, 255, 1)' : 'rgba(0, 200, 255, 0.7)'
+      idx === i
+        ? 'rgba(0, 255, 255, 1)'
+        : `rgba(0, 200, 255, ${opacity.toFixed(2)})`
     ctx.fill()
   })
 
+  // White cursor at live interpolated position
   ctx.beginPath()
   ctx.arc(cx * canvas.value.width, cy * canvas.value.height, 6, 0, 2 * Math.PI)
-  ctx.fillStyle = 'rgba(255,255,255,0.9)'
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.9)'
   ctx.fill()
 }
 
 function drawHeatmapPoint(x, y) {
-  const radius = 20
+  const radius = 60
   const gradient = ctx.createRadialGradient(x, y, 0, x, y, radius)
-  gradient.addColorStop(0, 'rgba(255,0,0,0.03)')
-  gradient.addColorStop(0.6, 'rgba(255,150,0,0.06)')
-  gradient.addColorStop(1, 'rgba(255,255,0,0.0012)')
+  gradient.addColorStop(0, 'rgba(255, 0,   0,   0.35)')
+  gradient.addColorStop(0.4, 'rgba(255, 80,  0,   0.20)')
+  gradient.addColorStop(0.7, 'rgba(255, 200, 0,   0.10)')
+  gradient.addColorStop(1, 'rgba(255, 255, 0,   0.00)')
   ctx.fillStyle = gradient
   ctx.beginPath()
   ctx.arc(x, y, radius, 0, 2 * Math.PI)
@@ -103,7 +123,7 @@ function animateSmooth(timestamp) {
   ctx.clearRect(0, 0, canvas.value.width, canvas.value.height)
 
   if (props.viewMode === 'free') drawFreeEye(cx, cy)
-  else if (props.viewMode === 'precision') drawPrecisionPoints()
+  else if (props.viewMode === 'precision') drawPrecisionPoints(cx, cy)
   else if (props.viewMode === 'heatmap') {
     heatmapData.push({ x: cx, y: cy })
     drawHeatmap()
@@ -229,9 +249,13 @@ watch(
     ctx.clearRect(0, 0, canvas.value.width, canvas.value.height)
 
     if (props.viewMode === 'free') {
-      visiblePoints.forEach((p) => drawFreeEye(p.x, p.y))
+      const trail = visiblePoints.slice(-FREE_TRAIL_LENGTH)
+      trail.forEach((p, idx) => {
+        const opacity = (idx + 1) / trail.length
+        drawFreeEye(p.x, p.y, opacity)
+      })
     } else if (props.viewMode === 'precision') {
-      visiblePoints.forEach((p) => drawPrecisionPoints(p.x, p.y))
+      drawPrecisionPoints(normalized[i].x, normalized[i].y)
     } else if (props.viewMode === 'heatmap') {
       heatmapData = visiblePoints
       drawHeatmap()

--- a/src/ux/UserTest/components/dialogs/SessionAnalyticsDialog.vue
+++ b/src/ux/UserTest/components/dialogs/SessionAnalyticsDialog.vue
@@ -61,7 +61,7 @@
           <v-col cols="12" md="6">
             <v-tabs v-model="rightTab" bg-color="grey-lighten-4" grow>
               <!-- <v-tab value="general">General</v-tab> -->
-              <v-tab v-if="taskAnswer?.irisTrackingData.length > 0" value="eye"
+              <v-tab v-if="taskAnswer?.irisTrackingData?.length > 0" value="eye"
                 >Eye Tracker</v-tab
               >
               <v-tab v-if="taskAnswer?.webcamRecordURL" value="sentimental"
@@ -80,7 +80,7 @@
                             </v-window-item> -->
 
               <v-window-item
-                v-if="taskAnswer?.irisTrackingData.length > 0"
+                v-if="taskAnswer?.irisTrackingData?.length > 0"
                 value="eye"
               >
                 <EyeTrackingStats

--- a/src/ux/UserTest/components/sessions/EyeTrackingStats.vue
+++ b/src/ux/UserTest/components/sessions/EyeTrackingStats.vue
@@ -209,7 +209,6 @@ const predictedData = ref(null)
 const isAnalyzing = ref(true)
 const hasError = ref(false)
 
-const totalPredictions = ref(0)
 const insights = ref([])
 const summaryMetrics = ref([])
 
@@ -258,6 +257,60 @@ onMounted(async () => {
   }
 })
 
+function detectFixations(predictions) {
+  const SPATIAL_THRESHOLD = 50
+  const MIN_DURATION = 200
+  const SCREEN_W = predictions[0]?.screen_width || 1920
+  const SCREEN_H = predictions[0]?.screen_height || 1080
+
+  if (!predictions.length) return []
+
+  const fixations = []
+  let cluster = [predictions[0]]
+
+  for (let k = 1; k < predictions.length; k++) {
+    const p = predictions[k]
+    const cx = cluster.reduce((s, q) => s + q.predicted_x, 0) / cluster.length
+    const cy = cluster.reduce((s, q) => s + q.predicted_y, 0) / cluster.length
+    const dx = p.predicted_x - cx
+    const dy = p.predicted_y - cy
+
+    if (Math.sqrt(dx * dx + dy * dy) <= SPATIAL_THRESHOLD) {
+      cluster.push(p)
+    } else {
+      const duration =
+        cluster[cluster.length - 1].timestamp - cluster[0].timestamp
+      if (duration >= MIN_DURATION && cluster.length >= 3) {
+        fixations.push({
+          x: cx / SCREEN_W,
+          y: cy / SCREEN_H,
+          duration,
+          pointCount: cluster.length,
+        })
+      }
+      cluster = [p]
+    }
+  }
+
+  // Finalize last cluster
+  if (cluster.length >= 3) {
+    const duration =
+      cluster[cluster.length - 1].timestamp - cluster[0].timestamp
+    if (duration >= MIN_DURATION) {
+      const cx = cluster.reduce((s, q) => s + q.predicted_x, 0) / cluster.length
+      const cy = cluster.reduce((s, q) => s + q.predicted_y, 0) / cluster.length
+      fixations.push({
+        x: cx / SCREEN_W,
+        y: cy / SCREEN_H,
+        duration,
+        pointCount: cluster.length,
+      })
+    }
+  }
+
+  return fixations
+}
+
 function processAnalytics(data) {
   const predictions = Array.isArray(data) ? data : []
 
@@ -267,16 +320,113 @@ function processAnalytics(data) {
     return
   }
 
-  totalPredictions.value = predictions.length
+  const total = predictions.length
+
+  const fixations = detectFixations(predictions)
+  const fixationCount = fixations.length
+  const avgFixationDuration =
+    fixationCount > 0
+      ? Math.round(
+          fixations.reduce((s, f) => s + f.duration, 0) / fixationCount,
+        )
+      : 0
+
+  const GRID = 10
+  const visitedCells = new Set()
+  predictions.forEach((p) => {
+    const col = Math.min(
+      Math.floor((p.predicted_x / (p.screen_width || 1920)) * GRID),
+      GRID - 1,
+    )
+    const row = Math.min(
+      Math.floor((p.predicted_y / (p.screen_height || 1080)) * GRID),
+      GRID - 1,
+    )
+    visitedCells.add(`${col},${row}`)
+  })
+  const coveragePct = Math.round((visitedCells.size / (GRID * GRID)) * 100)
 
   summaryMetrics.value = [
     {
       label: 'Total Predictions',
-      value: totalPredictions.value,
-      progress: Math.min(totalPredictions.value, 300),
+      value: total,
+      progress: Math.min((total / 500) * 100, 100),
       color: 'indigo-darken-2',
       icon: 'mdi-eye-outline',
     },
+    {
+      label: 'Fixation Count',
+      value: fixationCount,
+      progress: Math.min((fixationCount / 30) * 100, 100),
+      color: 'teal-darken-2',
+      icon: 'mdi-eye-circle-outline',
+    },
+    {
+      label: 'Avg Fixation Duration',
+      value: `${avgFixationDuration} ms`,
+      progress: Math.min((avgFixationDuration / 800) * 100, 100),
+      color: 'deep-purple-darken-2',
+      icon: 'mdi-timer-outline',
+    },
+    {
+      label: 'Screen Coverage',
+      value: `${coveragePct}%`,
+      progress: coveragePct,
+      color: 'green-darken-2',
+      icon: 'mdi-grid',
+    },
   ]
+
+  const insightList = []
+
+  if (fixationCount > 20) {
+    insightList.push({
+      type: 'success',
+      color: 'green',
+      icon: 'mdi-check-circle',
+      text: `High engagement detected: ${fixationCount} fixations recorded.`,
+    })
+  } else if (fixationCount > 8) {
+    insightList.push({
+      type: 'info',
+      color: 'blue',
+      icon: 'mdi-information',
+      text: `Moderate gaze stability: ${fixationCount} fixations detected.`,
+    })
+  } else {
+    insightList.push({
+      type: 'warning',
+      color: 'orange',
+      icon: 'mdi-alert',
+      text: `Few fixations detected (${fixationCount}). User may have been scanning rapidly.`,
+    })
+  }
+
+  if (avgFixationDuration > 400) {
+    insightList.push({
+      type: 'info',
+      color: 'deep-purple',
+      icon: 'mdi-timer-sand',
+      text: `Long average fixation duration (${avgFixationDuration} ms): user focused on specific areas.`,
+    })
+  }
+
+  if (coveragePct > 60) {
+    insightList.push({
+      type: 'success',
+      color: 'teal',
+      icon: 'mdi-view-grid',
+      text: `Good screen coverage (${coveragePct}%): gaze explored most of the viewport.`,
+    })
+  } else if (coveragePct < 30) {
+    insightList.push({
+      type: 'warning',
+      color: 'orange',
+      icon: 'mdi-view-grid-outline',
+      text: `Limited screen coverage (${coveragePct}%): gaze was concentrated in a narrow region.`,
+    })
+  }
+
+  insights.value = insightList
 }
 </script>


### PR DESCRIPTION
- Fix precision mode rendering n² bug causing hundreds of overlapping
  lines (animateSmooth was not passing cx/cy to drawPrecisionPoints,
  and currentTime watch called drawPrecisionPoints once per visible
  point instead of once)
- Fix heatmap near-invisible due to near-zero opacity values and 20px
  radius; raise to 60px radius with proper heat gradient (0.35→0.10)
- Add opacity-fading trail to precision mode (older segments fade out)
- Add sliding-window trail to free eye mode (last 20 pts with fade)
- Add fixation detection algorithm to EyeTrackingStats (50px spatial
  threshold, 200ms min duration) computing fixation count, avg
  fixation duration, and screen coverage metrics
- Populate previously empty insights array with contextual messages
- Fix optional chaining crash when irisTrackingData is undefined