### PR TITLE
docs: fixed incorrect redirection links for bug and feature request issue templates in CONTRIBUTING.md #1996

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,7 +274,7 @@ When reporting bugs, please include:
 - **Screenshots** if applicable
 - **Error messages** or console logs
 
-Use the [Bug Report template](https://github.com/uramakilab/remote-usability-lab/issues/new)
+Use the [Bug Report template](https://github.com/uramakilab/remote-usability-lab/issues/new?template=bug.yml)
 
 ### Feature Requests
 
@@ -284,7 +284,7 @@ For feature requests, include:
 - **Proposed solution** - How should it work?
 - **Alternatives considered** - Other approaches you've thought about
 
-Use the [Feature Request template](https://github.com/uramakilab/remote-usability-lab/issues/new)
+Use the [Feature Request template](https://github.com/uramakilab/remote-usability-lab/issues/new?template=feature.yml)
 
 ### Questions and Discussions
 


### PR DESCRIPTION
## Problem
Both "Bug Report template" and "Feature Request template" links in 
CONTRIBUTING.md point to the same generic URL:
https://github.com/uramakilab/remote-usability-lab/issues/new 

This causes users to land on the blank issue template page instead of 
the specific template directly.

## Fix
Added the correct `?template=` query parameter to both links.

## Changes
- Fixed Bug Report template link → `?template=bug.yml`
- Fixed Feature Request template link → `?template=feature.yml`

## Screenshots

### Before
<img width="1399" height="926" alt="Image" src="https://github.com/user-attachments/assets/db0475ce-9156-4e2d-8dc2-dd7593b47918" />

### After (Bug Template)
<img width="1415" height="916" alt="Image" src="https://github.com/user-attachments/assets/bd08336e-0c80-4305-85c1-7479fbebefb1" />

### After (Feature Template)
<img width="1403" height="927" alt="Screenshot 2026-03-30 005925" src="https://github.com/user-attachments/assets/11fa8dde-c8b2-4512-98b8-5c15a81ac466" />


Fixes #1996