### PR TITLE
fix(calibration): correct globalIndex navigation for eye tracking scenarios

### DIFF
--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -361,7 +361,7 @@
             v-if="globalIndex === 3 && hasEyeTracking"
             :calibration-in-progress="calibrationInProgress"
             :calibration-completed="calibrationCompleted"
-            @done="globalIndex = 4"
+            @done="globalIndex = hasPreTest ? 4 : 5"
             @close-calibration="closeCalibration()"
             @open-calibration="openCalibration()"
           />
@@ -952,7 +952,8 @@ const completeStep = (id, type, userCompleted = true) => {
       if (hasPreTest.value) {
         globalIndex.value = 2 // PreTest
       } else {
-        globalIndex.value = 4 // Tasks
+        // No pre-test: go to calibration if eye tracking is enabled, otherwise go to tasks
+        globalIndex.value = hasEyeTracking.value ? 3 : 4
         localTestAnswer.preTestCompleted = true
       }
       savePartialAnswer()
@@ -960,12 +961,14 @@ const completeStep = (id, type, userCompleted = true) => {
 
     if (type === 'preTest') {
       localTestAnswer.preTestCompleted = true
-      globalIndex.value = hasEyeTracking.value ? 3 : 3 // se tiver, vai pro PreCalibration
+      // With eye tracking: index 3 = Calibration; without eye tracking: index 3 = PreTasksStep
+      globalIndex.value = 3
       savePartialAnswer()
     }
 
     if (type === 'eyeCalibration') {
-      globalIndex.value = 4 // PreTasks
+      // After calibration: go to PreTasksStep if there was a pre-test, otherwise go directly to tasks
+      globalIndex.value = hasPreTest.value ? 4 : 5
       taskIndex.value = 0
       eyeCalibrationStepDone.value = true
     }


### PR DESCRIPTION
## Summary
- Fixed blank screen when eye tracking is enabled but no pre-test exists
- The `completeStep` function had incorrect `globalIndex` values
- Fixed the `@done` handler hardcoded to index 4 instead of being conditional

<img width="531" height="454" alt="image" src="https://github.com/user-attachments/assets/284d345b-e618-4638-bdaf-c537e103452c" />


### Root cause
- **Consent handler** jumped to index 4 instead of index 3 (Calibration)
- **Calibration handler** always jumped to index 4 even without a pre-test
- **`@done` template handler** was hardcoded `globalIndex = 4`

## Test plan
- [ ] Test with eye tracking enabled and no pre-test
- [ ] Test with eye tracking enabled and pre-test
- [ ] Test without eye tracking

Fixes #1485