### PR TITLE
feat(flow): redirect evaluators to test dashboard after completion

### DIFF
--- a/src/ux/Heuristic/views/HeuristicTestView.vue
+++ b/src/ux/Heuristic/views/HeuristicTestView.vue
@@ -598,6 +598,7 @@ import Snackbar from '@/shared/components/Snackbar'
 import HeuristicQuestionAnswer from '@/ux/Heuristic/models/HeuristicQuestionAnswer'
 import Heuristic from '@/ux/Heuristic/models/Heuristic'
 import { showSuccess, showError } from '@/shared/utils/toast'
+import { ACCESS_LEVEL } from '@/shared/utils/accessLevel'
 
 const props = defineProps({
   id: { type: String, default: '' },
@@ -694,6 +695,15 @@ const showSaveBtn = computed(() => {
 
 const isUserTestAdmin = computed(() => {
   return test.value.testAdmin.userDocId === user.value?.id
+})
+
+const hasTestDashboardAccess = computed(() => {
+  if (!user.value) return false
+  if (isUserTestAdmin.value) return true
+  const coop = test.value?.cooperators?.find(
+    (c) => c.userDocId === user.value.id,
+  )
+  return coop?.accessLevel === ACCESS_LEVEL.EVALUATOR
 })
 
 const isValidProgress = computed(() => {
@@ -1363,7 +1373,11 @@ const submitAnswer = async () => {
     })
     showSuccess('alerts.genericSuccess')
     setTimeout(() => {
-      router.push('/admin')
+      if (hasTestDashboardAccess.value) {
+        router.push(`/heuristic/manager/${test.value.id}`)
+      } else {
+        router.push('/admin')
+      }
     }, 1500)
   } catch {
     currentUserTestAnswer.value.submitted = false

--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -630,6 +630,7 @@ import SubmitDialog from '@/ux/UserTest/components/SubmitDialog.vue'
 import VideoCall from '@/ux/UserTest/components/VideoCall.vue'
 import ObservatorNotes from '@/ux/UserTest/components/ObservatorNotes.vue'
 import { STUDY_TYPES } from '@/shared/constants/methodDefinitions'
+import { ACCESS_LEVEL } from '@/shared/utils/accessLevel'
 import UserStudyEvaluatorAnswer from '@/ux/UserTest/models/UserStudyEvaluatorAnswer'
 import TaskAnswer from '@/ux/UserTest/models/TaskAnswer'
 import { MEDIA_FIELD_MAP } from '@/shared/constants/mediasType'
@@ -692,6 +693,14 @@ const currentUserAccessLevel = computed(() => {
 })
 
 const isObservator = computed(() => currentUserAccessLevel.value === 3)
+
+const hasTestDashboardAccess = computed(() => {
+  if (!user.value) return false
+  return (
+    currentUserAccessLevel.value === ACCESS_LEVEL.ADMIN ||
+    currentUserAccessLevel.value === ACCESS_LEVEL.EVALUATOR
+  )
+})
 
 const timerComponent = computed(() => {
   // Get timer ref from TaskStep
@@ -841,7 +850,11 @@ const handleSubmit = async () => {
   try {
     localTestAnswer.submitted = true
     await saveAnswer()
-    await router.push({ name: 'Admin' })
+    if (hasTestDashboardAccess.value) {
+      await router.push(`/userTest/moderated/manager/${test.value.id}`)
+    } else {
+      await router.push({ name: 'Admin' })
+    }
   } catch {
     store.commit('SET_TOAST', {
       type: 'error',

--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -541,6 +541,7 @@ import TaskStep from '@/ux/UserTest/components/steps/TaskStep.vue'
 import PostTestStep from '@/ux/UserTest/components/steps/PostTestStep.vue'
 import FinishStep from '@/ux/UserTest/components/steps/FinishStep.vue'
 import { STUDY_TYPES } from '@/shared/constants/methodDefinitions'
+import { ACCESS_LEVEL } from '@/shared/utils/accessLevel'
 import UserStudyEvaluatorAnswer from '@/ux/UserTest/models/UserStudyEvaluatorAnswer'
 import TaskAnswer from '@/ux/UserTest/models/TaskAnswer'
 import EyeTrackingCalibrationStep from '@/ux/UserTest/calibration/EyeTrackingCalibrationStep.vue'
@@ -622,6 +623,15 @@ const hasPostTest = computed(() => {
 
 const isUserTestAdmin = computed(() => {
   return test.value.testAdmin.userDocId === user.value?.id
+})
+
+const hasTestDashboardAccess = computed(() => {
+  if (!user.value) return false
+  if (isUserTestAdmin.value) return true
+  const coop = test.value?.cooperators?.find(
+    (c) => c.userDocId === user.value.id,
+  )
+  return coop?.accessLevel === ACCESS_LEVEL.EVALUATOR
 })
 
 const isStartTestDisabled = computed(() => {
@@ -773,7 +783,11 @@ const saveAnswer = async () => {
   try {
     attachMediaToTasks(localTestAnswer, mediaUrls.value)
     await savePartialAnswer()
-    router.push('/admin')
+    if (hasTestDashboardAccess.value) {
+      router.push(`/userTest/unmoderated/manager/${test.value.id}`)
+    } else {
+      router.push('/admin')
+    }
   } catch {
     store.commit('SET_TOAST', {
       type: 'error',


### PR DESCRIPTION
## Summary
- Evaluators now redirect to test dashboard instead of main menu after completing a test
- Covers unmoderated, moderated, and heuristic test types
- Guest/anonymous users still redirect to `/admin`

### Changes
- **UserTestView.vue**: redirects to `/userTest/unmoderated/manager/:id`
- **ModeratedTestView.vue**: redirects to `/userTest/moderated/manager/:id`
- **HeuristicTestView.vue**: redirects to `/heuristic/manager/:id`

## Test plan
- [ ] Complete test as evaluator — verify redirect to dashboard
- [ ] Complete test as guest — verify redirect to `/admin`
- [ ] Test all three test types

Fixes #1491