### PR TITLE
fix(task): await media upload before completing task

### DIFF
--- a/src/ux/UserTest/components/AudioRecorder.vue
+++ b/src/ux/UserTest/components/AudioRecorder.vue
@@ -224,22 +224,70 @@ const startAudioRecording = async () => {
   }
 }
 
+const STOP_TIMEOUT_MS = 30000
+
 const stopAudioRecording = () => {
-  if (!recordingAudio.value) return
+  if (!recordingAudio.value) return Promise.resolve()
+
+  const promises = []
 
   if (
     mediaRecorder.value?.local &&
     mediaRecorder.value.local.state !== 'inactive'
   ) {
-    mediaRecorder.value.local.stop()
+    promises.push(
+      new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+          console.warn('AudioRecorder: local upload timed out after 30s')
+          resolve()
+        }, STOP_TIMEOUT_MS)
+
+        const originalOnStop = mediaRecorder.value.local.onstop
+        mediaRecorder.value.local.onstop = async (event) => {
+          try {
+            await originalOnStop(event)
+          } catch (err) {
+            console.error('AudioRecorder: error in local onstop handler', err)
+          } finally {
+            clearTimeout(timeout)
+            resolve()
+          }
+        }
+
+        mediaRecorder.value.local.stop()
+      }),
+    )
   }
 
   if (
     mediaRecorder.value?.remote &&
     mediaRecorder.value.remote.state !== 'inactive'
   ) {
-    mediaRecorder.value.remote.stop()
+    promises.push(
+      new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+          console.warn('AudioRecorder: remote upload timed out after 30s')
+          resolve()
+        }, STOP_TIMEOUT_MS)
+
+        const originalOnStop = mediaRecorder.value.remote.onstop
+        mediaRecorder.value.remote.onstop = async (event) => {
+          try {
+            await originalOnStop(event)
+          } catch (err) {
+            console.error('AudioRecorder: error in remote onstop handler', err)
+          } finally {
+            clearTimeout(timeout)
+            resolve()
+          }
+        }
+
+        mediaRecorder.value.remote.stop()
+      }),
+    )
   }
+
+  return Promise.all(promises)
 }
 
 defineExpose({ startAudioRecording, stopAudioRecording })

--- a/src/ux/UserTest/components/ScreenRecorder.vue
+++ b/src/ux/UserTest/components/ScreenRecorder.vue
@@ -153,10 +153,31 @@ const recordScreen = async () => {
   }
 }
 
+const STOP_TIMEOUT_MS = 30000
+
 const stopRecording = () => {
-  if (isRecording.value) {
+  if (!isRecording.value) return Promise.resolve()
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      console.warn('ScreenRecorder: upload timed out after 30s')
+      resolve()
+    }, STOP_TIMEOUT_MS)
+
+    const originalOnStop = mediaRecorder.value.onstop
+    mediaRecorder.value.onstop = async (event) => {
+      try {
+        await originalOnStop(event)
+      } catch (err) {
+        console.error('ScreenRecorder: error in onstop handler', err)
+      } finally {
+        clearTimeout(timeout)
+        resolve()
+      }
+    }
+
     mediaRecorder.value.stop()
-  }
+  })
 }
 
 defineExpose({ captureScreen, stopRecording })

--- a/src/ux/UserTest/components/VideoRecorder.vue
+++ b/src/ux/UserTest/components/VideoRecorder.vue
@@ -103,7 +103,7 @@ const requestCameraPermission = async () => {
 }
 
 const startRecording = async () => {
-  if(cameraPermissionDenied.value) {
+  if (cameraPermissionDenied.value) {
     const permissionGranted = await requestCameraPermission()
     if (!permissionGranted) {
       showError(t('errors.cameraPermissionDenied'))
@@ -134,12 +134,12 @@ const startRecording = async () => {
     }
   } catch (e) {
     recording.value = false
-    if(e.name === 'NotAllowedError' || e.name === 'PermissionDeniedError') {
+    if (e.name === 'NotAllowedError' || e.name === 'PermissionDeniedError') {
       cameraPermissionDenied.value = true
       showError(t('errors.cameraPermissionDenied'))
       return false
     }
-    console.error("Unexpected error while starting video recording:", e)
+    console.error('Unexpected error while starting video recording:', e)
     showError('errors.globalError')
     return false
   }
@@ -211,10 +211,33 @@ const startRecording = async () => {
   }
 }
 
+const STOP_TIMEOUT_MS = 30000
+
 const stopRecording = () => {
-  if (mediaRecorder.value) {
-    mediaRecorder.value.stop()
+  if (!mediaRecorder.value || mediaRecorder.value.state === 'inactive') {
+    return Promise.resolve()
   }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      console.warn('VideoRecorder: upload timed out after 30s')
+      resolve()
+    }, STOP_TIMEOUT_MS)
+
+    const originalOnStop = mediaRecorder.value.onstop
+    mediaRecorder.value.onstop = async (event) => {
+      try {
+        await originalOnStop(event)
+      } catch (err) {
+        console.error('VideoRecorder: error in onstop handler', err)
+      } finally {
+        clearTimeout(timeout)
+        resolve()
+      }
+    }
+
+    mediaRecorder.value.stop()
+  })
 }
 
 defineExpose({ startRecording, stopRecording })

--- a/src/ux/UserTest/components/steps/TaskStep.vue
+++ b/src/ux/UserTest/components/steps/TaskStep.vue
@@ -528,10 +528,6 @@ onBeforeUnmount(() => {
     clearInterval(timerInterval)
     timerInterval = null
   }
-  if (finishTimeout) {
-    clearTimeout(finishTimeout)
-    finishTimeout = null
-  }
   forceStopAllMedia()
 
   uploadingCount.value = 0
@@ -643,7 +639,6 @@ const pendingFinalTime = ref(null)
 
 let taskStartTime = null
 let timerInterval = null
-let finishTimeout = null
 
 function onShowLoading() {
   uploadingCount.value++
@@ -654,29 +649,10 @@ function onStopShowLoading() {
   uploadingCount.value--
   if (uploadingCount.value < 0) uploadingCount.value = 0
   emit('stop-show-loading')
-
-  if (uploadingCount.value === 0 && isWaitingForUploadToFinish.value) {
-    emitDoneOrCouldNotFinish(pendingFinalTime.value)
-  }
 }
 
 function attemptFinish() {
-  if (uploadingCount.value > 0) {
-    isWaitingForUploadToFinish.value = true
-  } else {
-    // Check for where uploads have not started yet
-    if (stage.value !== 3 && hasAnyRecording.value) {
-      isWaitingForUploadToFinish.value = true
-      // Short timeout to alllow recorders to emit show-loading
-      finishTimeout = setTimeout(() => {
-        if (uploadingCount.value === 0 && isWaitingForUploadToFinish.value) {
-          emitDoneOrCouldNotFinish(pendingFinalTime.value)
-        }
-      }, 500)
-    } else {
-      emitDoneOrCouldNotFinish(pendingFinalTime.value)
-    }
-  }
+  emitDoneOrCouldNotFinish(pendingFinalTime.value)
 }
 
 function updateElapsedTime() {
@@ -734,7 +710,7 @@ async function startMediaRecorders() {
   }
   if (props.task?.hasCamRecord && videoRecorder.value) {
     const videoStarted = await videoRecorder.value.startRecording()
-    if(!videoStarted){
+    if (!videoStarted) {
       return false
     }
   }
@@ -744,16 +720,40 @@ async function startMediaRecorders() {
   return true
 }
 
-function forceStopAllMedia() {
-  audioRecorder.value?.stopAudioRecording?.()
-  videoRecorder.value?.stopRecording?.()
-  screenRecorder.value?.stopRecording?.()
+async function forceStopAllMedia() {
+  const promises = []
+
+  if (audioRecorder.value?.stopAudioRecording) {
+    promises.push(
+      Promise.resolve(audioRecorder.value.stopAudioRecording()).catch((err) =>
+        console.error('Error stopping audio recorder:', err),
+      ),
+    )
+  }
+  if (videoRecorder.value?.stopRecording) {
+    promises.push(
+      Promise.resolve(videoRecorder.value.stopRecording()).catch((err) =>
+        console.error('Error stopping video recorder:', err),
+      ),
+    )
+  }
+  if (screenRecorder.value?.stopRecording) {
+    promises.push(
+      Promise.resolve(screenRecorder.value.stopRecording()).catch((err) =>
+        console.error('Error stopping screen recorder:', err),
+      ),
+    )
+  }
+
+  await Promise.all(promises)
 }
 
-function handleShowPostForm(userCompleted) {
+async function handleShowPostForm(userCompleted) {
   if (isWaitingForUploadToFinish.value) return
 
-  forceStopAllMedia()
+  isWaitingForUploadToFinish.value = true
+  showPostForm.value.userCompleted = userCompleted
+  emit('show-loading')
 
   if (timerInterval) {
     clearInterval(timerInterval)
@@ -764,11 +764,13 @@ function handleShowPostForm(userCompleted) {
   if (taskStartTime) {
     finalTime = Math.round(Date.now() - taskStartTime)
     pendingFinalTime.value = finalTime
-    console.log('Tiempo detenido en:', finalTime, 'segundos')
     emit('timer-stopped', finalTime, props.taskIndex)
   }
 
-  showPostForm.value.userCompleted = userCompleted
+  await forceStopAllMedia()
+
+  emit('stop-show-loading')
+  isWaitingForUploadToFinish.value = false
 
   if (props.task?.taskType === 'post-form' && props.task?.postForm) {
     const link = props.task?.postForm
@@ -785,7 +787,7 @@ function handleShowPostForm(userCompleted) {
   if (VALIDATION_REQUIRED_TYPES.has(props.task?.taskType)) {
     stage.value = 3
   } else {
-    attemptFinish()
+    emitDoneOrCouldNotFinish(pendingFinalTime.value)
   }
 }
 
@@ -837,10 +839,6 @@ watch(
 watch(
   () => props.taskIndex,
   () => {
-    if (finishTimeout) {
-      clearTimeout(finishTimeout)
-      finishTimeout = null
-    }
     forceStopAllMedia()
     stage.value = 1
     taskStartTime = null

--- a/src/ux/UserTest/views/UserTestView.vue
+++ b/src/ux/UserTest/views/UserTestView.vue
@@ -890,25 +890,10 @@ const callTimerSave = () => {
 async function handleTaskFinish(userCompleted) {
   callTimerSave()
 
-  await nextTick()
-
-  if (isLoading.value) {
-    const unwatch = watch(
-      () => isLoading.value,
-      async (val) => {
-        if (!val) {
-          unwatch()
-          completeStep(taskIndex.value, 'tasks', userCompleted)
-          attachMediaToTasks(localTestAnswer, mediaUrls.value)
-          await savePartialAnswer()
-        }
-      },
-    )
-  } else {
-    completeStep(taskIndex.value, 'tasks', userCompleted)
-    attachMediaToTasks(localTestAnswer, mediaUrls.value)
-    await savePartialAnswer()
-  }
+  // Media uploads are now guaranteed to be complete before TaskStep emits done/couldNotFinish
+  completeStep(taskIndex.value, 'tasks', userCompleted)
+  attachMediaToTasks(localTestAnswer, mediaUrls.value)
+  await savePartialAnswer()
 }
 
 const startTimer = () => {


### PR DESCRIPTION
## Summary
- Fixed race condition where task completion navigated away before media finished uploading
- Recorder stop methods now return Promises that resolve after Firebase upload completes
- Added 30-second safety timeout to prevent hangs
- Removed unreliable 500ms setTimeout fallback

### Files changed
- **ScreenRecorder.vue** — promisified stopRecording with 30s timeout
- **VideoRecorder.vue** — same pattern
- **AudioRecorder.vue** — same for local and remote recorders
- **TaskStep.vue** — async forceStopAllMedia, loading overlay around save
- **UserTestView.vue** — simplified handleTaskFinish

## Test plan
- [ ] Complete task with screen + webcam recording — verify full upload before navigation
- [ ] Check loading overlay appears during save
- [ ] Verify no data loss on slow connections

Fixes #1486