### PR TITLE
fix(studies): status filter dropdown unresponsive when clicking chip text

### DIFF
--- a/src/features/navigation/components/navbarSections/StudiesSection.vue
+++ b/src/features/navigation/components/navbarSections/StudiesSection.vue
@@ -89,9 +89,9 @@
 
           <!-- ⚙️ Status -->
           <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">
+            <label class="filter-label" style="cursor:pointer">
               {{ $t('pages.studies.statusLabel') }}
-            </div>
+            </label>
             <v-select
               v-model="selectedStatusFilter"
               :items="statusOptions"
@@ -102,6 +102,9 @@
               density="compact"
               variant="outlined"
               hide-details
+              class="status-select"
+              role="listbox"
+              :aria-label="$t('pages.studies.statusLabel')"
             />
           </v-col>
 
@@ -405,4 +408,9 @@ const goTo = (test) => {
 .filter-field :deep(.v-field__input) {
   min-height: 36px;
 }
+
+.status-select :deep(.v-chip){
+  pointer-events: none;
+}
+
 </style>


### PR DESCRIPTION
## Problem
On the Studies page, clicking directly on the "All Statuses" chip text inside the Status filter dropdown does not open the dropdown menu. Clicking on the empty area of the input box works fine, but the chip text intercepts the click event and prevents it from reaching the dropdown trigger.

Root Cause
The v-chip component rendered inside the v-select was capturing pointer events, blocking clicks from propagating to the Vuetify dropdown trigger.

## Fix
Added pointer-events: none to the chip element via scoped CSS so clicks pass through to the dropdown trigger. Also replaced the <div> filter label with a semantic <label> element and added aria-label + role attributes for accessibility improvements.

## Changes
- Fixed chip click interception → pointer-events: none on .status-select :deep(.v-chip)
- Replaced <div class="filter-label"> with <label> for semantic HTML
- Added aria-label and role="listbox" to the v-select for screen reader support

## Screenshots

### Before

https://github.com/user-attachments/assets/84a5f0a4-c5b8-43bc-9add-8c039492807f



### After

https://github.com/user-attachments/assets/a8b21914-6cd8-4e37-932f-09621fd85a07


Fixes #2007 