### PR TITLE
fix(studies): status filter dropdown not opening on label click

### DIFF
--- a/src/features/navigation/components/navbarSections/StudiesSection.vue
+++ b/src/features/navigation/components/navbarSections/StudiesSection.vue
@@ -89,9 +89,11 @@
 
           <!-- ⚙️ Status -->
           <v-col cols="12" sm="6" md="3">
-            <label class="filter-label" style="cursor:pointer">
+            <label class="filter-label" for="status-select" style="cursor:pointer">
               {{ $t('pages.studies.statusLabel') }}
             </label>
+
+            <!-- status-select id ties this to the label above for accessibility -->
             <v-select
               v-model="selectedStatusFilter"
               :items="statusOptions"
@@ -103,7 +105,6 @@
               variant="outlined"
               hide-details
               class="status-select"
-              role="listbox"
               :aria-label="$t('pages.studies.statusLabel')"
             />
           </v-col>
@@ -409,7 +410,7 @@ const goTo = (test) => {
   min-height: 36px;
 }
 
-.status-select :deep(.v-chip){
+.status-select :deep(.v-chip) {
   pointer-events: none;
 }
 

--- a/src/features/navigation/components/navbarSections/StudiesSection.vue
+++ b/src/features/navigation/components/navbarSections/StudiesSection.vue
@@ -89,9 +89,9 @@
 
           <!-- ⚙️ Status -->
           <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">
+            <label class="filter-label" style="cursor:pointer">
               {{ $t('pages.studies.statusLabel') }}
-            </div>
+            </label>
             <v-select
               v-model="selectedStatusFilter"
               :items="statusOptions"
@@ -102,6 +102,9 @@
               density="compact"
               variant="outlined"
               hide-details
+              class="status-select"
+              role="listbox"
+              :aria-label="$t('pages.studies.statusLabel')"
             />
           </v-col>
 
@@ -405,4 +408,9 @@ const goTo = (test) => {
 .filter-field :deep(.v-field__input) {
   min-height: 36px;
 }
+
+.status-select :deep(.v-chip){
+  pointer-events: none;
+}
+
 </style>

--- a/src/features/navigation/components/navbarSections/StudiesSection.vue
+++ b/src/features/navigation/components/navbarSections/StudiesSection.vue
@@ -95,6 +95,7 @@
 
             <!-- status-select id ties this to the label above for accessibility -->
             <v-select
+              id="status-select"
               v-model="selectedStatusFilter"
               :items="statusOptions"
               item-title="text"


### PR DESCRIPTION
## Problem
On the Studies page, clicking directly on the "All Statuses" chip text inside the Status filter does not open the dropdown. Clicking elsewhere within the input field works as expected

Root Cause
The v-chip rendered inside the v-select component captures pointer events, preventing click propagation to the dropdown trigger. This results in inconsistent interaction depending on the click target.

## Fix
Applied pointer-events: none to the chip element via scoped CSS, allowing click events to pass through to the parent v-select trigger.

Additionally:
Improved semantic structure of the filter label
Added accessibility attributes (aria-label) to enhance screen reader support

## Changes
- Prevented click interception by applying pointer-events: none to .status-select :deep(.v-chip)
- Added aria-label to v-select for screen reader support
- Added id + for attributes to properly associate label with input

## Screenshots

### Before

https://github.com/user-attachments/assets/84a5f0a4-c5b8-43bc-9add-8c039492807f



### After

https://github.com/user-attachments/assets/a8b21914-6cd8-4e37-932f-09621fd85a07


Fixes #2007 