### PR TITLE
fix: retry uploadBytes on network failure to prevent audio data loss

### DIFF
--- a/src/ux/UserTest/components/AudioRecorder.vue
+++ b/src/ux/UserTest/components/AudioRecorder.vue
@@ -103,6 +103,34 @@ async function hasAudio() {
   }
 }
 
+/**
+ * Retry a Firebase uploadBytes call up to `maxAttempts` times.
+ * Uses exponential back-off: 1 s → 2 s → 4 s between retries.
+ * Throws the last error if all attempts are exhausted.
+ */
+async function uploadWithRetry(storageReference, blob, maxAttempts = 3) {
+  let lastError
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await uploadBytes(storageReference, blob)
+      return // success – exit immediately
+    } catch (err) {
+      lastError = err
+      console.warn(
+        `Upload attempt ${attempt}/${maxAttempts} failed:`,
+        err.message,
+      )
+      if (attempt < maxAttempts) {
+        // wait 1 s × 2^(attempt-1): 1 s, 2 s, 4 s …
+        await new Promise((resolve) =>
+          setTimeout(resolve, 1000 * Math.pow(2, attempt - 1)),
+        )
+      }
+    }
+  }
+  throw lastError
+}
+
 // Methods
 const startAudioRecording = async () => {
   try {
@@ -141,39 +169,47 @@ const startAudioRecording = async () => {
       const audioBlob = new Blob(recordedChunks.value.local, {
         type: 'audio/webm',
       })
-      const storage = getStorage()
-      const correctTaskIndex = recordingTaskIndex.value
-      const storageReference = storageRef(
-        storage,
-        `tests/${props.testId}/${currentUserTestAnswer.value.userDocId}/task_${correctTaskIndex}_evaluator/${Date.now()}.webm`,
-      )
-      await uploadBytes(storageReference, audioBlob)
+      try {
+        const storage = getStorage()
+        const correctTaskIndex = recordingTaskIndex.value
+        const storageReference = storageRef(
+          storage,
+          `tests/${props.testId}/${currentUserTestAnswer.value.userDocId}/task_${correctTaskIndex}_evaluator/${Date.now()}.webm`,
+        )
 
-      recordedAudio.value = await getDownloadURL(storageReference)
+        // Retry up to 3 times on transient network errors
+        await uploadWithRetry(storageReference, audioBlob)
 
-      await store.dispatch('updateTaskMediaUrl', {
-        taskIndex: correctTaskIndex,
-        mediaType: MEDIA_FIELD_MAP.audio,
-        url: recordedAudio.value,
-        size: audioBlob.size,
-      })
+        recordedAudio.value = await getDownloadURL(storageReference)
 
-      if (audioStream.value) {
-        audioStream.value.getTracks().forEach((track) => track.stop())
-        audioStream.value = null
+        await store.dispatch('updateTaskMediaUrl', {
+          taskIndex: correctTaskIndex,
+          mediaType: MEDIA_FIELD_MAP.audio,
+          url: recordedAudio.value,
+          size: audioBlob.size,
+        })
+
+        if (audioStream.value) {
+          audioStream.value.getTracks().forEach((track) => track.stop())
+          audioStream.value = null
+        }
+
+        emit('recordingStarted', false)
+        // Size
+        if (
+          currentUserTestAnswer.value.tasks &&
+          currentUserTestAnswer.value.tasks[recordingTaskIndex.value]
+        ) {
+          currentUserTestAnswer.value.tasks[
+            recordingTaskIndex.value
+          ].audioSize = new Blob(recordedChunks.value.local).size
+        }
+      } catch (err) {
+        console.error('Audio upload failed after retries:', err)
+      } finally {
+        emit('stopShowLoading')
+        recordingAudio.value = false
       }
-
-      emit('recordingStarted', false)
-      // Size
-      if (
-        currentUserTestAnswer.value.tasks &&
-        currentUserTestAnswer.value.tasks[recordingTaskIndex.value]
-      ) {
-        currentUserTestAnswer.value.tasks[recordingTaskIndex.value].audioSize =
-          new Blob(recordedChunks.value.local).size
-      }
-      emit('stopShowLoading')
-      recordingAudio.value = false
     }
 
     mediaRecorder.value.local.start()
@@ -198,21 +234,28 @@ const startAudioRecording = async () => {
           const blob = new Blob(recordedChunks.value.remote, {
             type: 'audio/webm',
           })
-          const storage = getStorage()
-          const correctTaskIndex = recordingTaskIndex.value
-          const storageReference = storageRef(
-            storage,
-            `tests/${props.testId}/${currentUserTestAnswer.value.userDocId}/task_${correctTaskIndex}_moderator/${Date.now()}.webm`,
-          )
-          await uploadBytes(storageReference, blob)
-          const downloadURL = await getDownloadURL(storageReference)
+          try {
+            const storage = getStorage()
+            const correctTaskIndex = recordingTaskIndex.value
+            const storageReference = storageRef(
+              storage,
+              `tests/${props.testId}/${currentUserTestAnswer.value.userDocId}/task_${correctTaskIndex}_moderator/${Date.now()}.webm`,
+            )
 
-          await store.dispatch('updateTaskMediaUrl', {
-            taskIndex: correctTaskIndex,
-            mediaType: MEDIA_FIELD_MAP.moderator,
-            url: downloadURL,
-            size: blob.size,
-          })
+            // Retry up to 3 times on transient network errors
+            await uploadWithRetry(storageReference, blob)
+
+            const downloadURL = await getDownloadURL(storageReference)
+
+            await store.dispatch('updateTaskMediaUrl', {
+              taskIndex: correctTaskIndex,
+              mediaType: MEDIA_FIELD_MAP.moderator,
+              url: downloadURL,
+              size: blob.size,
+            })
+          } catch (err) {
+            console.error('Remote audio upload failed after retries:', err)
+          }
         }
 
         mediaRecorder.value.remote.start()


### PR DESCRIPTION
## Problem
When `uploadBytes` failed due to a transient network issue, the error was silently caught (or uncaught), and the recorded audio `Blob` — stored only in local component memory — was permanently lost. No retry was attempted and no feedback was given to the user.

## Root Cause
Both `onstop` handlers in `AudioRecorder.vue` called `await uploadBytes(...)` with no error handling or retry logic. A single network blip caused an unrecoverable failure.

## Fix
Added a minimal `uploadWithRetry` helper that wraps `uploadBytes` with **exponential back-off retry** (up to 3 attempts):

| Attempt | Delay before next retry |
|---------|------------------------|
| 1 → 2   | 1 second               |
| 2 → 3   | 2 seconds              |
| 3 (fail)| throws error           |

Both the **local (evaluator)** and **remote (moderator)** upload handlers are now wrapped in `try/catch/finally` blocks:
- `try` — runs upload + store dispatch only on success
- `catch` — logs the final error clearly if all retries fail
- `finally` — always dismisses the loading spinner so the UI is never stuck

## Files Changed
- `src/ux/UserTest/components/AudioRecorder.vue`

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- Record audio and stop normally → upload succeeds on first attempt ✅
- Simulate network drop during upload → retries up to 3 times, logs error if all fail ✅
- Loading spinner is always dismissed regardless of upload outcome ✅

## Related Issue
Closes #1388 
