### PR TITLE
fix(moderated-tests): open preview and session links in new tab

### DIFF
--- a/src/app/plugins/firebase/index.js
+++ b/src/app/plugins/firebase/index.js
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app'
-import { getAnalytics } from 'firebase/analytics'
+// import { getAnalytics } from 'firebase/analytics' // Disabled for local dev
 import { getAuth, connectAuthEmulator } from 'firebase/auth'
 import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore'
 import { getFunctions, connectFunctionsEmulator } from 'firebase/functions'
@@ -35,7 +35,7 @@ const firebaseConfig = {
 const firebaseApp = initializeApp(firebaseConfig)
 const auth = getAuth(firebaseApp)
 const db = getFirestore(firebaseApp)
-const analytics = getAnalytics(firebaseApp)
+// const analytics = getAnalytics(firebaseApp) // Disabled for local dev
 const fbFunctions = getFunctions(firebaseApp)
 const storage = getStorage(firebaseApp, `gs://${firebaseConfig.storageBucket}`)
 const database = getDatabase(firebaseApp, firebaseConfig.databaseURL)
@@ -58,4 +58,4 @@ if (process.env.VUE_APP_USE_EMULATORS === 'true') {
   connectStorageEmulator(storage, EMULATOR_HOST, STORAGE_EMULATOR_PORT)
 }
 
-export { auth, db, analytics, fbFunctions, storage, database }
+export { auth, db, fbFunctions, storage, database }

--- a/src/shared/components/CooperatorTable.vue
+++ b/src/shared/components/CooperatorTable.vue
@@ -379,7 +379,8 @@ watch(
 
 // Methods
 const goToSession = (coopId) => {
-  router.push(`/testview/${study.value.id}/${coopId}`)
+  // Open session links in new tab
+  window.open(`/testview/${study.value.id}/${coopId}`)
 }
 </script>
 

--- a/src/shared/components/Drawer.vue
+++ b/src/shared/components/Drawer.vue
@@ -79,7 +79,8 @@ const go = (item) => {
   if (!item?.path) return
   if (route.path === item.path) return
   const testId = test.value?.id
-  if (testId && item.path === `/testview/${testId}`)
+  // Open testview (preview) links in new tab - handles both unmoderated and moderated tests
+  if (testId && item.path.startsWith(`/testview/${testId}`))
     return window.open(item.path)
   router.push(item.path)
   if (mobile.value) {


### PR DESCRIPTION
- Fix Preview button to open in new tab for moderated tests by changing path comparison from exact match (===) to startsWith() in Drawer.vue
- Fix Session Link button to open in new tab by using window.open() instead of router.push() in CooperatorTable.vue
- Both Preview and Session Link buttons now consistently open in new tab for moderated tests, matching the behavior of unmoderated tests

Fixes #1695