### PR TITLE
password validation errors shown before user interaction

### DIFF
--- a/src/features/auth/components/ChangePasswordForm.vue
+++ b/src/features/auth/components/ChangePasswordForm.vue
@@ -1,16 +1,13 @@
 <template>
   <v-card class="rounded-xl pa-6" elevation="2">
     <v-card-title class="text-h6 font-weight-bold mb-4">
-      <v-icon start color="primary"> mdi-lock </v-icon>
+      <v-icon start color="primary">
+        mdi-lock
+      </v-icon>
       {{ $t('profile.changePassword') }}
     </v-card-title>
     <v-card-text>
-      <v-alert
-        v-if="newPassword.length > 0"
-        type="warning"
-        variant="outlined"
-        class="mb-6"
-      >
+      <v-alert v-if="newPassword.length > 0" type="warning" variant="outlined" class="mb-6">
         <div class="text-subtitle-1 font-weight-medium mb-2">
           {{ $t('profile.passwordRequirements') }}
         </div>
@@ -19,11 +16,7 @@
         </div>
         <div>
           <div class="d-flex align-center mb-2">
-            <v-icon
-              size="small"
-              class="mr-2"
-              :color="newPassword.length >= 8 ? 'success' : 'grey-darken-1'"
-            >
+            <v-icon size="small" class="mr-2" :color="newPassword.length >= 8 ? 'success' : 'grey-darken-1'">
               {{
                 newPassword.length >= 8
                   ? 'mdi-check-circle'
@@ -33,11 +26,7 @@
             <span>{{ $t('profile.passwordMinLength') }}</span>
           </div>
           <div class="d-flex align-center mb-2">
-            <v-icon
-              size="small"
-              class="mr-2"
-              :color="/[A-Z]/.test(newPassword) ? 'success' : 'grey-darken-1'"
-            >
+            <v-icon size="small" class="mr-2" :color="/[A-Z]/.test(newPassword) ? 'success' : 'grey-darken-1'">
               {{
                 /[A-Z]/.test(newPassword)
                   ? 'mdi-check-circle'
@@ -56,73 +45,39 @@
       </v-alert>
 
       <v-form ref="formRef" v-model="valid">
-        <v-alert
-          v-if="isGoogleUser"
-          type="info"
-          variant="outlined"
-          class="mb-4"
-        >
+        <v-alert v-if="isGoogleUser" type="info" variant="outlined" class="mb-4">
           {{ $t('profile.googleUserPasswordInfo') }}
         </v-alert>
         <v-row dense>
           <v-col v-if="!isGoogleUser" cols="12">
             <v-text-field
-              v-model="currentPassword"
-              :rules="currentPasswordRules"
-              :label="$t('profile.currentPassword')"
-              :type="showCurrentPassword ? 'text' : 'password'"
-              variant="outlined"
-              density="compact"
-              prepend-inner-icon="mdi-lock-check"
-              :append-inner-icon="
-                showCurrentPassword ? 'mdi-eye' : 'mdi-eye-off'
-              "
-              class="input-field-transition"
-              @click:append-inner="toggleCurrentPasswordVisibility()"
-            />
+v-model="currentPassword" :rules="currentPasswordRules" :label="$t('profile.currentPassword')"
+              :type="showCurrentPassword ? 'text' : 'password'" variant="outlined" density="compact"
+              prepend-inner-icon="mdi-lock-check" :append-inner-icon="showCurrentPassword ? 'mdi-eye' : 'mdi-eye-off'"
+              class="input-field-transition" @click:append-inner="toggleCurrentPasswordVisibility()" />
           </v-col>
           <v-col cols="12" sm="6">
             <v-text-field
-              v-model="newPassword"
-              :rules="passwordRules"
-              :label="$t('profile.newPassword')"
-              :type="showPassword ? 'text' : 'password'"
-              variant="outlined"
-              density="compact"
-              prepend-inner-icon="mdi-lock"
-              :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-              class="input-field-transition"
-              @click:append-inner="togglePasswordVisibility()"
-              @input="passwordTouched = true"
-            />
+v-model="newPassword" :rules="passwordRules" :label="$t('profile.newPassword')"
+              :type="showPassword ? 'text' : 'password'" variant="outlined" density="compact"
+              prepend-inner-icon="mdi-lock" :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+              class="input-field-transition" @click:append-inner="togglePasswordVisibility()" @input="passwordTouched = true" />
           </v-col>
           <v-col cols="12" sm="6">
             <v-text-field
-              v-model="confirmPassword"
-              :rules="confirmPasswordRules"
-              :label="$t('profile.confirmNewPassword')"
-              :type="showConfirmPassword ? 'text' : 'password'"
-              variant="outlined"
-              density="compact"
-              prepend-inner-icon="mdi-lock-check"
-              :append-inner-icon="
-                showConfirmPassword ? 'mdi-eye' : 'mdi-eye-off'
-              "
-              class="input-field-transition"
-              @click:append-inner="toggleConfirmPasswordVisibility()"
-              @input="confirmTouched = true"
-            />
+v-model="confirmPassword" :rules="confirmPasswordRules"
+              :label="$t('profile.confirmNewPassword')" :type="showConfirmPassword ? 'text' : 'password'"
+              variant="outlined" density="compact" prepend-inner-icon="mdi-lock-check"
+              :append-inner-icon="showConfirmPassword ? 'mdi-eye' : 'mdi-eye-off'" class="input-field-transition"
+              @click:append-inner="toggleConfirmPasswordVisibility()" @input="confirmTouched = true" />
           </v-col>
         </v-row>
         <v-btn
-          :disabled="!valid || isChanging"
-          :loading="isChanging"
-          color="primary"
-          variant="flat"
-          class="mt-4 text-capitalize"
-          @click="handleChangePassword"
-        >
-          <v-icon start> mdi-key </v-icon>
+:disabled="!valid || isChanging" :loading="isChanging" color="primary" variant="flat"
+          class="mt-4 text-capitalize" @click="handleChangePassword">
+          <v-icon start>
+            mdi-key
+          </v-icon>
           {{ $t('profile.changePassword') }}
         </v-btn>
       </v-form>
@@ -131,11 +86,11 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { useChangePassword } from '../composables/useChangePassword'
+import { ref } from 'vue';
+import { useChangePassword } from '../composables/useChangePassword';
 
-const formRef = ref(null)
-const isChanging = ref(false)
+const formRef = ref(null);
+const isChanging = ref(false);
 
 const {
   currentPassword,
@@ -158,19 +113,19 @@ const {
   toggleCurrentPasswordVisibility,
   togglePasswordVisibility,
   toggleConfirmPasswordVisibility,
-} = useChangePassword()
+} = useChangePassword();
 
 const handleChangePassword = async () => {
-  const { valid } = await formRef.value.validate()
-  if (!valid) return
-
-  isChanging.value = true
-  const success = await changePassword()
-  isChanging.value = false
-
+  const { valid } = await formRef.value.validate();
+  if (!valid) return;
+  
+  isChanging.value = true;
+  const success = await changePassword();
+  isChanging.value = false;
+  
   if (success && formRef.value) {
-    formRef.value.reset()
-    resetForm()
+    formRef.value.reset();
+    resetForm();
   }
-}
+};
 </script>

--- a/src/features/auth/components/ChangePasswordForm.vue
+++ b/src/features/auth/components/ChangePasswordForm.vue
@@ -1,13 +1,16 @@
 <template>
   <v-card class="rounded-xl pa-6" elevation="2">
     <v-card-title class="text-h6 font-weight-bold mb-4">
-      <v-icon start color="primary">
-        mdi-lock
-      </v-icon>
+      <v-icon start color="primary"> mdi-lock </v-icon>
       {{ $t('profile.changePassword') }}
     </v-card-title>
     <v-card-text>
-      <v-alert type="warning" variant="outlined" class="mb-6">
+      <v-alert
+        v-if="newPassword.length > 0"
+        type="warning"
+        variant="outlined"
+        class="mb-6"
+      >
         <div class="text-subtitle-1 font-weight-medium mb-2">
           {{ $t('profile.passwordRequirements') }}
         </div>
@@ -16,7 +19,11 @@
         </div>
         <div>
           <div class="d-flex align-center mb-2">
-            <v-icon size="small" class="mr-2" :color="newPassword.length >= 8 ? 'success' : 'grey-darken-1'">
+            <v-icon
+              size="small"
+              class="mr-2"
+              :color="newPassword.length >= 8 ? 'success' : 'grey-darken-1'"
+            >
               {{
                 newPassword.length >= 8
                   ? 'mdi-check-circle'
@@ -26,7 +33,11 @@
             <span>{{ $t('profile.passwordMinLength') }}</span>
           </div>
           <div class="d-flex align-center mb-2">
-            <v-icon size="small" class="mr-2" :color="/[A-Z]/.test(newPassword) ? 'success' : 'grey-darken-1'">
+            <v-icon
+              size="small"
+              class="mr-2"
+              :color="/[A-Z]/.test(newPassword) ? 'success' : 'grey-darken-1'"
+            >
               {{
                 /[A-Z]/.test(newPassword)
                   ? 'mdi-check-circle'
@@ -45,39 +56,73 @@
       </v-alert>
 
       <v-form ref="formRef" v-model="valid">
-        <v-alert v-if="isGoogleUser" type="info" variant="outlined" class="mb-4">
+        <v-alert
+          v-if="isGoogleUser"
+          type="info"
+          variant="outlined"
+          class="mb-4"
+        >
           {{ $t('profile.googleUserPasswordInfo') }}
         </v-alert>
         <v-row dense>
           <v-col v-if="!isGoogleUser" cols="12">
             <v-text-field
-v-model="currentPassword" :rules="currentPasswordRules" :label="$t('profile.currentPassword')"
-              :type="showCurrentPassword ? 'text' : 'password'" variant="outlined" density="compact"
-              prepend-inner-icon="mdi-lock-check" :append-inner-icon="showCurrentPassword ? 'mdi-eye' : 'mdi-eye-off'"
-              class="input-field-transition" @click:append-inner="toggleCurrentPasswordVisibility()" />
+              v-model="currentPassword"
+              :rules="currentPasswordRules"
+              :label="$t('profile.currentPassword')"
+              :type="showCurrentPassword ? 'text' : 'password'"
+              variant="outlined"
+              density="compact"
+              prepend-inner-icon="mdi-lock-check"
+              :append-inner-icon="
+                showCurrentPassword ? 'mdi-eye' : 'mdi-eye-off'
+              "
+              class="input-field-transition"
+              @click:append-inner="toggleCurrentPasswordVisibility()"
+            />
           </v-col>
           <v-col cols="12" sm="6">
             <v-text-field
-v-model="newPassword" :rules="passwordRules" :label="$t('profile.newPassword')"
-              :type="showPassword ? 'text' : 'password'" variant="outlined" density="compact"
-              prepend-inner-icon="mdi-lock" :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-              class="input-field-transition" @click:append-inner="togglePasswordVisibility()" />
+              v-model="newPassword"
+              :rules="passwordRules"
+              :label="$t('profile.newPassword')"
+              :type="showPassword ? 'text' : 'password'"
+              variant="outlined"
+              density="compact"
+              prepend-inner-icon="mdi-lock"
+              :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+              class="input-field-transition"
+              @click:append-inner="togglePasswordVisibility()"
+              @input="passwordTouched = true"
+            />
           </v-col>
           <v-col cols="12" sm="6">
             <v-text-field
-v-model="confirmPassword" :rules="confirmPasswordRules"
-              :label="$t('profile.confirmNewPassword')" :type="showConfirmPassword ? 'text' : 'password'"
-              variant="outlined" density="compact" prepend-inner-icon="mdi-lock-check"
-              :append-inner-icon="showConfirmPassword ? 'mdi-eye' : 'mdi-eye-off'" class="input-field-transition"
-              @click:append-inner="toggleConfirmPasswordVisibility()" />
+              v-model="confirmPassword"
+              :rules="confirmPasswordRules"
+              :label="$t('profile.confirmNewPassword')"
+              :type="showConfirmPassword ? 'text' : 'password'"
+              variant="outlined"
+              density="compact"
+              prepend-inner-icon="mdi-lock-check"
+              :append-inner-icon="
+                showConfirmPassword ? 'mdi-eye' : 'mdi-eye-off'
+              "
+              class="input-field-transition"
+              @click:append-inner="toggleConfirmPasswordVisibility()"
+              @input="confirmTouched = true"
+            />
           </v-col>
         </v-row>
         <v-btn
-:disabled="!valid || isChanging" :loading="isChanging" color="primary" variant="flat"
-          class="mt-4 text-capitalize" @click="handleChangePassword">
-          <v-icon start>
-            mdi-key
-          </v-icon>
+          :disabled="!valid || isChanging"
+          :loading="isChanging"
+          color="primary"
+          variant="flat"
+          class="mt-4 text-capitalize"
+          @click="handleChangePassword"
+        >
+          <v-icon start> mdi-key </v-icon>
           {{ $t('profile.changePassword') }}
         </v-btn>
       </v-form>
@@ -86,11 +131,11 @@ v-model="confirmPassword" :rules="confirmPasswordRules"
 </template>
 
 <script setup>
-import { ref } from 'vue';
-import { useChangePassword } from '../composables/useChangePassword';
+import { ref } from 'vue'
+import { useChangePassword } from '../composables/useChangePassword'
 
-const formRef = ref(null);
-const isChanging = ref(false);
+const formRef = ref(null)
+const isChanging = ref(false)
 
 const {
   currentPassword,
@@ -100,6 +145,8 @@ const {
   showPassword,
   showConfirmPassword,
   valid,
+  passwordTouched,
+  confirmTouched,
   isGoogleUser,
   currentPasswordRules,
   passwordRules,
@@ -111,19 +158,19 @@ const {
   toggleCurrentPasswordVisibility,
   togglePasswordVisibility,
   toggleConfirmPasswordVisibility,
-} = useChangePassword();
+} = useChangePassword()
 
 const handleChangePassword = async () => {
-  const { valid } = await formRef.value.validate();
-  if (!valid) return;
-  
-  isChanging.value = true;
-  const success = await changePassword();
-  isChanging.value = false;
-  
+  const { valid } = await formRef.value.validate()
+  if (!valid) return
+
+  isChanging.value = true
+  const success = await changePassword()
+  isChanging.value = false
+
   if (success && formRef.value) {
-    formRef.value.reset();
-    resetForm();
+    formRef.value.reset()
+    resetForm()
   }
-};
+}
 </script>

--- a/src/features/auth/composables/useChangePassword.js
+++ b/src/features/auth/composables/useChangePassword.js
@@ -18,6 +18,8 @@ export function useChangePassword() {
   const showPassword = ref(false)
   const showConfirmPassword = ref(false)
   const valid = ref(false)
+  const passwordTouched = ref(false)
+  const confirmTouched = ref(false)
 
   const isGoogleUser = computed(() => {
     const auth = getAuth()
@@ -38,15 +40,33 @@ export function useChangePassword() {
   ])
 
   const passwordRules = computed(() => [
-    (v) => !!v || i18n.global.t('profile.passwordRequired'),
-    (v) => (v && v.length >= 8) || i18n.global.t('profile.passwordMinLength'),
-    (v) => (v && /[A-Z]/.test(v)) || i18n.global.t('profile.passwordUppercase'),
-    (v) => (v && hasSpecialChar(v)) || i18n.global.t('profile.passwordSymbol'),
+    (v) =>
+      !passwordTouched.value ||
+      !!v ||
+      i18n.global.t('profile.passwordRequired'),
+    (v) =>
+      !passwordTouched.value ||
+      v?.length >= 8 ||
+      i18n.global.t('profile.passwordMinLength'),
+    (v) =>
+      !passwordTouched.value ||
+      (v && /[A-Z]/.test(v)) ||
+      i18n.global.t('profile.passwordUppercase'),
+    (v) =>
+      !passwordTouched.value ||
+      (v && hasSpecialChar(v)) ||
+      i18n.global.t('profile.passwordSymbol'),
   ])
 
   const confirmPasswordRules = computed(() => [
-    (v) => !!v || i18n.global.t('profile.confirmPasswordRequired'),
-    (v) => v === newPassword.value || i18n.global.t('profile.passwordsMatch'),
+    (v) =>
+      !confirmTouched.value ||
+      !!v ||
+      i18n.global.t('profile.confirmPasswordRequired'),
+    (v) =>
+      !confirmTouched.value ||
+      v === newPassword.value ||
+      i18n.global.t('profile.passwordsMatch'),
   ])
 
   const specialCharColor = computed(() =>
@@ -67,6 +87,8 @@ export function useChangePassword() {
     showPassword.value = false
     showConfirmPassword.value = false
     valid.value = false
+    passwordTouched.value = false
+    confirmTouched.value = false
   }
 
   const changePassword = async () => {
@@ -130,6 +152,8 @@ export function useChangePassword() {
     showPassword,
     showConfirmPassword,
     valid,
+    passwordTouched,
+    confirmTouched,
     isGoogleUser,
     currentPasswordRules,
     passwordRules,


### PR DESCRIPTION
## Problem
On the Profile page, the Change Password form shows red validation 
errors and a warning box immediately on page load before the user 
types anything.

## Root Cause
Vuetify runs validation rules on mount. Empty fields cause `!!v` 
to return `false`, triggering errors instantly.

## Fix
- Added `passwordTouched` and `confirmTouched` refs in `useChangePassword.js`
- Rules now skip validation until user interacts with the field
- Warning box hidden until user starts typing via `v-if="newPassword.length > 0"`

## Before vs After
| | Before | After |
|---|---|---|
| Page load | ❌ Red errors visible | Clean form |
| Typing |  Already showing errors |  Validates in real time |
| Warning box |  Always visible |  Shows only when typing |

## Steps to Reproduce
1. Log in → go to Profile page
2. Scroll to Change Password section
3. Observe red errors without touching anything

## Related Issue
Fixes #2018