### PR TITLE
Lazy-load users on dialog open and drop redundant re-fetch on role update

### DIFF
--- a/src/features/super/store/User.js
+++ b/src/features/super/store/User.js
@@ -31,6 +31,10 @@ export default {
     REMOVE_USER(state, userId) {
       state.users = state.users.filter((user) => user.id !== userId)
     },
+    UPDATE_USER_LEVEL(state, { uid, accessLevel }) {
+      const user = state.users?.find((u) => u.id === uid)
+      if (user) user.accessLevel = accessLevel
+    },
   },
 
   actions: {
@@ -50,8 +54,10 @@ export default {
           data.uid,
           data.customClaims.accessLevel,
         )
-        const updatedUsers = await userController.readAll()
-        commit('SET_USERS', updatedUsers)
+        commit('UPDATE_USER_LEVEL', {
+          uid: data.uid,
+          accessLevel: data.customClaims.accessLevel,
+        })
       } catch (e) {
         return e
       } finally {

--- a/src/shared/views/CooperatorsView.vue
+++ b/src/shared/views/CooperatorsView.vue
@@ -612,6 +612,7 @@ const executeInvitationCancellation = async (guest) => {
 }
 
 const openDialog = async () => {
+  if (!store.state.Users?.users) store.dispatch('getAllUsers')
   if (slots.dialog) drawerOpen.value = true
   else showInviteDialog.value = true
 }
@@ -623,8 +624,6 @@ watch(loading, (newVal) => {
 })
 
 onMounted(async () => {
-  store.dispatch('getAllUsers')
-
   const testId = props.id || route.params.id
 
   if (testId) {


### PR DESCRIPTION
## Summary

- **CooperatorsView** was dispatching `getAllUsers` on every mount — fetching the entire users Firestore collection even if the user never opened the invite dialog. Moved the fetch into `openDialog()` with a guard so it only fires once, on first use.
- **updateLevel** in the User store was calling `userController.readAll()` after every role change to refresh state — a full collection re-fetch just to update one field. Replaced with a local `UPDATE_USER_LEVEL` mutation.

---

## Root Cause

`FirebaseFirestoreRepository.readAll()` has no `.where()` or `limit()` , it fetches an entire collection. Two callers were triggering this unnecessarily:

1. `CooperatorsView.onMounted` — fired for every study owner opening cooperators management, across all study types (UserTest, CardSorting, Heuristic, Accessibility)
2. `User.js updateLevel` action — fired after every super-admin role change

---

## Changes

### `src/shared/views/CooperatorsView.vue`
- Removed `store.dispatch('getAllUsers')` from `onMounted`
- Added it to `openDialog()` behind a `!store.state.Users?.users` guard — fetches once on first dialog open, skips on subsequent opens
- Works correctly for both dialog paths:
  - `InviteDialog` (non-moderated)
  - `CreateInviteDialog` via `#dialog` slot (moderated)

### `src/features/super/store/User.js`
- Added `UPDATE_USER_LEVEL` mutation that finds the user by ID in existing state and updates `accessLevel` in-place
- `updateLevel` action now commits that mutation instead of calling `readAll()` again

---

## Test Plan

- Open any study → **Cooperators tab** → verify no users collection Firestore read fires on page load (check DevTools Network)
- Click **"Send Invitation"** → verify users collection is fetched exactly once
- Close and reopen the invite dialog → verify no second Firestore read fires
- Open a moderated **UserTest** → Cooperators tab → click **"Send Invitation"** → verify `CreateInviteDialog` populates with users correctly
- As super admin, change a user's access level → verify the table updates correctly without a page reload
- Change two users' access levels back-to-back → verify both update correctly in the table

---

## Screenshots
- Before (develop) — users: Array[1] populated on page load
<img width="1470" height="956" alt="Screenshot 2026-04-04 at 7 23 40 PM" src="https://github.com/user-attachments/assets/99ca0e2a-1754-4719-8776-a5a91c992c25" />

- After (fix branch) — users: null on page load, no fetch
<img width="1470" height="956" alt="Screenshot 2026-04-04 at 7 26 28 PM" src="https://github.com/user-attachments/assets/07086754-7f15-4fd0-b66b-65da4d264558" />

-  After (fix branch) — users: Array[1] only after clicking Send Invitation
<img width="1470" height="956" alt="Screenshot 2026-04-04 at 7 26 08 PM" src="https://github.com/user-attachments/assets/ef0156cd-c82c-4adb-a03e-0602d60e5c09" />

---

Fixes : #2022 