### PR TITLE
feat(a11y): Save accessibility scan results to the database and fix broken report display ( automatic_test )

### DIFF
--- a/src/ux/accessibility/composables/useAccessibilityAccess.js
+++ b/src/ux/accessibility/composables/useAccessibilityAccess.js
@@ -9,10 +9,31 @@ export function useAccessibilityAccess() {
   const accessLevel = ref(null)
   const isLoading = ref(true)
 
-  /** Fetches study data from the store by testId. */
   const fetchStudyData = async (testId) => {
-    await store.dispatch('getStudy', { id: testId })
-    return store.getters.test ?? null
+    try {
+      await store.dispatch('getStudy', { id: testId })
+    } catch {
+      try {
+        await store.dispatch('getTest', { id: testId })
+      } catch {
+        const studyModule = store._modules.root._children.Study
+        if (studyModule) {
+          await store.dispatch('Study/getStudy', { id: testId })
+        } else {
+          await store.dispatch('getStudy', { id: testId })
+        }
+      }
+    }
+
+    if (store.getters.test) {
+      return store.getters.test
+    } else if (store.state.Study?.Test) {
+      return store.state.Study.Test
+    } else if (store.state.Test) {
+      return store.state.Test
+    } else {
+      return null
+    }
   }
 
   const determineUserRole = (currentUser, studyData) => {

--- a/src/ux/accessibility/composables/useAccessibilityAccess.js
+++ b/src/ux/accessibility/composables/useAccessibilityAccess.js
@@ -9,31 +9,10 @@ export function useAccessibilityAccess() {
   const accessLevel = ref(null)
   const isLoading = ref(true)
 
+  /** Fetches study data from the store by testId. */
   const fetchStudyData = async (testId) => {
-    try {
-      await store.dispatch('getStudy', { id: testId })
-    } catch {
-      try {
-        await store.dispatch('getTest', { id: testId })
-      } catch {
-        const studyModule = store._modules.root._children.Study
-        if (studyModule) {
-          await store.dispatch('Study/getStudy', { id: testId })
-        } else {
-          await store.dispatch('getStudy', { id: testId })
-        }
-      }
-    }
-
-    if (store.getters.test) {
-      return store.getters.test
-    } else if (store.state.Study?.Test) {
-      return store.state.Study.Test
-    } else if (store.state.Test) {
-      return store.state.Test
-    } else {
-      return null
-    }
+    await store.dispatch('getStudy', { id: testId })
+    return store.getters.test ?? null
   }
 
   const determineUserRole = (currentUser, studyData) => {

--- a/src/ux/accessibility/controllers/AccessibilityReportController.js
+++ b/src/ux/accessibility/controllers/AccessibilityReportController.js
@@ -1,17 +1,54 @@
 import { db } from '@/app/plugins/firebase'
-import { collection, query, where, getDocs } from 'firebase/firestore'
+import {
+  collection,
+  query,
+  where,
+  getDocs,
+  doc,
+  getDoc,
+  setDoc,
+} from 'firebase/firestore'
 
 /**
- * Fetches the accessibility report from Firestore by testId
+ * Fetches the accessibility report from Firestore by testId.
  * @param {string} testId
- * @returns {Promise<Object|null>} The report data or null if not found
+ * @returns {Promise<Object|null>}
  */
 export async function fetchReportByTestId(testId) {
   const q = query(collection(db, 'report'), where('ReportId', '==', testId))
   const snapshot = await getDocs(q)
   if (!snapshot.empty) {
-    // Return the first matching report (or map if you expect multiple)
     return { id: snapshot.docs[0].id, ...snapshot.docs[0].data() }
   }
   return null
+}
+
+/**
+ * Saves (or updates) the accessibility report in Firestore.
+ * `createdAt` is only stamped on the first write; `updatedAt` is always refreshed.
+ *
+ * @param {string} testId
+ * @param {Object} reportData
+ * @returns {Promise<{ success: boolean, id: string }>}
+ */
+export async function saveReportByTestId(testId, reportData) {
+  const docRef = doc(db, 'report', testId)
+
+  const existing = await getDoc(docRef)
+  const now = new Date().toISOString()
+
+  const report = {
+    ...reportData,
+    ReportId: testId,
+    updatedAt: now,
+    // Only stamp createdAt when the document does not yet exist.
+    ...(existing.exists() ? {} : { createdAt: now }),
+  }
+
+  try {
+    await setDoc(docRef, report, { merge: true })
+    return { success: true, id: docRef.id }
+  } catch (error) {
+    throw new Error('Failed to save accessibility report: ' + error.message)
+  }
 }

--- a/src/ux/accessibility/controllers/AccessibilityReportController.js
+++ b/src/ux/accessibility/controllers/AccessibilityReportController.js
@@ -10,14 +10,15 @@ import {
 } from 'firebase/firestore'
 
 /**
- * Fetches the accessibility report from Firestore by testId.
+ * Fetches the accessibility report from Firestore by testId
  * @param {string} testId
- * @returns {Promise<Object|null>}
+ * @returns {Promise<Object|null>} The report data or null if not found
  */
 export async function fetchReportByTestId(testId) {
   const q = query(collection(db, 'report'), where('ReportId', '==', testId))
   const snapshot = await getDocs(q)
   if (!snapshot.empty) {
+    // Return the first matching report (or map if you expect multiple)
     return { id: snapshot.docs[0].id, ...snapshot.docs[0].data() }
   }
   return null

--- a/src/ux/accessibility/store/Assessment.js
+++ b/src/ux/accessibility/store/Assessment.js
@@ -607,7 +607,7 @@ const actions = {
             // Include rule metadata for easier querying
             ruleTitle: findRuleTitle(ruleId, state.wcagData),
             principle: findPrincipleForRule(ruleId, state.wcagData),
-            guideline: findGuidelineForRule(ruleId, state.wcogData),
+            guideline: findGuidelineForRule(ruleId, state.wcagData),
           }),
         }),
       )
@@ -673,7 +673,7 @@ const actions = {
         ...(state.wcagData && {
           ruleTitle: findRuleTitle(ruleId, state.wcagData),
           principle: findPrincipleForRule(ruleId, state.wcagData),
-          guideline: findGuidelineForRule(ruleId, state.wcogData),
+          guideline: findGuidelineForRule(ruleId, state.wcagData),
         }),
       })
 

--- a/src/ux/accessibility/store/automaticReport.js
+++ b/src/ux/accessibility/store/automaticReport.js
@@ -1,5 +1,29 @@
 import { fetchReportByTestId } from '@/ux/accessibility/controllers/AccessibilityReportController'
 
+/**
+ * Converts a raw issue (axe-core or pa11y format) to the canonical UI shape:
+ * { type: 'error'|'warning'|'notice', code: string, ...rest }
+ */
+function normalizeIssue(raw) {
+  if (!raw) return raw
+  // Already in pa11y canonical format
+  if (raw.type && !raw.impact) return raw
+
+  // axe-core impact → canonical type
+  const impactToType = {
+    critical: 'error',
+    serious: 'warning',
+    moderate: 'warning',
+    minor: 'notice',
+  }
+
+  return {
+    ...raw,
+    type: impactToType[raw.impact] ?? 'notice',
+    code: raw.rule ?? raw.wcag ?? '',
+  }
+}
+
 const state = () => ({
   report: null,
 })
@@ -16,6 +40,11 @@ const actions = {
     try {
       const report = await fetchReportByTestId(testId)
       if (!report) throw new Error('No report found for this test')
+
+      if (Array.isArray(report.ReportIssues)) {
+        report.ReportIssues = report.ReportIssues.map(normalizeIssue)
+      }
+
       commit('SET_REPORT', report)
     } catch (error) {
       commit(

--- a/src/ux/accessibility/view/automatic/Answers.vue
+++ b/src/ux/accessibility/view/automatic/Answers.vue
@@ -183,6 +183,7 @@
                   v-if="report.ReportModifiedHtml"
                   ref="previewFrame"
                   class="preview-frame"
+                  title="Accessibility issue visual preview"
                   sandbox="allow-same-origin allow-scripts"
                   :srcdoc="markedUpHtml"
                   style="width: 100%; height: 480px; border: none"
@@ -349,7 +350,7 @@ export default {
           if (!issue?.selector) return
           try {
             doc.querySelectorAll(issue.selector).forEach((el) => {
-              el.setAttribute('data-issue-id', `issue-${idx}`)
+              el.dataset.issueId = `issue-${idx}`
               el.style.outline = `3px solid ${colors[issue.type] || colors.notice}`
               el.style.outlineOffset = '2px'
             })

--- a/src/ux/accessibility/view/automatic/Answers.vue
+++ b/src/ux/accessibility/view/automatic/Answers.vue
@@ -30,139 +30,99 @@
       {{ $t('Accessibility.noReportData') }}
     </v-alert>
 
-    <!-- Main Report -->
+    <!-- Main Report Content -->
     <template v-else>
-      <v-card class="mb-4 rounded-xl" elevation="2">
-        <v-card-text class="pa-4">
-          <div class="d-flex align-center flex-wrap gap-3 mb-3">
-            <v-icon color="primary" size="28">mdi-web-check</v-icon>
-            <div>
-              <div class="text-h6 font-weight-bold">
-                {{ $t('Accessibility.accessibilityReport') }}
-              </div>
-              <div class="text-caption text-grey">
-                {{ formatDate(report.ReportDateTime) }}
-              </div>
+      <!-- Header Summary -->
+      <v-card class="mb-4 rounded-xl" elevation="1">
+        <v-card-text class="pa-3">
+          <div class="d-flex align-center flex-wrap gap-2 mb-3">
+            <v-icon color="primary">mdi-web-check</v-icon>
+            <div class="text-subtitle-1 font-weight-bold">
+              Accessibility Audit
             </div>
             <v-spacer />
-            <v-chip
-              prepend-icon="mdi-link-variant"
-              variant="outlined"
-              color="primary"
-              class="text-caption"
-            >
-              {{ report.ReportUrl }}
-            </v-chip>
+            <v-chip size="small" variant="outlined" color="primary">{{
+              report.ReportUrl
+            }}</v-chip>
+            <v-chip size="small" variant="outlined" color="secondary">{{
+              formatDate(report.ReportDateTime)
+            }}</v-chip>
           </div>
-
-          <!-- Summary stat cards -->
           <v-row dense>
-            <v-col v-for="stat in summaryStats" :key="stat.label" cols="4">
+            <v-col v-for="s in summaryStats" :key="s.label" cols="4">
               <v-card
-                :color="stat.count > 0 ? stat.color : undefined"
-                :variant="stat.count > 0 ? 'tonal' : 'outlined'"
-                class="rounded-lg text-center pa-2"
+                :color="s.count > 0 ? s.color : 'grey-lighten-4'"
+                :variant="s.count > 0 ? 'tonal' : 'outlined'"
+                class="text-center py-1"
                 elevation="0"
               >
                 <div
-                  class="text-h5 font-weight-black"
-                  :class="stat.count > 0 ? `text-${stat.color}` : 'text-grey'"
+                  class="text-h6 font-weight-black"
+                  :class="s.count > 0 ? `text-${s.color}` : 'text-grey'"
                 >
-                  {{ stat.count }}
+                  {{ s.count }}
                 </div>
-                <div
-                  class="text-caption font-weight-medium"
-                  :class="stat.count > 0 ? `text-${stat.color}` : 'text-grey'"
-                >
-                  {{ stat.label }}
-                </div>
+                <div class="text-caption">{{ s.label }}</div>
               </v-card>
             </v-col>
           </v-row>
         </v-card-text>
       </v-card>
 
-      <v-card class="rounded-xl" elevation="2">
+      <!-- Interactive Tabs -->
+      <v-card class="rounded-xl overflow-hidden" elevation="1">
         <v-tabs
           v-model="currentTab"
           bg-color="primary"
           color="white"
           align-tabs="center"
-          density="comfortable"
+          density="compact"
         >
           <v-tab
-            v-for="(tab, idx) in tabs"
-            :key="idx"
-            :value="idx"
-            class="text-none text-caption font-weight-medium"
+            v-for="(t, i) in tabs"
+            :key="i"
+            :value="i"
+            class="text-none px-2 text-caption"
           >
-            <v-icon :icon="tabIcons[idx]" class="me-1" size="16" />
-            {{ tab }}
+            <v-icon :icon="tabIcons[i]" class="me-1" size="16" /> {{ t }}
           </v-tab>
         </v-tabs>
 
         <v-window v-model="currentTab">
-          <!-- ── Tab 0 : Summary & Issues ──────────────────────── -->
+          <!-- Tab 0: List View -->
           <v-window-item :value="0">
-            <v-container fluid class="pa-3">
-              <div
-                class="text-body-2 font-weight-medium mb-2 d-flex align-center gap-1"
-              >
-                <v-icon size="16" color="primary"
-                  >mdi-format-list-bulleted</v-icon
-                >
-                All Issues
-                <v-chip
-                  size="x-small"
-                  color="primary"
-                  variant="tonal"
-                  class="ms-1"
-                  >{{ report.ReportIssues.length }}</v-chip
-                >
-              </div>
-              <v-list lines="two" class="pa-0">
+            <v-container fluid class="pa-2">
+              <v-list lines="two" density="compact" class="pa-0">
                 <v-list-item
                   v-for="(issue, idx) in paginatedIssues"
-                  :key="(page - 1) * itemsPerPage + idx"
+                  :key="idx"
                   :active="selectedIssue === (page - 1) * itemsPerPage + idx"
-                  :active-color="getIssueColor(issue.type)"
-                  class="issue-row rounded-lg mb-2 pa-2"
+                  class="rounded-lg mb-1"
                   @click="selectedIssue = (page - 1) * itemsPerPage + idx"
                 >
                   <template #prepend>
                     <v-avatar
                       :color="getIssueColor(issue.type)"
-                      size="32"
-                      class="me-2 text-caption font-weight-bold text-white"
+                      size="24"
+                      class="me-2 text-white text-caption"
+                      >{{ (page - 1) * itemsPerPage + idx + 1 }}</v-avatar
                     >
-                      {{ (page - 1) * itemsPerPage + idx + 1 }}
-                    </v-avatar>
                   </template>
-
                   <v-list-item-title
-                    class="text-caption mb-1 d-flex align-center flex-wrap gap-1"
+                    class="text-caption d-flex align-center gap-1"
                   >
                     <v-chip
                       :color="getIssueColor(issue.type)"
                       size="x-small"
-                      variant="elevated"
-                      class="text-uppercase font-weight-bold"
+                      label
                       >{{ issue.type }}</v-chip
                     >
                     <v-chip
                       v-if="issue.code"
+                      size="x-small"
                       variant="tonal"
                       color="grey"
-                      size="x-small"
-                      class="font-weight-medium"
                       >{{ issue.code }}</v-chip
-                    >
-                    <v-chip
-                      v-if="issue.wcag"
-                      variant="outlined"
-                      color="primary"
-                      size="x-small"
-                      >WCAG {{ issue.wcag }}</v-chip
                     >
                   </v-list-item-title>
                   <v-list-item-subtitle class="text-caption">{{
@@ -170,338 +130,142 @@
                   }}</v-list-item-subtitle>
                 </v-list-item>
               </v-list>
-
               <v-pagination
                 v-if="totalPages > 1"
                 v-model="page"
                 :length="totalPages"
-                class="mt-3"
+                class="mt-2"
                 color="primary"
-                size="small"
-                density="compact"
+                size="x-small"
               />
             </v-container>
           </v-window-item>
 
-          <!-- ── Tab 1 : Issues & Preview ──────────────────────── -->
+          <!-- Tab 1: Visual Preview -->
           <v-window-item :value="1">
-            <v-row no-gutters style="min-height: 520px">
-              <v-col cols="12" md="4" class="border-e">
-                <div class="pa-2 border-b">
-                  <div
-                    class="text-caption font-weight-medium text-grey-darken-2 d-flex align-center gap-1"
-                  >
-                    <v-icon size="14">mdi-alert-circle-outline</v-icon>
-                    Issues
-                    <v-chip
-                      size="x-small"
-                      variant="tonal"
-                      color="primary"
-                      class="ms-1"
-                      >{{ report.ReportIssues.length }}</v-chip
-                    >
-                  </div>
-                </div>
-                <div
-                  class="overflow-y-auto"
+            <v-row no-gutters>
+              <v-col cols="12" md="4" style="border-right: 1px solid #eee">
+                <v-list
+                  density="compact"
+                  class="overflow-y-auto pa-1"
                   style="max-height: 480px"
                   @scroll="onInfiniteScroll"
                 >
-                  <v-list lines="two" density="compact" class="pa-1">
-                    <v-list-item
-                      v-for="(issue, idx) in infiniteIssues"
-                      :key="idx"
-                      :active="selectedIssue === idx"
-                      :active-color="getIssueColor(issue.type)"
-                      class="rounded-lg mb-1"
-                      @click="selectIssue(idx)"
+                  <v-list-item
+                    v-for="(issue, idx) in infiniteIssues"
+                    :key="idx"
+                    :active="selectedIssue === idx"
+                    class="rounded-lg mb-1"
+                    @click="selectIssue(idx)"
+                  >
+                    <template #prepend
+                      ><v-avatar
+                        :color="getIssueColor(issue.type)"
+                        size="20"
+                        class="me-2 text-white"
+                        style="font-size: 10px"
+                        >{{ idx + 1 }}</v-avatar
+                      ></template
                     >
-                      <template #prepend>
-                        <v-avatar
-                          :color="getIssueColor(issue.type)"
-                          size="24"
-                          class="me-2 text-white"
-                          style="font-size: 10px; font-weight: 700"
-                          >{{ idx + 1 }}</v-avatar
-                        >
-                      </template>
-                      <v-list-item-title
-                        class="text-caption d-flex align-center gap-1 flex-wrap mb-1"
+                    <v-list-item-title class="text-caption"
+                      ><v-chip
+                        :color="getIssueColor(issue.type)"
+                        size="x-small"
+                        >{{ issue.type }}</v-chip
                       >
-                        <v-chip
-                          :color="getIssueColor(issue.type)"
-                          size="x-small"
-                          variant="elevated"
-                          >{{ issue.type }}</v-chip
-                        >
-                        <v-chip
-                          v-if="issue.code"
-                          size="x-small"
-                          variant="tonal"
-                          color="grey"
-                          >{{ issue.code }}</v-chip
-                        >
-                      </v-list-item-title>
-                      <v-list-item-subtitle class="text-caption">{{
-                        issue.message
-                      }}</v-list-item-subtitle>
-                    </v-list-item>
-                  </v-list>
-                  <div
-                    v-if="
-                      infiniteIssues.length <
-                      (report?.ReportIssues?.length || 0)
-                    "
-                    class="text-center text-caption text-grey pa-2"
-                  >
-                    Loading more...
-                  </div>
-                </div>
-              </v-col>
-
-              <v-col cols="12" md="8">
-                <div class="pa-2 border-b">
-                  <div
-                    class="text-caption font-weight-medium text-grey-darken-2 d-flex align-center gap-1"
-                  >
-                    <v-icon size="14">mdi-monitor-screenshot</v-icon>
-                    Page Snapshot
-                    <v-chip
-                      v-if="selectedIssue !== null"
-                      size="x-small"
-                      variant="tonal"
-                      :color="
-                        getIssueColor(report.ReportIssues[selectedIssue]?.type)
-                      "
-                      >Issue #{{ selectedIssue + 1 }} highlighted</v-chip
+                      {{ issue.code }}</v-list-item-title
                     >
-                  </div>
-                </div>
-                <div class="pa-2" style="height: 480px">
-                  <iframe
-                    v-if="report.ReportModifiedHtml"
-                    ref="previewFrame"
-                    class="preview-frame"
-                    sandbox="allow-same-origin allow-scripts allow-popups"
-                    title="Page snapshot with highlighted accessibility issues"
-                    :srcdoc="markedUpHtml"
-                    style="
-                      width: 100%;
-                      height: 100%;
-                      border: 1px solid #e0e0e0;
-                      border-radius: 8px;
-                    "
-                  />
-                  <v-alert
-                    v-else
-                    type="info"
-                    variant="tonal"
-                    class="ma-2 rounded-lg"
-                    text="No snapshot available for this report."
-                  />
-                </div>
+                  </v-list-item>
+                </v-list>
+              </v-col>
+              <v-col cols="12" md="8">
+                <iframe
+                  v-if="report.ReportModifiedHtml"
+                  ref="previewFrame"
+                  class="preview-frame"
+                  sandbox="allow-same-origin allow-scripts"
+                  :srcdoc="markedUpHtml"
+                  style="width: 100%; height: 480px; border: none"
+                />
               </v-col>
             </v-row>
           </v-window-item>
 
-          <!-- ── Tab 2 : Issues & Details ──────────────────────── -->
+          <!-- Tab 2: Technical Detail -->
           <v-window-item :value="2">
-            <v-row no-gutters style="min-height: 520px">
-              <v-col cols="12" md="4" class="border-e">
-                <div class="pa-2 border-b">
-                  <div
-                    class="text-caption font-weight-medium text-grey-darken-2 d-flex align-center gap-1"
-                  >
-                    <v-icon size="14">mdi-alert-circle-outline</v-icon>
-                    Issues
-                    <v-chip
-                      size="x-small"
-                      variant="tonal"
-                      color="primary"
-                      class="ms-1"
-                      >{{ report.ReportIssues.length }}</v-chip
-                    >
-                  </div>
-                </div>
-                <div
-                  class="overflow-y-auto"
+            <v-row no-gutters>
+              <v-col cols="12" md="4" style="border-right: 1px solid #eee">
+                <v-list
+                  density="compact"
+                  class="overflow-y-auto pa-1"
                   style="max-height: 480px"
-                  @scroll="onInfiniteScroll"
                 >
-                  <v-list lines="two" density="compact" class="pa-1">
-                    <v-list-item
-                      v-for="(issue, idx) in infiniteIssues"
-                      :key="idx"
-                      :active="selectedIssue === idx"
-                      :active-color="getIssueColor(issue.type)"
-                      class="rounded-lg mb-1"
-                      @click="selectedIssue = idx"
-                    >
-                      <template #prepend>
-                        <v-avatar
-                          :color="getIssueColor(issue.type)"
-                          size="24"
-                          class="me-2 text-white"
-                          style="font-size: 10px; font-weight: 700"
-                          >{{ idx + 1 }}</v-avatar
-                        >
-                      </template>
-                      <v-list-item-title
-                        class="text-caption d-flex align-center gap-1 flex-wrap mb-1"
-                      >
-                        <v-chip
-                          :color="getIssueColor(issue.type)"
-                          size="x-small"
-                          variant="elevated"
-                          >{{ issue.type }}</v-chip
-                        >
-                        <v-chip
-                          v-if="issue.code"
-                          size="x-small"
-                          variant="tonal"
-                          color="grey"
-                          >{{ issue.code }}</v-chip
-                        >
-                      </v-list-item-title>
-                      <v-list-item-subtitle class="text-caption">{{
-                        issue.message
-                      }}</v-list-item-subtitle>
-                    </v-list-item>
-                  </v-list>
-                  <div
-                    v-if="
-                      infiniteIssues.length <
-                      (report?.ReportIssues?.length || 0)
-                    "
-                    class="text-center text-caption text-grey pa-2"
+                  <v-list-item
+                    v-for="(issue, idx) in infiniteIssues"
+                    :key="idx"
+                    :active="selectedIssue === idx"
+                    class="rounded-lg mb-1"
+                    @click="selectedIssue = idx"
                   >
-                    Loading more...
-                  </div>
-                </div>
+                    <template #prepend
+                      ><v-avatar
+                        :color="getIssueColor(issue.type)"
+                        size="20"
+                        class="me-2 text-white"
+                        style="font-size: 10px"
+                        >{{ idx + 1 }}</v-avatar
+                      ></template
+                    >
+                    <v-list-item-title class="text-caption">{{
+                      issue.message
+                    }}</v-list-item-title>
+                  </v-list-item>
+                </v-list>
               </v-col>
-
-              <v-col cols="12" md="8">
-                <div class="pa-2 border-b">
-                  <div
-                    class="text-caption font-weight-medium text-grey-darken-2 d-flex align-center gap-1"
-                  >
-                    <v-icon size="14">mdi-information-outline</v-icon>
-                    Issue Detail
-                  </div>
-                </div>
-
-                <div
-                  v-if="selectedIssue === null"
-                  class="d-flex flex-column align-center justify-center text-grey"
-                  style="height: 460px"
-                >
-                  <v-icon size="48" class="mb-3" color="grey-lighten-2"
-                    >mdi-cursor-pointer</v-icon
-                  >
-                  <div class="text-body-2">Select an issue to view details</div>
-                </div>
-
-                <div
-                  v-else
-                  class="pa-4 overflow-y-auto"
-                  style="max-height: 480px"
-                >
+              <v-col
+                cols="12"
+                md="8"
+                class="pa-4 bg-grey-lighten-5 overflow-y-auto"
+                style="max-height: 480px"
+              >
+                <div v-if="activeIssue">
                   <v-alert
                     :color="getIssueColor(activeIssue.type)"
                     variant="tonal"
-                    class="mb-4 rounded-xl"
-                    :icon="getSeverityIcon(activeIssue.type)"
+                    class="mb-4 text-caption font-weight-bold"
+                    density="compact"
+                    >{{ activeIssue.message }}</v-alert
                   >
-                    <div class="d-flex align-center gap-2 flex-wrap">
-                      <v-chip
-                        :color="getIssueColor(activeIssue.type)"
-                        variant="elevated"
-                        size="small"
-                        class="text-uppercase font-weight-bold"
-                        >{{ activeIssue.type }}</v-chip
-                      >
-                      <v-chip
-                        v-if="activeIssue.code"
-                        variant="tonal"
-                        color="grey"
-                        size="small"
-                        >{{ activeIssue.code }}</v-chip
-                      >
-                      <v-chip
-                        v-if="activeIssue.wcag"
-                        variant="outlined"
-                        color="primary"
-                        size="small"
-                        >WCAG {{ activeIssue.wcag }}</v-chip
-                      >
-                    </div>
-                  </v-alert>
-
-                  <div class="mb-4">
-                    <div
-                      class="text-caption text-grey font-weight-medium mb-1 text-uppercase tracking-wider"
-                    >
-                      Message
-                    </div>
-                    <div class="text-body-2">{{ activeIssue.message }}</div>
+                  <div class="text-caption text-grey font-weight-bold mb-1">
+                    CSS SELECTOR
                   </div>
-
-                  <div v-if="activeIssue.selector" class="mb-4">
-                    <div
-                      class="text-caption text-grey font-weight-medium mb-1 text-uppercase tracking-wider"
-                    >
-                      CSS Selector
-                    </div>
-                    <v-sheet color="grey-lighten-5" class="pa-2 rounded-lg">
-                      <code
-                        class="text-caption"
-                        style="word-break: break-all"
-                        >{{ activeIssue.selector }}</code
-                      >
-                    </v-sheet>
+                  <v-sheet color="white" class="pa-2 border rounded-lg mb-3"
+                    ><code class="text-caption">{{
+                      activeIssue.selector
+                    }}</code></v-sheet
+                  >
+                  <div class="text-caption text-grey font-weight-bold mb-1">
+                    HTML CONTEXT
                   </div>
-
-                  <div v-if="activeIssue.context" class="mb-4">
-                    <div
-                      class="text-caption text-grey font-weight-medium mb-1 text-uppercase tracking-wider"
+                  <v-sheet color="white" class="pa-2 border rounded-lg mb-3">
+                    <pre
+                      class="ma-0 text-caption"
+                      style="font-size: 10px; white-space: pre-wrap"
+                      >{{ activeIssue.context }}</pre
                     >
-                      HTML Context
-                    </div>
-                    <v-sheet
-                      color="grey-lighten-5"
-                      class="pa-2 rounded-lg"
-                      style="overflow-x: auto"
-                    >
-                      <pre
-                        class="text-caption ma-0"
-                        style="
-                          font-size: 11px;
-                          white-space: pre-wrap;
-                          word-break: break-all;
-                        "
-                        >{{ activeIssue.context }}</pre
-                      >
-                    </v-sheet>
-                  </div>
-
-                  <div v-if="activeIssue.runnerExtras?.wcagReference">
-                    <div
-                      class="text-caption text-grey font-weight-medium mb-2 text-uppercase tracking-wider"
-                    >
-                      WCAG Reference
-                    </div>
-                    <v-btn
-                      :href="activeIssue.runnerExtras.wcagReference"
-                      target="_blank"
-                      variant="outlined"
-                      color="primary"
-                      size="small"
-                      prepend-icon="mdi-open-in-new"
-                      class="rounded-lg"
-                    >
-                      View WCAG Guidelines
-                    </v-btn>
-                  </div>
+                  </v-sheet>
+                  <v-btn
+                    v-if="activeIssue.runnerExtras?.wcagReference"
+                    :href="activeIssue.runnerExtras.wcagReference"
+                    target="_blank"
+                    variant="outlined"
+                    size="x-small"
+                    color="primary"
+                    >Manual Criteria Reference</v-btn
+                  >
+                </div>
+                <div v-else class="text-center text-grey text-caption mt-10">
+                  Select an issue to view details
                 </div>
               </v-col>
             </v-row>
@@ -520,181 +284,137 @@ import { createManagedListeners } from '@/shared/composables/useManagedListeners
 export default {
   name: 'ReportDetail',
   components: { PageWrapper },
-
   data() {
-    const testId = this.$route.params.testId || this.$route.params.id
     return {
       selectedIssue: null,
-      testId,
-      tabs: ['Summary & Issues', 'Issues & Preview', 'Issues & Details'],
-      tabIcons: ['mdi-view-list', 'mdi-monitor-eye', 'mdi-information-outline'],
+      testId: this.$route.params.testId || this.$route.params.id,
+      tabs: ['Summary', 'Visual Preview', 'Details'],
+      tabIcons: ['mdi-chart-bar', 'mdi-monitor-eye', 'mdi-code-json'],
       currentTab: 0,
       page: 1,
-      itemsPerPage: 15,
+      itemsPerPage: 10,
       infiniteScrollCount: 20,
       iframeListeners: createManagedListeners(),
     }
   },
-
   computed: {
     ...mapState('automaticReport', ['report']),
-
     loading() {
       return this.$store.getters.loading
     },
     error() {
       return this.$store.getters.getError
     },
-
     paginatedIssues() {
       if (!this.report?.ReportIssues) return []
-      const start = (this.page - 1) * this.itemsPerPage
-      return this.report.ReportIssues.slice(start, start + this.itemsPerPage)
+      const s = (this.page - 1) * this.itemsPerPage
+      return this.report.ReportIssues.slice(s, s + this.itemsPerPage)
     },
     totalPages() {
       if (!this.report?.ReportIssues) return 1
       return Math.ceil(this.report.ReportIssues.length / this.itemsPerPage) || 1
     },
-
     infiniteIssues() {
       if (!this.report?.ReportIssues) return []
       return this.report.ReportIssues.slice(0, this.infiniteScrollCount)
     },
-
     activeIssue() {
-      if (this.selectedIssue === null || !this.report?.ReportIssues) return null
-      return this.report.ReportIssues[this.selectedIssue] ?? null
+      return this.selectedIssue !== null
+        ? this.report?.ReportIssues[this.selectedIssue]
+        : null
     },
-
     summaryStats() {
       const issues = this.report?.ReportIssues ?? []
-      const count = (type) => issues.filter((i) => i?.type === type).length
+      const c = (t) => issues.filter((i) => i?.type === t).length
       return [
-        { label: 'Errors', color: 'error', count: count('error') },
-        { label: 'Warnings', color: 'warning', count: count('warning') },
-        { label: 'Notices', color: 'info', count: count('notice') },
+        { label: 'Errors', color: 'error', count: c('error') },
+        { label: 'Warnings', color: 'warning', count: c('warning') },
+        { label: 'Notices', color: 'info', count: c('notice') },
       ]
     },
-
     markedUpHtml() {
       const html = this.report?.ReportModifiedHtml
       const issues = this.report?.ReportIssues
       if (!html || !issues?.length) return html ?? ''
-
       try {
         const parser = new DOMParser()
         const doc = parser.parseFromString(html, 'text/html')
-        const severityColor = {
-          error: 'rgba(239,68,68,0.75)',
-          warning: 'rgba(245,158,11,0.75)',
-          notice: 'rgba(59,130,246,0.6)',
+        const colors = {
+          error: 'rgba(239,68,68,0.7)',
+          warning: 'rgba(245,158,11,0.7)',
+          notice: 'rgba(59,130,246,0.5)',
         }
-
-        issues.forEach((issue, index) => {
+        issues.forEach((issue, idx) => {
           if (!issue?.selector) return
           try {
             doc.querySelectorAll(issue.selector).forEach((el) => {
-              el.setAttribute('data-issue-id', `issue-${index}`)
-              el.classList.add('a11y-marker')
-              el.style.outline = `3px solid ${severityColor[issue.type] ?? severityColor.notice}`
+              el.setAttribute('data-issue-id', `issue-${idx}`)
+              el.style.outline = `3px solid ${colors[issue.type] || colors.notice}`
               el.style.outlineOffset = '2px'
-              el.style.cursor = 'pointer'
             })
-          } catch {
-            /* skip invalid selector */
-          }
+          } catch (e) {}
         })
-
         const style = doc.createElement('style')
-        style.textContent = [
-          '.a11y-marker { transition: box-shadow 0.2s; }',
-          '.a11y-marker:hover { box-shadow: 0 0 0 4px rgba(99,102,241,0.35); }',
-          '.a11y-marker--active { box-shadow: 0 0 0 6px rgba(99,102,241,0.8) !important; position: relative; z-index: 9999; }',
-        ].join('\n')
+        style.textContent =
+          '.a11y-active { box-shadow: 0 0 0 6px #6366f1 !important; z-index: 9999; }'
         doc.head.appendChild(style)
         return doc.documentElement.outerHTML
-      } catch {
+      } catch (e) {
         return html
       }
     },
   },
-
   mounted() {
     if (!this.testId) {
       this.$store.commit('setError', {
         errorCode: 'NO_TEST_ID',
-        message: 'No testId provided in route.',
+        message: 'No testId in route.',
       })
       return
     }
     this.fetchReport(this.testId)
   },
-
   beforeUnmount() {
     this.iframeListeners.removeListeners()
   },
-
   methods: {
     ...mapActions('automaticReport', ['fetchReport']),
-
-    formatDate(dateString) {
-      if (!dateString) return '—'
-      return new Date(dateString).toLocaleString()
+    formatDate(d) {
+      return d ? new Date(d).toLocaleString() : '—'
     },
-
-    getIssueColor(type) {
-      switch (type) {
-        case 'error':
-          return 'error'
-        case 'warning':
-          return 'warning'
-        case 'notice':
-          return 'info'
-        default:
-          return 'grey'
-      }
+    getIssueColor(t) {
+      return t === 'error'
+        ? 'error'
+        : t === 'warning'
+          ? 'warning'
+          : t === 'notice'
+            ? 'info'
+            : 'grey'
     },
-
-    getSeverityIcon(type) {
-      switch (type) {
-        case 'error':
-          return 'mdi-alert-circle'
-        case 'warning':
-          return 'mdi-alert'
-        case 'notice':
-          return 'mdi-information'
-        default:
-          return 'mdi-help-circle'
-      }
+    selectIssue(idx) {
+      this.selectedIssue = idx
+      this.$nextTick(() => {
+        const f = this.$refs.previewFrame
+        if (!f?.contentDocument) return
+        const el = f.contentDocument.querySelector(
+          `[data-issue-id="issue-${idx}"]`,
+        )
+        if (!el) return
+        f.contentDocument
+          .querySelectorAll('.a11y-active')
+          .forEach((e) => e.classList.remove('a11y-active'))
+        el.classList.add('a11y-active')
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      })
     },
-
-    selectIssue(index) {
-      this.selectedIssue = index
-      this.$nextTick(() => this.scrollToIssue(index))
-    },
-
-    scrollToIssue(index) {
-      const frame = this.$refs.previewFrame
-      if (!frame?.contentDocument) return
-      const el = frame.contentDocument.querySelector(
-        `[data-issue-id="issue-${index}"]`,
-      )
-      if (!el) return
-
-      frame.contentDocument
-        .querySelectorAll('.a11y-marker--active')
-        .forEach((e) => e.classList.remove('a11y-marker--active'))
-      el.classList.add('a11y-marker--active')
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-    },
-
     onInfiniteScroll(e) {
       const el = e.target
-      if (el.scrollTop + el.clientHeight >= el.scrollHeight - 50) {
-        this.infiniteScrollCount = Math.min(
-          this.infiniteScrollCount + 20,
-          this.report?.ReportIssues?.length ?? 0,
-        )
+      if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
+        if (
+          this.infiniteScrollCount < (this.report?.ReportIssues?.length || 0)
+        ) {
+          this.infiniteScrollCount += 20
+        }
       }
     },
   },
@@ -702,39 +422,17 @@ export default {
 </script>
 
 <style scoped>
-.issue-row {
-  border: 1px solid transparent;
-  transition:
-    border-color 0.15s,
-    background-color 0.15s;
-  cursor: pointer;
-}
-.issue-row:hover {
-  background-color: rgba(var(--v-theme-primary), 0.04);
-  border-color: rgba(var(--v-theme-primary), 0.15);
+pre {
+  font-family: 'Roboto Mono', monospace;
 }
 .preview-frame {
-  width: 100%;
-  height: 100%;
-  border: none;
-  border-radius: 8px;
+  background-color: #fff;
 }
-.border-e {
-  border-right: 1px solid rgba(0, 0, 0, 0.08);
+.overflow-y-auto::-webkit-scrollbar {
+  width: 5px;
 }
-.border-b {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-}
-.tracking-wider {
-  letter-spacing: 0.08em;
-}
-.gap-1 {
-  gap: 4px;
-}
-.gap-2 {
-  gap: 8px;
-}
-.gap-3 {
-  gap: 12px;
+.overflow-y-auto::-webkit-scrollbar-thumb {
+  background: #ccc;
+  border-radius: 10px;
 }
 </style>

--- a/src/ux/accessibility/view/automatic/Answers.vue
+++ b/src/ux/accessibility/view/automatic/Answers.vue
@@ -32,7 +32,6 @@
 
     <!-- Main Report -->
     <template v-else>
-      <!-- ── Report Header ───────────────────────────────────────── -->
       <v-card class="mb-4 rounded-xl" elevation="2">
         <v-card-text class="pa-4">
           <div class="d-flex align-center flex-wrap gap-3 mb-3">
@@ -83,7 +82,6 @@
         </v-card-text>
       </v-card>
 
-      <!-- ── Tabs ────────────────────────────────────────────────── -->
       <v-card class="rounded-xl" elevation="2">
         <v-tabs
           v-model="currentTab"
@@ -107,7 +105,6 @@
           <!-- ── Tab 0 : Summary & Issues ──────────────────────── -->
           <v-window-item :value="0">
             <v-container fluid class="pa-3">
-              <!-- Issue list with pagination -->
               <div
                 class="text-body-2 font-weight-medium mb-2 d-flex align-center gap-1"
               >
@@ -120,9 +117,8 @@
                   color="primary"
                   variant="tonal"
                   class="ms-1"
+                  >{{ report.ReportIssues.length }}</v-chip
                 >
-                  {{ report.ReportIssues.length }}
-                </v-chip>
               </div>
               <v-list lines="two" class="pa-0">
                 <v-list-item
@@ -151,30 +147,27 @@
                       size="x-small"
                       variant="elevated"
                       class="text-uppercase font-weight-bold"
+                      >{{ issue.type }}</v-chip
                     >
-                      {{ issue.type }}
-                    </v-chip>
                     <v-chip
                       v-if="issue.code"
                       variant="tonal"
                       color="grey"
                       size="x-small"
                       class="font-weight-medium"
+                      >{{ issue.code }}</v-chip
                     >
-                      {{ issue.code }}
-                    </v-chip>
                     <v-chip
                       v-if="issue.wcag"
                       variant="outlined"
                       color="primary"
                       size="x-small"
+                      >WCAG {{ issue.wcag }}</v-chip
                     >
-                      WCAG {{ issue.wcag }}
-                    </v-chip>
                   </v-list-item-title>
-                  <v-list-item-subtitle class="text-caption">
-                    {{ issue.message }}
-                  </v-list-item-subtitle>
+                  <v-list-item-subtitle class="text-caption">{{
+                    issue.message
+                  }}</v-list-item-subtitle>
                 </v-list-item>
               </v-list>
 
@@ -193,7 +186,6 @@
           <!-- ── Tab 1 : Issues & Preview ──────────────────────── -->
           <v-window-item :value="1">
             <v-row no-gutters style="min-height: 520px">
-              <!-- Left: scrollable issue list -->
               <v-col cols="12" md="4" class="border-e">
                 <div class="pa-2 border-b">
                   <div
@@ -206,9 +198,8 @@
                       variant="tonal"
                       color="primary"
                       class="ms-1"
+                      >{{ report.ReportIssues.length }}</v-chip
                     >
-                      {{ report.ReportIssues.length }}
-                    </v-chip>
                   </div>
                 </div>
                 <div
@@ -231,9 +222,8 @@
                           size="24"
                           class="me-2 text-white"
                           style="font-size: 10px; font-weight: 700"
+                          >{{ idx + 1 }}</v-avatar
                         >
-                          {{ idx + 1 }}
-                        </v-avatar>
                       </template>
                       <v-list-item-title
                         class="text-caption d-flex align-center gap-1 flex-wrap mb-1"
@@ -264,12 +254,11 @@
                     "
                     class="text-center text-caption text-grey pa-2"
                   >
-                    {{ $t('Accessibility.loadingMore') }}
+                    Loading more...
                   </div>
                 </div>
               </v-col>
 
-              <!-- Right: snapshot iframe -->
               <v-col cols="12" md="8">
                 <div class="pa-2 border-b">
                   <div
@@ -284,9 +273,8 @@
                       :color="
                         getIssueColor(report.ReportIssues[selectedIssue]?.type)
                       "
+                      >Issue #{{ selectedIssue + 1 }} highlighted</v-chip
                     >
-                      Issue #{{ selectedIssue + 1 }} highlighted
-                    </v-chip>
                   </div>
                 </div>
                 <div class="pa-2" style="height: 480px">
@@ -319,7 +307,6 @@
           <!-- ── Tab 2 : Issues & Details ──────────────────────── -->
           <v-window-item :value="2">
             <v-row no-gutters style="min-height: 520px">
-              <!-- Left: scrollable issue list -->
               <v-col cols="12" md="4" class="border-e">
                 <div class="pa-2 border-b">
                   <div
@@ -332,9 +319,8 @@
                       variant="tonal"
                       color="primary"
                       class="ms-1"
+                      >{{ report.ReportIssues.length }}</v-chip
                     >
-                      {{ report.ReportIssues.length }}
-                    </v-chip>
                   </div>
                 </div>
                 <div
@@ -357,9 +343,8 @@
                           size="24"
                           class="me-2 text-white"
                           style="font-size: 10px; font-weight: 700"
+                          >{{ idx + 1 }}</v-avatar
                         >
-                          {{ idx + 1 }}
-                        </v-avatar>
                       </template>
                       <v-list-item-title
                         class="text-caption d-flex align-center gap-1 flex-wrap mb-1"
@@ -390,12 +375,11 @@
                     "
                     class="text-center text-caption text-grey pa-2"
                   >
-                    {{ $t('Accessibility.loadingMore') }}
+                    Loading more...
                   </div>
                 </div>
               </v-col>
 
-              <!-- Right: issue detail panel -->
               <v-col cols="12" md="8">
                 <div class="pa-2 border-b">
                   <div
@@ -406,7 +390,6 @@
                   </div>
                 </div>
 
-                <!-- No selection -->
                 <div
                   v-if="selectedIssue === null"
                   class="d-flex flex-column align-center justify-center text-grey"
@@ -418,13 +401,11 @@
                   <div class="text-body-2">Select an issue to view details</div>
                 </div>
 
-                <!-- Detail view -->
                 <div
                   v-else
                   class="pa-4 overflow-y-auto"
                   style="max-height: 480px"
                 >
-                  <!-- Severity banner -->
                   <v-alert
                     :color="getIssueColor(activeIssue.type)"
                     variant="tonal"
@@ -437,29 +418,25 @@
                         variant="elevated"
                         size="small"
                         class="text-uppercase font-weight-bold"
+                        >{{ activeIssue.type }}</v-chip
                       >
-                        {{ activeIssue.type }}
-                      </v-chip>
                       <v-chip
                         v-if="activeIssue.code"
                         variant="tonal"
                         color="grey"
                         size="small"
+                        >{{ activeIssue.code }}</v-chip
                       >
-                        {{ activeIssue.code }}
-                      </v-chip>
                       <v-chip
                         v-if="activeIssue.wcag"
                         variant="outlined"
                         color="primary"
                         size="small"
+                        >WCAG {{ activeIssue.wcag }}</v-chip
                       >
-                        WCAG {{ activeIssue.wcag }}
-                      </v-chip>
                     </div>
                   </v-alert>
 
-                  <!-- Message -->
                   <div class="mb-4">
                     <div
                       class="text-caption text-grey font-weight-medium mb-1 text-uppercase tracking-wider"
@@ -469,7 +446,6 @@
                     <div class="text-body-2">{{ activeIssue.message }}</div>
                   </div>
 
-                  <!-- Selector -->
                   <div v-if="activeIssue.selector" class="mb-4">
                     <div
                       class="text-caption text-grey font-weight-medium mb-1 text-uppercase tracking-wider"
@@ -485,7 +461,6 @@
                     </v-sheet>
                   </div>
 
-                  <!-- Context HTML -->
                   <div v-if="activeIssue.context" class="mb-4">
                     <div
                       class="text-caption text-grey font-weight-medium mb-1 text-uppercase tracking-wider"
@@ -509,7 +484,6 @@
                     </v-sheet>
                   </div>
 
-                  <!-- WCAG reference link -->
                   <div v-if="activeIssue.runnerExtras?.wcagReference">
                     <div
                       class="text-caption text-grey font-weight-medium mb-2 text-uppercase tracking-wider"
@@ -572,7 +546,6 @@ export default {
       return this.$store.getters.getError
     },
 
-    /** Issues for Tab 0 pagination */
     paginatedIssues() {
       if (!this.report?.ReportIssues) return []
       const start = (this.page - 1) * this.itemsPerPage
@@ -583,19 +556,16 @@ export default {
       return Math.ceil(this.report.ReportIssues.length / this.itemsPerPage) || 1
     },
 
-    /** Issues for Tabs 1 & 2 (infinite scroll) */
     infiniteIssues() {
       if (!this.report?.ReportIssues) return []
       return this.report.ReportIssues.slice(0, this.infiniteScrollCount)
     },
 
-    /** Currently selected issue object */
     activeIssue() {
       if (this.selectedIssue === null || !this.report?.ReportIssues) return null
       return this.report.ReportIssues[this.selectedIssue] ?? null
     },
 
-    /** Summary-card data derived from normalized issues */
     summaryStats() {
       const issues = this.report?.ReportIssues ?? []
       const count = (type) => issues.filter((i) => i?.type === type).length
@@ -606,10 +576,6 @@ export default {
       ]
     },
 
-    /**
-     * Snapshot HTML with coloured outlines injected onto each element
-     * matched by issue.selector — resolved entirely client-side.
-     */
     markedUpHtml() {
       const html = this.report?.ReportModifiedHtml
       const issues = this.report?.ReportIssues
@@ -618,7 +584,6 @@ export default {
       try {
         const parser = new DOMParser()
         const doc = parser.parseFromString(html, 'text/html')
-
         const severityColor = {
           error: 'rgba(239,68,68,0.75)',
           warning: 'rgba(245,158,11,0.75)',
@@ -636,7 +601,7 @@ export default {
               el.style.cursor = 'pointer'
             })
           } catch {
-            /* invalid selector — skip */
+            /* skip invalid selector */
           }
         })
 
@@ -647,7 +612,6 @@ export default {
           '.a11y-marker--active { box-shadow: 0 0 0 6px rgba(99,102,241,0.8) !important; position: relative; z-index: 9999; }',
         ].join('\n')
         doc.head.appendChild(style)
-
         return doc.documentElement.outerHTML
       } catch {
         return html
@@ -720,7 +684,6 @@ export default {
       frame.contentDocument
         .querySelectorAll('.a11y-marker--active')
         .forEach((e) => e.classList.remove('a11y-marker--active'))
-
       el.classList.add('a11y-marker--active')
       el.scrollIntoView({ behavior: 'smooth', block: 'center' })
     },

--- a/src/ux/accessibility/view/automatic/Answers.vue
+++ b/src/ux/accessibility/view/automatic/Answers.vue
@@ -319,9 +319,10 @@ export default {
       return this.report.ReportIssues.slice(0, this.infiniteScrollCount)
     },
     activeIssue() {
-      return this.selectedIssue !== null
-        ? this.report?.ReportIssues[this.selectedIssue]
-        : null
+      if (this.selectedIssue === null || this.selectedIssue === undefined) {
+        return null
+      }
+      return this.report?.ReportIssues[this.selectedIssue] ?? null
     },
     summaryStats() {
       const issues = this.report?.ReportIssues ?? []
@@ -352,14 +353,16 @@ export default {
               el.style.outline = `3px solid ${colors[issue.type] || colors.notice}`
               el.style.outlineOffset = '2px'
             })
-          } catch (e) {}
+          } catch {
+            // Malformed CSS selector — skip this issue safely.
+          }
         })
         const style = doc.createElement('style')
         style.textContent =
           '.a11y-active { box-shadow: 0 0 0 6px #6366f1 !important; z-index: 9999; }'
         doc.head.appendChild(style)
         return doc.documentElement.outerHTML
-      } catch (e) {
+      } catch {
         return html
       }
     },
@@ -382,14 +385,9 @@ export default {
     formatDate(d) {
       return d ? new Date(d).toLocaleString() : '—'
     },
-    getIssueColor(t) {
-      return t === 'error'
-        ? 'error'
-        : t === 'warning'
-          ? 'warning'
-          : t === 'notice'
-            ? 'info'
-            : 'grey'
+    getIssueColor(type) {
+      const colorMap = { error: 'error', warning: 'warning', notice: 'info' }
+      return colorMap[type] ?? 'grey'
     },
     selectIssue(idx) {
       this.selectedIssue = idx

--- a/src/ux/accessibility/view/automatic/Answers.vue
+++ b/src/ux/accessibility/view/automatic/Answers.vue
@@ -1,546 +1,540 @@
 <template>
   <PageWrapper
-    title="Accessibility Test Answers"
+    title="Accessibility Report"
     :loading="loading"
     loading-text="Loading accessibility test results..."
   >
-    <!-- Error State -->
-    <!-- if the data not available  -->
     <template #subtitle>
-      <p class="text-body-1 text-grey-darken-1">
+      <p class="text-body-2 text-grey-darken-1">
         {{ $t('Accessibility.viewDetailedIssues') }}
       </p>
     </template>
+
+    <!-- Error / Empty States -->
     <v-alert
       v-if="error"
       type="info"
       variant="tonal"
-      closable
-      class="mb-2 text-body-2 pa-2"
+      class="mb-4 rounded-xl"
+      icon="mdi-information-outline"
     >
-      <div class="d-flex flex-column align-center justify-center">
-        <v-icon color="info" size="48" class="mb-2"> mdi-info-circle </v-icon>
-        <span class="text-h6 font-weight-bold mb-1">{{
-          $t('Accessibility.information')
-        }}</span>
-        <span class="text-body-1">{{
-          $t('Accessibility.noAssessmentAvailable')
-        }}</span>
-      </div>
+      {{ $t('Accessibility.noAssessmentAvailable') }}
     </v-alert>
 
-    <!-- Main Report Content -->
-    <div v-else-if="report">
-      <!-- Report Header -->
-      <v-card class="mb-2" density="compact">
-        <v-card-title class="text-body-1 py-2">
-          <v-icon icon="mdi-web-check" class="me-2" color="primary" size="20" />
-          {{ $t('Accessibility.accessibilityReport') }}
-        </v-card-title>
-        <v-card-text class="py-1">
-          <v-row class="ma-0" dense>
-            <v-col cols="12" md="6" class="py-0">
-              <v-chip
-                prepend-icon="mdi-link"
-                variant="outlined"
-                color="primary"
-                class="mb-1 text-caption"
-                size="small"
-              >
-                {{ report.ReportUrl }}
-              </v-chip>
-            </v-col>
-            <v-col cols="12" md="6" class="py-0">
-              <v-chip
-                prepend-icon="mdi-calendar"
-                variant="outlined"
-                color="secondary"
-                class="mb-1 text-caption"
-                size="small"
-              >
+    <v-alert
+      v-else-if="!report"
+      type="info"
+      variant="tonal"
+      class="mb-4 rounded-xl"
+    >
+      {{ $t('Accessibility.noReportData') }}
+    </v-alert>
+
+    <!-- Main Report -->
+    <template v-else>
+      <!-- ── Report Header ───────────────────────────────────────── -->
+      <v-card class="mb-4 rounded-xl" elevation="2">
+        <v-card-text class="pa-4">
+          <div class="d-flex align-center flex-wrap gap-3 mb-3">
+            <v-icon color="primary" size="28">mdi-web-check</v-icon>
+            <div>
+              <div class="text-h6 font-weight-bold">
+                {{ $t('Accessibility.accessibilityReport') }}
+              </div>
+              <div class="text-caption text-grey">
                 {{ formatDate(report.ReportDateTime) }}
-              </v-chip>
+              </div>
+            </div>
+            <v-spacer />
+            <v-chip
+              prepend-icon="mdi-link-variant"
+              variant="outlined"
+              color="primary"
+              class="text-caption"
+            >
+              {{ report.ReportUrl }}
+            </v-chip>
+          </div>
+
+          <!-- Summary stat cards -->
+          <v-row dense>
+            <v-col v-for="stat in summaryStats" :key="stat.label" cols="4">
+              <v-card
+                :color="stat.count > 0 ? stat.color : undefined"
+                :variant="stat.count > 0 ? 'tonal' : 'outlined'"
+                class="rounded-lg text-center pa-2"
+                elevation="0"
+              >
+                <div
+                  class="text-h5 font-weight-black"
+                  :class="stat.count > 0 ? `text-${stat.color}` : 'text-grey'"
+                >
+                  {{ stat.count }}
+                </div>
+                <div
+                  class="text-caption font-weight-medium"
+                  :class="stat.count > 0 ? `text-${stat.color}` : 'text-grey'"
+                >
+                  {{ stat.label }}
+                </div>
+              </v-card>
             </v-col>
           </v-row>
         </v-card-text>
       </v-card>
 
-      <!-- Tabs -->
-      <v-card density="compact">
+      <!-- ── Tabs ────────────────────────────────────────────────── -->
+      <v-card class="rounded-xl" elevation="2">
         <v-tabs
           v-model="currentTab"
           bg-color="primary"
-          align-tabs="center"
           color="white"
-          density="compact"
-          class="text-caption"
+          align-tabs="center"
+          density="comfortable"
         >
           <v-tab
-            v-for="(tab, index) in tabs"
-            :key="index"
-            :value="index"
-            class="text-none px-2"
+            v-for="(tab, idx) in tabs"
+            :key="idx"
+            :value="idx"
+            class="text-none text-caption font-weight-medium"
           >
-            <v-icon :icon="getTabIcon(index)" class="me-1" size="16" />
+            <v-icon :icon="tabIcons[idx]" class="me-1" size="16" />
             {{ tab }}
           </v-tab>
         </v-tabs>
 
         <v-window v-model="currentTab">
-          <!-- Summary & Issues Tab -->
+          <!-- ── Tab 0 : Summary & Issues ──────────────────────── -->
           <v-window-item :value="0">
-            <v-container fluid class="pa-1">
-              <!-- Summary Cards -->
-              <v-row class="mb-2" dense>
-                <v-col cols="12" sm="4" class="py-0">
-                  <v-card
-                    :color="
-                      getIssueCounts().errors > 0 ? 'error' : 'grey-lighten-3'
-                    "
-                    :variant="
-                      getIssueCounts().errors > 0 ? 'elevated' : 'outlined'
-                    "
-                    density="compact"
-                  >
-                    <v-card-text class="text-center py-2 px-1">
-                      <div
-                        class="text-h5 font-weight-bold mb-0"
-                        style="font-size: 1.3rem"
-                      >
-                        {{ getIssueCounts().errors }}
-                      </div>
-                      <div class="text-caption">
-                        {{ $t('Accessibility.errors') }}
-                      </div>
-                    </v-card-text>
-                  </v-card>
-                </v-col>
-                <v-col cols="12" sm="4" class="py-0">
-                  <v-card
-                    :color="
-                      getIssueCounts().warnings > 0
-                        ? 'warning'
-                        : 'grey-lighten-3'
-                    "
-                    :variant="
-                      getIssueCounts().warnings > 0 ? 'elevated' : 'outlined'
-                    "
-                    density="compact"
-                  >
-                    <v-card-text class="text-center py-2 px-1">
-                      <div
-                        class="text-h5 font-weight-bold mb-0"
-                        style="font-size: 1.3rem"
-                      >
-                        {{ getIssueCounts().warnings }}
-                      </div>
-                      <div class="text-caption">
-                        {{ $t('Accessibility.warnings') }}
-                      </div>
-                    </v-card-text>
-                  </v-card>
-                </v-col>
-                <v-col cols="12" sm="4" class="py-0">
-                  <v-card
-                    :color="
-                      getIssueCounts().notices > 0 ? 'info' : 'grey-lighten-3'
-                    "
-                    :variant="
-                      getIssueCounts().notices > 0 ? 'elevated' : 'outlined'
-                    "
-                    density="compact"
-                  >
-                    <v-card-text class="text-center py-2 px-1">
-                      <div
-                        class="text-h5 font-weight-bold mb-0"
-                        style="font-size: 1.3rem"
-                      >
-                        {{ getIssueCounts().notices }}
-                      </div>
-                      <div class="text-caption">
-                        {{ $t('Accessibility.notices') }}
-                      </div>
-                    </v-card-text>
-                  </v-card>
-                </v-col>
-              </v-row>
+            <v-container fluid class="pa-3">
+              <!-- Issue list with pagination -->
+              <div
+                class="text-body-2 font-weight-medium mb-2 d-flex align-center gap-1"
+              >
+                <v-icon size="16" color="primary"
+                  >mdi-format-list-bulleted</v-icon
+                >
+                All Issues
+                <v-chip
+                  size="x-small"
+                  color="primary"
+                  variant="tonal"
+                  class="ms-1"
+                >
+                  {{ report.ReportIssues.length }}
+                </v-chip>
+              </div>
+              <v-list lines="two" class="pa-0">
+                <v-list-item
+                  v-for="(issue, idx) in paginatedIssues"
+                  :key="(page - 1) * itemsPerPage + idx"
+                  :active="selectedIssue === (page - 1) * itemsPerPage + idx"
+                  :active-color="getIssueColor(issue.type)"
+                  class="issue-row rounded-lg mb-2 pa-2"
+                  @click="selectedIssue = (page - 1) * itemsPerPage + idx"
+                >
+                  <template #prepend>
+                    <v-avatar
+                      :color="getIssueColor(issue.type)"
+                      size="32"
+                      class="me-2 text-caption font-weight-bold text-white"
+                    >
+                      {{ (page - 1) * itemsPerPage + idx + 1 }}
+                    </v-avatar>
+                  </template>
 
-              <!-- Issues List -->
-              <v-card density="compact">
-                <v-card-title class="py-2 px-3 text-body-2">
-                  <v-icon icon="mdi-alert-circle" class="me-1" size="18" />
-                  {{ $t('Accessibility.issues') }}
-                </v-card-title>
-                <v-card-text class="py-1 px-2">
-                  <v-list density="compact">
+                  <v-list-item-title
+                    class="text-caption mb-1 d-flex align-center flex-wrap gap-1"
+                  >
+                    <v-chip
+                      :color="getIssueColor(issue.type)"
+                      size="x-small"
+                      variant="elevated"
+                      class="text-uppercase font-weight-bold"
+                    >
+                      {{ issue.type }}
+                    </v-chip>
+                    <v-chip
+                      v-if="issue.code"
+                      variant="tonal"
+                      color="grey"
+                      size="x-small"
+                      class="font-weight-medium"
+                    >
+                      {{ issue.code }}
+                    </v-chip>
+                    <v-chip
+                      v-if="issue.wcag"
+                      variant="outlined"
+                      color="primary"
+                      size="x-small"
+                    >
+                      WCAG {{ issue.wcag }}
+                    </v-chip>
+                  </v-list-item-title>
+                  <v-list-item-subtitle class="text-caption">
+                    {{ issue.message }}
+                  </v-list-item-subtitle>
+                </v-list-item>
+              </v-list>
+
+              <v-pagination
+                v-if="totalPages > 1"
+                v-model="page"
+                :length="totalPages"
+                class="mt-3"
+                color="primary"
+                size="small"
+                density="compact"
+              />
+            </v-container>
+          </v-window-item>
+
+          <!-- ── Tab 1 : Issues & Preview ──────────────────────── -->
+          <v-window-item :value="1">
+            <v-row no-gutters style="min-height: 520px">
+              <!-- Left: scrollable issue list -->
+              <v-col cols="12" md="4" class="border-e">
+                <div class="pa-2 border-b">
+                  <div
+                    class="text-caption font-weight-medium text-grey-darken-2 d-flex align-center gap-1"
+                  >
+                    <v-icon size="14">mdi-alert-circle-outline</v-icon>
+                    Issues
+                    <v-chip
+                      size="x-small"
+                      variant="tonal"
+                      color="primary"
+                      class="ms-1"
+                    >
+                      {{ report.ReportIssues.length }}
+                    </v-chip>
+                  </div>
+                </div>
+                <div
+                  class="overflow-y-auto"
+                  style="max-height: 480px"
+                  @scroll="onInfiniteScroll"
+                >
+                  <v-list lines="two" density="compact" class="pa-1">
                     <v-list-item
-                      v-for="(issue, index) in paginatedIssues"
-                      :key="(page - 1) * itemsPerPage + index"
-                      :active="
-                        selectedIssue === (page - 1) * itemsPerPage + index
-                      "
-                      class="mb-1 py-1 px-1"
-                      style="min-height: 36px"
-                      @click="selectIssue((page - 1) * itemsPerPage + index)"
+                      v-for="(issue, idx) in infiniteIssues"
+                      :key="idx"
+                      :active="selectedIssue === idx"
+                      :active-color="getIssueColor(issue.type)"
+                      class="rounded-lg mb-1"
+                      @click="selectIssue(idx)"
                     >
                       <template #prepend>
                         <v-avatar
                           :color="getIssueColor(issue.type)"
-                          size="x-small"
+                          size="24"
+                          class="me-2 text-white"
+                          style="font-size: 10px; font-weight: 700"
                         >
-                          {{ (page - 1) * itemsPerPage + index + 1 }}
+                          {{ idx + 1 }}
                         </v-avatar>
                       </template>
-                      <v-list-item-title class="text-caption">
+                      <v-list-item-title
+                        class="text-caption d-flex align-center gap-1 flex-wrap mb-1"
+                      >
                         <v-chip
                           :color="getIssueColor(issue.type)"
                           size="x-small"
-                          class="me-1"
+                          variant="elevated"
+                          >{{ issue.type }}</v-chip
                         >
-                          {{ issue.type }}
-                        </v-chip>
-                        <v-chip variant="outlined" size="x-small" class="me-1">
-                          {{ issue.code }}
-                        </v-chip>
+                        <v-chip
+                          v-if="issue.code"
+                          size="x-small"
+                          variant="tonal"
+                          color="grey"
+                          >{{ issue.code }}</v-chip
+                        >
                       </v-list-item-title>
-                      <v-list-item-subtitle class="text-caption">
-                        {{ issue.message }}
-                      </v-list-item-subtitle>
+                      <v-list-item-subtitle class="text-caption">{{
+                        issue.message
+                      }}</v-list-item-subtitle>
                     </v-list-item>
                   </v-list>
-                  <v-pagination
-                    v-if="totalPages > 1"
-                    v-model="page"
-                    :length="totalPages"
-                    class="mt-1"
-                    color="primary"
-                    size="small"
-                  />
-                </v-card-text>
-              </v-card>
-            </v-container>
-          </v-window-item>
-
-          <!-- Issues & Preview Tab -->
-          <v-window-item :value="1">
-            <v-row no-gutters>
-              <v-col cols="12" md="5">
-                <v-card
-                  height="100%"
-                  class="d-flex flex-column"
-                  density="compact"
-                >
-                  <v-card-title class="py-2 px-3 text-body-2">
-                    <v-icon icon="mdi-alert-circle" class="me-1" size="18" />
-                    {{ $t('Accessibility.issues') }}
-                  </v-card-title>
-                  <v-card-text
-                    class="flex-grow-1 overflow-y-auto py-1 px-2"
-                    @scroll="onInfiniteScroll"
+                  <div
+                    v-if="
+                      infiniteIssues.length <
+                      (report?.ReportIssues?.length || 0)
+                    "
+                    class="text-center text-caption text-grey pa-2"
                   >
-                    <v-list density="compact">
-                      <v-list-item
-                        v-for="(issue, index) in infiniteIssues"
-                        :key="index"
-                        :active="selectedIssue === index"
-                        class="mb-1 py-1 px-1"
-                        style="min-height: 36px"
-                        rounded
-                        @click="selectIssue(index)"
-                      >
-                        <template #prepend>
-                          <v-avatar
-                            :color="getIssueColor(issue.type)"
-                            size="x-small"
-                          >
-                            {{ index + 1 }}
-                          </v-avatar>
-                        </template>
-                        <v-list-item-title class="text-caption">
-                          <v-chip
-                            :color="getIssueColor(issue.type)"
-                            size="x-small"
-                            class="me-1"
-                          >
-                            {{ issue.type }}
-                          </v-chip>
-                          <v-chip
-                            variant="outlined"
-                            size="x-small"
-                            class="me-1"
-                          >
-                            {{ issue.code }}
-                          </v-chip>
-                        </v-list-item-title>
-                        <v-list-item-subtitle class="text-caption">
-                          {{ issue.message }}
-                        </v-list-item-subtitle>
-                      </v-list-item>
-                    </v-list>
-                    <div
-                      v-if="
-                        infiniteIssues.length <
-                        (report?.ReportIssues?.length || 0)
-                      "
-                      class="text-center py-2 text-caption grey-text"
-                    >
-                      {{ $t('Accessibility.loadingMore') }}
-                    </div>
-                  </v-card-text>
-                </v-card>
+                    {{ $t('Accessibility.loadingMore') }}
+                  </div>
+                </div>
               </v-col>
 
-              <v-col cols="12" md="7">
-                <v-card
-                  height="100%"
-                  class="d-flex flex-column"
-                  density="compact"
-                >
-                  <v-card-title class="py-2 px-3 text-body-2">
-                    <v-icon icon="mdi-web" class="me-1" size="18" />
-                    {{ $t('Accessibility.webpagePreview') }}
-                  </v-card-title>
-                  <v-card-text
-                    v-if="report.ReportModifiedHtml"
-                    class="flex-grow-1 pa-1"
+              <!-- Right: snapshot iframe -->
+              <v-col cols="12" md="8">
+                <div class="pa-2 border-b">
+                  <div
+                    class="text-caption font-weight-medium text-grey-darken-2 d-flex align-center gap-1"
                   >
-                    <iframe
-                      ref="previewFrame"
-                      class="preview-frame"
-                      sandbox="allow-same-origin allow-scripts allow-popups"
-                      title="Modified webpage preview with accessibility issues highlighted"
-                      :srcdoc="report?.ReportModifiedHtml"
-                      style="
-                        width: 100%;
-                        height: 100%;
-                        border: 1px solid #e0e0e0;
-                        border-radius: 4px;
-                        min-height: 320px;
-                      "
-                    />
-                  </v-card-text>
-                  <v-card-text v-else>
-                    <v-alert
-                      type="info"
+                    <v-icon size="14">mdi-monitor-screenshot</v-icon>
+                    Page Snapshot
+                    <v-chip
+                      v-if="selectedIssue !== null"
+                      size="x-small"
                       variant="tonal"
-                      class="pa-2 text-caption"
-                      text="No modified HTML content available."
-                    />
-                  </v-card-text>
-                </v-card>
+                      :color="
+                        getIssueColor(report.ReportIssues[selectedIssue]?.type)
+                      "
+                    >
+                      Issue #{{ selectedIssue + 1 }} highlighted
+                    </v-chip>
+                  </div>
+                </div>
+                <div class="pa-2" style="height: 480px">
+                  <iframe
+                    v-if="report.ReportModifiedHtml"
+                    ref="previewFrame"
+                    class="preview-frame"
+                    sandbox="allow-same-origin allow-scripts allow-popups"
+                    title="Page snapshot with highlighted accessibility issues"
+                    :srcdoc="markedUpHtml"
+                    style="
+                      width: 100%;
+                      height: 100%;
+                      border: 1px solid #e0e0e0;
+                      border-radius: 8px;
+                    "
+                  />
+                  <v-alert
+                    v-else
+                    type="info"
+                    variant="tonal"
+                    class="ma-2 rounded-lg"
+                    text="No snapshot available for this report."
+                  />
+                </div>
               </v-col>
             </v-row>
           </v-window-item>
 
-          <!-- Issues & Details Tab -->
+          <!-- ── Tab 2 : Issues & Details ──────────────────────── -->
           <v-window-item :value="2">
-            <v-row no-gutters>
-              <v-col cols="12" md="5">
-                <v-card
-                  height="100%"
-                  class="d-flex flex-column"
-                  density="compact"
-                >
-                  <v-card-title class="py-2 px-3 text-body-2">
-                    <v-icon icon="mdi-alert-circle" class="me-1" size="18" />
-                    {{ $t('Accessibility.issues') }}
-                  </v-card-title>
-                  <v-card-text
-                    class="flex-grow-1 overflow-y-auto py-1 px-2"
-                    style="max-height: 400px"
-                    @scroll="onInfiniteScroll"
+            <v-row no-gutters style="min-height: 520px">
+              <!-- Left: scrollable issue list -->
+              <v-col cols="12" md="4" class="border-e">
+                <div class="pa-2 border-b">
+                  <div
+                    class="text-caption font-weight-medium text-grey-darken-2 d-flex align-center gap-1"
                   >
-                    <v-list density="compact">
-                      <v-list-item
-                        v-for="(issue, index) in infiniteIssues"
-                        :key="index"
-                        :active="selectedIssue === index"
-                        class="mb-1 py-1 px-1"
-                        style="min-height: 36px"
-                        rounded
-                        @click="selectIssue(index)"
-                      >
-                        <template #prepend>
-                          <v-avatar
-                            :color="getIssueColor(issue.type)"
-                            size="x-small"
-                          >
-                            {{ index + 1 }}
-                          </v-avatar>
-                        </template>
-                        <v-list-item-title class="text-caption">
-                          <v-chip
-                            :color="getIssueColor(issue.type)"
-                            size="x-small"
-                            class="me-1"
-                          >
-                            {{ issue.type }}
-                          </v-chip>
-                          <v-chip
-                            variant="outlined"
-                            size="x-small"
-                            class="me-1"
-                          >
-                            {{ issue.code }}
-                          </v-chip>
-                        </v-list-item-title>
-                        <v-list-item-subtitle class="text-caption">
-                          {{ issue.message }}
-                        </v-list-item-subtitle>
-                      </v-list-item>
-                    </v-list>
-                    <div
-                      v-if="
-                        infiniteIssues.length <
-                        (report?.ReportIssues?.length || 0)
-                      "
-                      class="text-center py-2 text-caption grey-text"
+                    <v-icon size="14">mdi-alert-circle-outline</v-icon>
+                    Issues
+                    <v-chip
+                      size="x-small"
+                      variant="tonal"
+                      color="primary"
+                      class="ms-1"
                     >
-                      {{ $t('Accessibility.loadingMore') }}
-                    </div>
-                  </v-card-text>
-                </v-card>
+                      {{ report.ReportIssues.length }}
+                    </v-chip>
+                  </div>
+                </div>
+                <div
+                  class="overflow-y-auto"
+                  style="max-height: 480px"
+                  @scroll="onInfiniteScroll"
+                >
+                  <v-list lines="two" density="compact" class="pa-1">
+                    <v-list-item
+                      v-for="(issue, idx) in infiniteIssues"
+                      :key="idx"
+                      :active="selectedIssue === idx"
+                      :active-color="getIssueColor(issue.type)"
+                      class="rounded-lg mb-1"
+                      @click="selectedIssue = idx"
+                    >
+                      <template #prepend>
+                        <v-avatar
+                          :color="getIssueColor(issue.type)"
+                          size="24"
+                          class="me-2 text-white"
+                          style="font-size: 10px; font-weight: 700"
+                        >
+                          {{ idx + 1 }}
+                        </v-avatar>
+                      </template>
+                      <v-list-item-title
+                        class="text-caption d-flex align-center gap-1 flex-wrap mb-1"
+                      >
+                        <v-chip
+                          :color="getIssueColor(issue.type)"
+                          size="x-small"
+                          variant="elevated"
+                          >{{ issue.type }}</v-chip
+                        >
+                        <v-chip
+                          v-if="issue.code"
+                          size="x-small"
+                          variant="tonal"
+                          color="grey"
+                          >{{ issue.code }}</v-chip
+                        >
+                      </v-list-item-title>
+                      <v-list-item-subtitle class="text-caption">{{
+                        issue.message
+                      }}</v-list-item-subtitle>
+                    </v-list-item>
+                  </v-list>
+                  <div
+                    v-if="
+                      infiniteIssues.length <
+                      (report?.ReportIssues?.length || 0)
+                    "
+                    class="text-center text-caption text-grey pa-2"
+                  >
+                    {{ $t('Accessibility.loadingMore') }}
+                  </div>
+                </div>
               </v-col>
 
-              <v-col cols="12" md="7">
-                <v-card
-                  height="100%"
-                  class="d-flex flex-column"
-                  density="compact"
+              <!-- Right: issue detail panel -->
+              <v-col cols="12" md="8">
+                <div class="pa-2 border-b">
+                  <div
+                    class="text-caption font-weight-medium text-grey-darken-2 d-flex align-center gap-1"
+                  >
+                    <v-icon size="14">mdi-information-outline</v-icon>
+                    Issue Detail
+                  </div>
+                </div>
+
+                <!-- No selection -->
+                <div
+                  v-if="selectedIssue === null"
+                  class="d-flex flex-column align-center justify-center text-grey"
+                  style="height: 460px"
                 >
-                  <v-card-title class="py-2 px-3 text-body-2">
-                    <v-icon icon="mdi-information" class="me-1" size="18" />
-                    {{ $t('Accessibility.issueDetails') }}
-                  </v-card-title>
-                  <v-card-text class="flex-grow-1 overflow-y-auto py-1 px-2">
-                    <div v-if="selectedIssue !== null">
-                      <v-list density="compact">
-                        <v-list-item>
-                          <v-list-item-title
-                            class="text-caption font-weight-bold"
-                          >
-                            {{ $t('Accessibility.type') }}
-                          </v-list-item-title>
-                          <v-list-item-subtitle>
-                            <v-chip
-                              :color="
-                                getIssueColor(
-                                  report.ReportIssues[selectedIssue].type,
-                                )
-                              "
-                              size="x-small"
-                            >
-                              {{ report.ReportIssues[selectedIssue].type }}
-                            </v-chip>
-                          </v-list-item-subtitle>
-                        </v-list-item>
-                        <v-list-item>
-                          <v-list-item-title
-                            class="text-caption font-weight-bold"
-                          >
-                            {{ $t('Accessibility.code') }}
-                          </v-list-item-title>
-                          <v-list-item-subtitle>
-                            <code
-                              class="bg-grey-lighten-4 pa-1 rounded text-caption"
-                              >{{
-                                report.ReportIssues[selectedIssue].code
-                              }}</code
-                            >
-                          </v-list-item-subtitle>
-                        </v-list-item>
-                        <v-list-item>
-                          <v-list-item-title
-                            class="text-caption font-weight-bold"
-                          >
-                            {{ $t('Accessibility.message') }}
-                          </v-list-item-title>
-                          <v-list-item-subtitle class="mt-1 text-caption">
-                            {{ report.ReportIssues[selectedIssue].message }}
-                          </v-list-item-subtitle>
-                        </v-list-item>
-                        <v-list-item>
-                          <v-list-item-title
-                            class="text-caption font-weight-bold"
-                          >
-                            {{ $t('Accessibility.context') }}
-                          </v-list-item-title>
-                          <v-list-item-subtitle class="mt-1">
-                            <v-sheet
-                              color="grey-lighten-5"
-                              class="pa-1 rounded"
-                            >
-                              <pre class="text-caption" style="font-size: 11px"
-                                >{{
-                                  report.ReportIssues[selectedIssue].context
-                                }}
-                    </pre
-                              >
-                            </v-sheet>
-                          </v-list-item-subtitle>
-                        </v-list-item>
-                        <v-list-item
-                          v-if="report.ReportIssues[selectedIssue].selector"
-                        >
-                          <v-list-item-title
-                            class="text-caption font-weight-bold"
-                          >
-                            {{ $t('Accessibility.selector') }}
-                          </v-list-item-title>
-                          <v-list-item-subtitle>
-                            <code
-                              class="bg-grey-lighten-4 pa-1 rounded text-caption"
-                              >{{
-                                report.ReportIssues[selectedIssue].selector
-                              }}</code
-                            >
-                          </v-list-item-subtitle>
-                        </v-list-item>
-                        <v-list-item
-                          v-if="report.ReportIssues[selectedIssue].runnerExtras"
-                        >
-                          <v-list-item-title
-                            class="text-caption font-weight-bold"
-                          >
-                            {{ $t('Accessibility.wcagReference') }}
-                          </v-list-item-title>
-                          <v-list-item-subtitle>
-                            <v-btn
-                              :href="
-                                report.ReportIssues[selectedIssue].runnerExtras
-                                  .wcagReference
-                              "
-                              target="_blank"
-                              variant="outlined"
-                              size="x-small"
-                              prepend-icon="mdi-open-in-new"
-                            >
-                              {{ $t('Accessibility.viewWcagGuidelines') }}
-                            </v-btn>
-                          </v-list-item-subtitle>
-                        </v-list-item>
-                      </v-list>
+                  <v-icon size="48" class="mb-3" color="grey-lighten-2"
+                    >mdi-cursor-pointer</v-icon
+                  >
+                  <div class="text-body-2">Select an issue to view details</div>
+                </div>
+
+                <!-- Detail view -->
+                <div
+                  v-else
+                  class="pa-4 overflow-y-auto"
+                  style="max-height: 480px"
+                >
+                  <!-- Severity banner -->
+                  <v-alert
+                    :color="getIssueColor(activeIssue.type)"
+                    variant="tonal"
+                    class="mb-4 rounded-xl"
+                    :icon="getSeverityIcon(activeIssue.type)"
+                  >
+                    <div class="d-flex align-center gap-2 flex-wrap">
+                      <v-chip
+                        :color="getIssueColor(activeIssue.type)"
+                        variant="elevated"
+                        size="small"
+                        class="text-uppercase font-weight-bold"
+                      >
+                        {{ activeIssue.type }}
+                      </v-chip>
+                      <v-chip
+                        v-if="activeIssue.code"
+                        variant="tonal"
+                        color="grey"
+                        size="small"
+                      >
+                        {{ activeIssue.code }}
+                      </v-chip>
+                      <v-chip
+                        v-if="activeIssue.wcag"
+                        variant="outlined"
+                        color="primary"
+                        size="small"
+                      >
+                        WCAG {{ activeIssue.wcag }}
+                      </v-chip>
                     </div>
-                    <v-alert
-                      v-else
-                      type="info"
-                      variant="tonal"
-                      class="pa-2 text-caption"
-                      text="Select an issue from the list to view details"
-                    />
-                  </v-card-text>
-                </v-card>
+                  </v-alert>
+
+                  <!-- Message -->
+                  <div class="mb-4">
+                    <div
+                      class="text-caption text-grey font-weight-medium mb-1 text-uppercase tracking-wider"
+                    >
+                      Message
+                    </div>
+                    <div class="text-body-2">{{ activeIssue.message }}</div>
+                  </div>
+
+                  <!-- Selector -->
+                  <div v-if="activeIssue.selector" class="mb-4">
+                    <div
+                      class="text-caption text-grey font-weight-medium mb-1 text-uppercase tracking-wider"
+                    >
+                      CSS Selector
+                    </div>
+                    <v-sheet color="grey-lighten-5" class="pa-2 rounded-lg">
+                      <code
+                        class="text-caption"
+                        style="word-break: break-all"
+                        >{{ activeIssue.selector }}</code
+                      >
+                    </v-sheet>
+                  </div>
+
+                  <!-- Context HTML -->
+                  <div v-if="activeIssue.context" class="mb-4">
+                    <div
+                      class="text-caption text-grey font-weight-medium mb-1 text-uppercase tracking-wider"
+                    >
+                      HTML Context
+                    </div>
+                    <v-sheet
+                      color="grey-lighten-5"
+                      class="pa-2 rounded-lg"
+                      style="overflow-x: auto"
+                    >
+                      <pre
+                        class="text-caption ma-0"
+                        style="
+                          font-size: 11px;
+                          white-space: pre-wrap;
+                          word-break: break-all;
+                        "
+                        >{{ activeIssue.context }}</pre
+                      >
+                    </v-sheet>
+                  </div>
+
+                  <!-- WCAG reference link -->
+                  <div v-if="activeIssue.runnerExtras?.wcagReference">
+                    <div
+                      class="text-caption text-grey font-weight-medium mb-2 text-uppercase tracking-wider"
+                    >
+                      WCAG Reference
+                    </div>
+                    <v-btn
+                      :href="activeIssue.runnerExtras.wcagReference"
+                      target="_blank"
+                      variant="outlined"
+                      color="primary"
+                      size="small"
+                      prepend-icon="mdi-open-in-new"
+                      class="rounded-lg"
+                    >
+                      View WCAG Guidelines
+                    </v-btn>
+                  </div>
+                </div>
               </v-col>
             </v-row>
           </v-window-item>
         </v-window>
       </v-card>
-    </div>
-    <div v-else>
-      <v-alert type="info" variant="tonal" class="mb-2 text-body-2 pa-2">
-        {{ $t('Accessibility.noReportData') }}
-      </v-alert>
-    </div>
+    </template>
   </PageWrapper>
 </template>
 
@@ -551,44 +545,116 @@ import { createManagedListeners } from '@/shared/composables/useManagedListeners
 
 export default {
   name: 'ReportDetail',
-  components: {
-    PageWrapper,
-  },
+  components: { PageWrapper },
+
   data() {
     const testId = this.$route.params.testId || this.$route.params.id
     return {
       selectedIssue: null,
       testId,
       tabs: ['Summary & Issues', 'Issues & Preview', 'Issues & Details'],
+      tabIcons: ['mdi-view-list', 'mdi-monitor-eye', 'mdi-information-outline'],
       currentTab: 0,
       page: 1,
-      itemsPerPage: 10,
-      infiniteScrollCount: 20, // Number of issues to show initially in infinite scroll
+      itemsPerPage: 15,
+      infiniteScrollCount: 20,
       iframeListeners: createManagedListeners(),
     }
   },
+
   computed: {
     ...mapState('automaticReport', ['report']),
+
     loading() {
       return this.$store.getters.loading
     },
     error() {
       return this.$store.getters.getError
     },
+
+    /** Issues for Tab 0 pagination */
     paginatedIssues() {
-      if (!this.report || !this.report.ReportIssues) return []
+      if (!this.report?.ReportIssues) return []
       const start = (this.page - 1) * this.itemsPerPage
       return this.report.ReportIssues.slice(start, start + this.itemsPerPage)
     },
     totalPages() {
-      if (!this.report || !this.report.ReportIssues) return 1
+      if (!this.report?.ReportIssues) return 1
       return Math.ceil(this.report.ReportIssues.length / this.itemsPerPage) || 1
     },
+
+    /** Issues for Tabs 1 & 2 (infinite scroll) */
     infiniteIssues() {
-      if (!this.report || !this.report.ReportIssues) return []
+      if (!this.report?.ReportIssues) return []
       return this.report.ReportIssues.slice(0, this.infiniteScrollCount)
     },
+
+    /** Currently selected issue object */
+    activeIssue() {
+      if (this.selectedIssue === null || !this.report?.ReportIssues) return null
+      return this.report.ReportIssues[this.selectedIssue] ?? null
+    },
+
+    /** Summary-card data derived from normalized issues */
+    summaryStats() {
+      const issues = this.report?.ReportIssues ?? []
+      const count = (type) => issues.filter((i) => i?.type === type).length
+      return [
+        { label: 'Errors', color: 'error', count: count('error') },
+        { label: 'Warnings', color: 'warning', count: count('warning') },
+        { label: 'Notices', color: 'info', count: count('notice') },
+      ]
+    },
+
+    /**
+     * Snapshot HTML with coloured outlines injected onto each element
+     * matched by issue.selector — resolved entirely client-side.
+     */
+    markedUpHtml() {
+      const html = this.report?.ReportModifiedHtml
+      const issues = this.report?.ReportIssues
+      if (!html || !issues?.length) return html ?? ''
+
+      try {
+        const parser = new DOMParser()
+        const doc = parser.parseFromString(html, 'text/html')
+
+        const severityColor = {
+          error: 'rgba(239,68,68,0.75)',
+          warning: 'rgba(245,158,11,0.75)',
+          notice: 'rgba(59,130,246,0.6)',
+        }
+
+        issues.forEach((issue, index) => {
+          if (!issue?.selector) return
+          try {
+            doc.querySelectorAll(issue.selector).forEach((el) => {
+              el.setAttribute('data-issue-id', `issue-${index}`)
+              el.classList.add('a11y-marker')
+              el.style.outline = `3px solid ${severityColor[issue.type] ?? severityColor.notice}`
+              el.style.outlineOffset = '2px'
+              el.style.cursor = 'pointer'
+            })
+          } catch {
+            /* invalid selector — skip */
+          }
+        })
+
+        const style = doc.createElement('style')
+        style.textContent = [
+          '.a11y-marker { transition: box-shadow 0.2s; }',
+          '.a11y-marker:hover { box-shadow: 0 0 0 4px rgba(99,102,241,0.35); }',
+          '.a11y-marker--active { box-shadow: 0 0 0 6px rgba(99,102,241,0.8) !important; position: relative; z-index: 9999; }',
+        ].join('\n')
+        doc.head.appendChild(style)
+
+        return doc.documentElement.outerHTML
+      } catch {
+        return html
+      }
+    },
   },
+
   mounted() {
     if (!this.testId) {
       this.$store.commit('setError', {
@@ -597,43 +663,21 @@ export default {
       })
       return
     }
-    this.fetchReport(this.testId).then(() => {
-      this.$nextTick(() => {
-        setTimeout(() => {
-          this.renderModifiedHtml()
-        }, 100)
-      })
-    })
+    this.fetchReport(this.testId)
   },
+
   beforeUnmount() {
     this.iframeListeners.removeListeners()
   },
+
   methods: {
     ...mapActions('automaticReport', ['fetchReport']),
+
     formatDate(dateString) {
-      const date = new Date(dateString)
-      return date.toLocaleString()
+      if (!dateString) return '—'
+      return new Date(dateString).toLocaleString()
     },
-    getIssueCounts() {
-      if (
-        !this.report ||
-        !this.report.ReportIssues ||
-        !Array.isArray(this.report.ReportIssues)
-      ) {
-        return { errors: 0, warnings: 0, notices: 0 }
-      }
-      return {
-        errors: this.report.ReportIssues.filter(
-          (issue) => issue && issue.type === 'error',
-        ).length,
-        warnings: this.report.ReportIssues.filter(
-          (issue) => issue && issue.type === 'warning',
-        ).length,
-        notices: this.report.ReportIssues.filter(
-          (issue) => issue && issue.type === 'notice',
-        ).length,
-      }
-    },
+
     getIssueColor(type) {
       switch (type) {
         case 'error':
@@ -646,98 +690,48 @@ export default {
           return 'grey'
       }
     },
-    getTabIcon(index) {
-      const icons = ['mdi-chart-pie', 'mdi-web', 'mdi-information']
-      return icons[index] || 'mdi-tab'
+
+    getSeverityIcon(type) {
+      switch (type) {
+        case 'error':
+          return 'mdi-alert-circle'
+        case 'warning':
+          return 'mdi-alert'
+        case 'notice':
+          return 'mdi-information'
+        default:
+          return 'mdi-help-circle'
+      }
     },
+
     selectIssue(index) {
       this.selectedIssue = index
-      this.scrollToIssue(index)
+      this.$nextTick(() => this.scrollToIssue(index))
     },
-    _onIframeLoad() {
-      const frame = this.$refs.previewFrame
-      if (!frame?.contentWindow || !frame?.contentDocument) return
-      this.iframeListeners.addListeners([
-        {
-          target: frame.contentWindow,
-          event: 'click',
-          handler: this._onContentWindowClick,
-        },
-      ])
-    },
-    _onContentWindowClick(event) {
-      const issueMarker = event.target.closest('.a11y-issue-marker')
-      if (issueMarker) {
-        const issueId = issueMarker.getAttribute('data-issue-id')
-        const index = parseInt(issueId?.replace('issue-', '') ?? '', 10)
-        if (!Number.isFinite(index) || index < 0) return
-        this.selectIssue(index)
-      }
-    },
-    renderModifiedHtml() {
-      if (
-        !this.$refs.previewFrame ||
-        !this.$refs.previewFrame.parentNode ||
-        !this.report?.modifiedHtml
-      ) {
-        return
-      }
-      try {
-        this.iframeListeners.removeListeners()
-        const frame = this.$refs.previewFrame
-        this.iframeListeners.addListeners([
-          { target: frame, event: 'load', handler: this._onIframeLoad },
-        ])
-      } catch {
-        // Ignore DOM/ref errors when iframe is not ready
-      }
-    },
+
     scrollToIssue(index) {
-      if (
-        !this.$refs.previewFrame ||
-        !this.$refs.previewFrame.parentNode ||
-        !this.report
+      const frame = this.$refs.previewFrame
+      if (!frame?.contentDocument) return
+      const el = frame.contentDocument.querySelector(
+        `[data-issue-id="issue-${index}"]`,
       )
-        return
-      const frame = this.$refs.previewFrame
-      const frameDoc = frame.contentDocument || frame.contentWindow.document
-      const element = frameDoc.querySelector(`[data-issue-id="issue-${index}"]`)
-      if (element) {
-        element.scrollIntoView({ behavior: 'smooth', block: 'center' })
-        this.highlightElement(`issue-${index}`)
-      }
+      if (!el) return
+
+      frame.contentDocument
+        .querySelectorAll('.a11y-marker--active')
+        .forEach((e) => e.classList.remove('a11y-marker--active'))
+
+      el.classList.add('a11y-marker--active')
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
     },
-    highlightElement(issueId) {
-      if (!this.$refs.previewFrame || !this.$refs.previewFrame.parentNode)
-        return
-      const frame = this.$refs.previewFrame
-      const frameDoc = frame.contentDocument || frame.contentWindow.document
-      this.unhighlightElements()
-      const element = frameDoc.querySelector(`[data-issue-id="${issueId}"]`)
-      if (element) {
-        element.style.boxShadow = '0 0 0 4px rgba(255, 0, 0, 0.5)'
-        element.style.zIndex = '1000'
-      }
-    },
-    unhighlightElements() {
-      if (!this.$refs.previewFrame || !this.$refs.previewFrame.parentNode)
-        return
-      const frame = this.$refs.previewFrame
-      const frameDoc = frame.contentDocument || frame.contentWindow.document
-      const elements = frameDoc.querySelectorAll('.a11y-issue')
-      elements.forEach((el) => {
-        el.style.boxShadow = ''
-        el.style.zIndex = ''
-      })
-    },
+
     onInfiniteScroll(e) {
       const el = e.target
-      if (el.scrollTop + el.clientHeight >= el.scrollHeight - 10) {
-        if (
-          this.infiniteScrollCount < (this.report?.ReportIssues?.length || 0)
-        ) {
-          this.infiniteScrollCount += 20
-        }
+      if (el.scrollTop + el.clientHeight >= el.scrollHeight - 50) {
+        this.infiniteScrollCount = Math.min(
+          this.infiniteScrollCount + 20,
+          this.report?.ReportIssues?.length ?? 0,
+        )
       }
     },
   },
@@ -745,43 +739,39 @@ export default {
 </script>
 
 <style scoped>
+.issue-row {
+  border: 1px solid transparent;
+  transition:
+    border-color 0.15s,
+    background-color 0.15s;
+  cursor: pointer;
+}
+.issue-row:hover {
+  background-color: rgba(var(--v-theme-primary), 0.04);
+  border-color: rgba(var(--v-theme-primary), 0.15);
+}
 .preview-frame {
-  background-color: #fff;
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: 8px;
 }
-
-pre {
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-family: 'Roboto Mono', monospace;
-  font-size: 0.875rem;
-  line-height: 1.4;
+.border-e {
+  border-right: 1px solid rgba(0, 0, 0, 0.08);
 }
-
-code {
-  font-family: 'Roboto Mono', monospace;
-  font-size: 0.875rem;
+.border-b {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 }
-
-/* Custom scrollbar for better aesthetics */
-.overflow-y-auto::-webkit-scrollbar {
-  width: 8px;
+.tracking-wider {
+  letter-spacing: 0.08em;
 }
-
-.overflow-y-auto::-webkit-scrollbar-track {
-  background: #f1f1f1;
-  border-radius: 4px;
+.gap-1 {
+  gap: 4px;
 }
-
-.overflow-y-auto::-webkit-scrollbar-thumb {
-  background: #c1c1c1;
-  border-radius: 4px;
+.gap-2 {
+  gap: 8px;
 }
-
-.overflow-y-auto::-webkit-scrollbar-thumb:hover {
-  background: #a8a8a8;
-}
-
-.error-alert-center {
-  text-align: center;
+.gap-3 {
+  gap: 12px;
 }
 </style>

--- a/src/ux/accessibility/view/automatic/AutomatedAccessibilityManager.vue
+++ b/src/ux/accessibility/view/automatic/AutomatedAccessibilityManager.vue
@@ -84,7 +84,7 @@ onMounted(async () => {
   // Redirect non-admin users trying to access manager page
   if (
     userRole.value !== 'admin' &&
-    route.path === `/accessibility/automatic/${testId.value}`
+    route.name === 'AccessibilityAutomaticManager'
   ) {
     router.push(`/accessibility/automatic/reports/${testId.value}`)
   }

--- a/src/ux/accessibility/view/automatic/EditTest.vue
+++ b/src/ux/accessibility/view/automatic/EditTest.vue
@@ -216,6 +216,7 @@
 <script>
 import axios from 'axios'
 import PageWrapper from '@/shared/views/template/PageWrapper.vue'
+import { saveReportByTestId } from '@/ux/accessibility/controllers/AccessibilityReportController'
 
 export default {
   name: 'Home',
@@ -263,20 +264,37 @@ export default {
           this.currentStep = i
         }
 
-        // Get the testId from route or store
-        const testId = this.$route.params.testId || this.testId
+        const testId = this.$route.params.id
+        if (!testId) {
+          throw new Error(
+            'No test ID found in route. Cannot save accessibility report.',
+          )
+        }
 
-        // Use env variable for API endpoint
-        const apiUrl = process.env.VUE_APP_ACCESSIBILITY_API
+        const apiUrl =
+          process.env.VUE_APP_ACCESSIBILITY_API ||
+          'http://localhost:4321/api/v3/test'
         const response = await axios.post(apiUrl, {
           url: this.url,
           testId: testId,
         })
-        if (response) {
-          // Done
+
+        if (response.data) {
+          const reportData = {
+            ReportUrl: response.data.meta?.url || response.data.url || this.url,
+            ReportDateTime:
+              response.data.meta?.scanTime ||
+              response.data.testDateTime ||
+              new Date().toISOString(),
+            ReportIssues: response.data.issues || [],
+            ReportModifiedHtml: response.data.snapshot?.html || '',
+            ReportSummary: response.data.summary || null,
+          }
+
+          await saveReportByTestId(testId, reportData)
         }
-        // Redirect to the report page
-        this.$router.push(`/answers/${testId}`)
+
+        this.$router.push(`/accessibility/automatic/answers/${testId}`)
       } catch (error) {
         this.error =
           error.response?.data?.error || 'Failed to run the accessibility test'
@@ -288,10 +306,13 @@ export default {
     },
 
     determineErrorType(error) {
-      if (!error.response) return 'network'
-      if (error.response.status === 400) return 'invalid-url'
-      if (error.response.status === 403) return 'blocked'
-      if (error.response.status === 408) return 'timeout'
+      if (error.response) {
+        if (error.response.status === 400) return 'invalid-url'
+        if (error.response.status === 403) return 'blocked'
+        if (error.response.status === 408) return 'timeout'
+        return 'server'
+      }
+      if (error.request) return 'network'
       return 'server'
     },
 


### PR DESCRIPTION
## What does this PR do?

Before this PR, running an automated accessibility scan would call the backend API and then do nothing with the results — the data was lost. The report page would either show nothing.

This PR fixes that end-to-end: the scan runs, the results are saved to Firestore, and the user is taken to a working report page that displays the issues correctly.

It also fixes three bugs that were silently breaking things in the background.

---

---
## Note : 
For Testing -> Start all three service of a11y and config them
 
- RUXAILAB ( main repo )
- Backend-api ( accessiblity-testing-backend )
- ai-api ( ai-accessibility-api )
---

## Changes explained

### 1. Scan results are now saved to the database
**File:** `AccessibilityReportController.js`

We added a new function `saveReportByTestId` that takes the scan results and saves them to Firestore under the test's ID.

A few important details about how it saves:
- The **first time** it saves a report, it records a `createdAt` timestamp.
- Every time after that, it only updates `updatedAt` — it never overwrites `createdAt`.
- It uses `merge: true` so re-running a scan on the same test doesn't wipe out any existing data.

Before this, `fetchReportByTestId` (read) existed but there was no matching write function — the controller was incomplete.

---

### 2. Issues from different scanners now look the same
**File:** `automaticReport.js`

Our backend can return results from two different scanners: **axe-core** and **pa11y**. The problem was they use different vocabulary to describe how serious an issue is:

| axe-core `impact` | pa11y `type` |
|---|---|
| `critical` | `error` |
| `serious` / `moderate` | `warning` |
| `minor` | `notice` |

Before this PR, axe-core results were displayed raw — the `type` field was missing, so the UI couldn't show the right badge (error / warning / notice).

We added a `normalizeIssue` function that transforms every axe-core issue into the same shape as pa11y before it's stored in the Vuex state. The component that renders issues doesn't need to care which scanner was used.

---

### 3. The scan page now actually sends results somewhere
**File:** `EditTest.vue`

This is the page where a user enters a URL and clicks "Run Scan". Before this PR, when the scan was done, the code checked `if (response)` and did nothing inside that block. Issues:

- **No data was saved** — the API response was thrown away.
- **The redirect was wrong** — it pointed to `/answers/:testId` which doesn't exist; the correct route is `/accessibility/automatic/answers/:testId`.
- **The test ID was wrong** — it read `this.$route.params.testId` but the actual route param is `:id`, so it was always `undefined`.
- **No fallback API URL** — if `VUE_APP_ACCESSIBILITY_API` wasn't set in `.env`, the request went to `undefined`.

This PR fixes all four issues:
- Maps the API response to a clean `reportData` object.
- Calls `saveReportByTestId` and waits for it to finish before redirecting.
- Reads the correct param: `this.$route.params.id`.
- Falls back to `http://localhost:4321/api/v3/test` for local development.

---

### 4. The admin route guard no longer breaks on path changes
**File:** `AutomatedAccessibilityManager.vue`

There was a check to redirect non-admin users away from the manager page. It compared the full URL string:

```js
// Before — fragile
route.path === `/accessibility/automatic/${testId.value}`
```

If the route path ever changes (e.g. a typo is fixed, a prefix is added), this check silently stops working. It was also matching nested routes it shouldn't.

Changed to use the route name instead, which is stable:

```js
// After — reliable
route.name === 'AccessibilityAutomaticManager'
```

---

### 5. Typo fix: `wcogData` → `wcagData`
**File:** `Assessment.js` (two places)

The Vuex state property is called `wcagData`. In two places in the `Assessment` store, it was referenced as `wcogData` (swapped `a` and `o`). JavaScript silently returns `undefined` for unknown properties, so the `guideline` field in every manually-scored report was `undefined` with no error shown. Fixed both occurrences.

---

### 6. The UI 
**File:** `Answer.vue` 

`Refactors accessibility report` to remove iframe listeners, reduce duplication, and use computed state for deterministic issue highlighting.
---
## Files changed

| File | What changed |
|---|---|
| `AccessibilityReportController.js` | Added `saveReportByTestId` write function |
| `automaticReport.js` | Added `normalizeIssue`; applied to issues on fetch |
| `EditTest.vue` | Wire scan → save → redirect; fix route param and URL |
| `AutomatedAccessibilityManager.vue` | Route guard uses `route.name` instead of `route.path` |
| `Assessment.js` | Fixed `wcogData` typo (×2) |
| `Answers.vue` | Report UI improvements for displaying scan results |

---

---

## Media files 

After : 
Link -> 
https://1drv.ms/v/c/b7e793eb50da0e33/IQDMHmP52kPKTKuLGSb-MN9tAfWVguzIdFVdn1-fHkSnK_k?e=iMQh6k


https://github.com/user-attachments/assets/2c157a22-a336-4bc5-bec5-6926b31dafc7


Before : 

https://github.com/user-attachments/assets/6e3e5f90-efe0-4ddf-8c9e-c4d0bc5367ef


## Notes

- The backend API contract is unchanged — this PR only changes how the frontend handles and stores the response.

