### PR TITLE
fix: prevent jest/axios ESM parse error in CI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,11 +2,14 @@ module.exports = {
   preset: '@vue/cli-plugin-unit-jest',
   transform: {
     '^.+\\.vue$': '@vue/vue3-jest',
-    '^.+\\.js$': 'babel-jest'
+    '^.+\\.js$': 'babel-jest',
   },
   testMatch: ['**/*.spec.js'],
   testPathIgnorePatterns: ['/e2e/', '/functions/'],
   transformIgnorePatterns: ['/node_modules/(?!axios)'],
+  moduleNameMapper: {
+    '^axios$': '<rootDir>/node_modules/axios/dist/node/axios.cjs',
+  },
   setupFilesAfterEnv: ['./tests/mocks/firebase.js'],
   resetMocks: true,
   clearMocks: true,


### PR DESCRIPTION
## What does this PR do?
Fixes CI/Jest failures caused by axios ESM imports by ensuring Jest uses axios' CommonJS build.

## Problems
- Jest in CI tried to parse the ESM entry of axios from `node_modules`, causing `Cannot use import statement outside a module`
- The parse error broke `EmailController.spec.js` and any test importing axios at module scope
- A temporary manual mock was masking the underlying issue and was not ideal for long-term maintenance

## Solution
- Mapped axios to its CommonJS bundle in `jest.config.js` so Jest loads `axios.cjs` instead of the ESM entry
- Verified locally that the full unit test suite passes after the change

## Changes
- `jest.config.js` — updated `moduleNameMapper` to map `^axios$` → `axios.cjs`

## Screenshots
<img width="1492" height="467" alt="image" src="https://github.com/user-attachments/assets/aa9319a5-7e8a-4de5-98ee-142597a39fae" />
<img width="900" height="518" alt="image" src="https://github.com/user-attachments/assets/7feb9953-fd43-4914-a72f-d4751c7ee6ad" />

## Related issue/PRs
Closes #1929 , #1943 , #1913 and #2023 