### PR TITLE
fix: prevent user studies from disappearing

### DIFF
--- a/src/controllers/StudyController.js
+++ b/src/controllers/StudyController.js
@@ -65,7 +65,12 @@ export default class StudyController extends Controller {
         )
         await Promise.all(promises)
       }
-      await super.update('users', payload.testAdmin.userDocId, payload.auxUser)
+      // Remove only the deleted test from the admin's myTests/myAnswers via a
+      // fresh read, instead of overwriting the whole user doc with a stale copy.
+      await userController.removeTestFromUser(
+        payload.testAdmin.userDocId,
+        payload.id,
+      )
       await super.delete(COLLECTION, payload.id)
     } catch (error) {
       throw error
@@ -95,10 +100,15 @@ export default class StudyController extends Controller {
       updateDate: Date.now(),
     })
 
-    // Update answers inside collaborator
+    // Update answers inside collaborator. Only write the single myAnswers
+    // entry; writing the full document with toFirestore() would overwrite
+    // myTests with the stale in-memory copy of the cooperator.
     const userToUpdate = payload.cooperator
     userToUpdate.myAnswers[`${userAnswer.testDocId}`] = userAnswer.toFirestore()
-    await userController.update(userToUpdate.id, userToUpdate.toFirestore())
+    await userController.update(userToUpdate.id, {
+      [`myAnswers.${userAnswer.testDocId}`]:
+        userToUpdate.myAnswers[`${userAnswer.testDocId}`],
+    })
 
     const testToUpdate = payload.test
     const index = testToUpdate.cooperators.findIndex(

--- a/src/features/auth/controllers/UserController.js
+++ b/src/features/auth/controllers/UserController.js
@@ -139,7 +139,11 @@ export default class UserController extends Controller {
   async addNotification(payload) {
     const userToUpdate = await this.getById(payload.userId)
     userToUpdate.notifications.push(payload.notification.toFirestore())
-    return this.update(payload.userId, userToUpdate.toFirestore())
+    // Only write the notifications field to avoid overwriting other fields
+    // (e.g. myTests) with a stale in-memory copy.
+    return this.update(payload.userId, {
+      notifications: userToUpdate.notifications,
+    })
   }
 
   async markNotificationAsRead(payload) {
@@ -155,11 +159,11 @@ export default class UserController extends Controller {
       userToUpdate.notifications[notificationIndex].read = true
       userToUpdate.notifications[notificationIndex].readAt = Date.now()
 
-      // Save updated user data to Firestore
-      await this.update(
-        userToUpdate.id,
-        userToUpdate.toFirestore(),
-      )
+      // Only write the notifications field. Writing the full document with
+      // toFirestore() would overwrite myTests with the stale in-memory copy.
+      await this.update(userToUpdate.id, {
+        notifications: userToUpdate.notifications,
+      })
       return userToUpdate
     } else {
       // Notification was not found in the array
@@ -181,10 +185,11 @@ export default class UserController extends Controller {
 
     if (!hasUnread) return userToUpdate
 
-    await this.update(
-      userToUpdate.id,
-      userToUpdate.toFirestore(),
-    )
+    // Only write the notifications field. Writing the full document with
+    // toFirestore() would overwrite myTests with the stale in-memory copy.
+    await this.update(userToUpdate.id, {
+      notifications: userToUpdate.notifications,
+    })
     // Return the updated user object (in memory) so the store can commit it immediately
     return userToUpdate
   }
@@ -230,10 +235,10 @@ export default class UserController extends Controller {
       }
       const userData = userDoc.data()
 
-      if (userData.myTests[testIdToRemove]) {
+      if (userData.myTests?.[testIdToRemove]) {
         delete userData.myTests[testIdToRemove]
       }
-      if (userData.myAnswers[testIdToRemove]) {
+      if (userData.myAnswers?.[testIdToRemove]) {
         delete userData.myAnswers[testIdToRemove]
       }
 

--- a/src/shared/views/SettingsView.vue
+++ b/src/shared/views/SettingsView.vue
@@ -672,9 +672,6 @@ const preventNav = (event) => {
 const deleteStudy = async (item) => {
   loading.value = true
   try {
-    const auxUser = { ...user.value }
-    delete auxUser.myTests[item.id]
-    item.auxUser = auxUser
     await store.dispatch('deleteStudy', item)
     showSuccess('alerts.genericSuccess')
     router.push({ name: 'Admin' })

--- a/tests/unit/StudyController.spec.js
+++ b/tests/unit/StudyController.spec.js
@@ -186,8 +186,7 @@ describe('StudyController', () => {
         it('should delete study and remove collaborators', async () => {
             const mockPayload = {
                 id: 'study-123',
-                testAdmin: { userDocId: 'admin-123' },
-                auxUser: { id: 'admin-123' }
+                testAdmin: { userDocId: 'admin-123' }
             }
 
             const mockStudyData = {
@@ -203,13 +202,14 @@ describe('StudyController', () => {
             }
 
             spies.readOne.mockResolvedValueOnce(mockDoc)
-            spies.update.mockResolvedValue()
             spies.delete.mockResolvedValue()
 
             await studyController.deleteStudy(mockPayload)
 
             expect(spies.readOne).toHaveBeenCalledWith('tests', 'study-123')
-            expect(spies.update).toHaveBeenCalled()
+            // The study doc is deleted. The admin's myTests entry is removed
+            // via UserController.removeTestFromUser (fresh read) rather than a
+            // full overwrite of the user doc, so super.update is not called here.
             expect(spies.delete).toHaveBeenCalledWith('tests', 'study-123')
         })
 


### PR DESCRIPTION
## Description

Users reported that studies they created would suddenly disappear from their account, even though the study documents still existed in Firestore. The data was never deleted — what got wiped was the `myTests` field on the user document, which is the link between a user and their studies.

### Root Cause

The `user` object in the Vuex store is loaded **once at login** (`getById`) and never refreshed. Meanwhile, new studies are added to `myTests` **server-side** by the `onTestCreate` Cloud Function. As a result, the browser's copy of `myTests` becomes stale immediately after a study is created.

Several actions later rewrote the **entire user document** from that stale copy via `User.toFirestore()`, which always includes `myTests`. Because the base writer uses `updateDoc`, the top-level `myTests` field was overwritten (not merged), replacing the correct server value and unlinking the user's studies.

The most common trigger was the notification system, where marking notifications as read saved the entire user document back to Firestore.

## Changes

To prevent stale data from overwriting `myTests`, all affected flows now update **only the fields they actually modify**:

- **`UserController.js`**
  - `addNotification()`
  - `markNotificationAsRead()`
  - `markAllNotificationsAsRead()`
  
  These methods now write only `{ notifications }`.

- **`UserController.js`**
  - Hardened `removeTestFromUser()` using optional chaining.

- **`StudyController.js`**
  - `acceptStudyCollaboration()` now updates only the `myAnswers.<testId>` field.
  - `deleteStudy()` now removes the admin's study using a fresh-read `removeTestFromUser()` call instead of the stale `auxUser` object.

- **`SettingsView.vue`**
  - Removed the now-unused stale `auxUser` construction.


### Before

Studies created since login disappear because `myTests` gets overwritten by stale client data.

### After

All studies remain visible because only the modified fields are written back.

## Verification

- Full unit test suite passing: **113/113 tests** across **11 suites**
- ESLint clean on all modified files
- Application compiles and runs successfully

## Recovery Note

Previously affected users can be recovered. The study documents still exist in the `tests` collection and can be re-linked to the user's `myTests` field.

## Related Images

<img width="2220" height="1410" alt="Data-Deletion-Fix" src="https://github.com/user-attachments/assets/4f7dbfe1-5418-4515-ae03-a76ca89f202e" />


Fixes #2126 