### PR TITLE
feat(focus-group): add Focus Group as a creatable study type

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -1972,6 +1972,13 @@
     "answers": "Answers",
     "no": "No"
   },
+  "focusGroup": {
+    "manager": {
+      "title": "Focus Group",
+      "underConstruction": "The Focus Group module is under active development. Session setup, the live discussion room, and reporting are coming soon.",
+      "description": "For now you can manage cooperators and study settings. Use the navigation menu to invite participants and configure your study."
+    }
+  },
   "studyCreation": {
     "chooseEvaluationCategory": "Choose Evaluation Category",
     "selectEvaluationType": "Select the type of evaluation you want to conduct for your study",
@@ -2029,6 +2036,20 @@
         "ab_testing": {
           "name": "A/B Testing",
           "description": "Compare two versions to determine which performs better"
+        }
+      },
+      "inquiry": {
+        "focus_group": {
+          "name": "Focus Group",
+          "description": "Moderated group discussion to gather qualitative insights from participants"
+        },
+        "survey": {
+          "name": "Survey",
+          "description": "Collect structured feedback from participants through questionnaires"
+        },
+        "interview": {
+          "name": "Interview",
+          "description": "One-on-one qualitative conversations to explore participant experiences"
         }
       },
       "inspection": {

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -1892,6 +1892,13 @@
     "no": "No",
     "sartAnalytics": "Análisis SART"
   },
+  "focusGroup": {
+    "manager": {
+      "title": "Grupo Focal",
+      "underConstruction": "El módulo de Grupo Focal está en desarrollo activo. La configuración de sesiones, la sala de discusión en vivo y los informes estarán disponibles pronto.",
+      "description": "Por ahora puedes gestionar colaboradores y la configuración del estudio. Usa el menú de navegación para invitar participantes y configurar tu estudio."
+    }
+  },
   "studyCreation": {
     "chooseEvaluationCategory": "Elegir Categoría de Evaluación",
     "selectEvaluationType": "Selecciona el tipo de evaluación que deseas realizar para tu estudio",
@@ -1949,6 +1956,20 @@
         "ab_testing": {
           "name": "Pruebas A/B",
           "description": "Compara dos versiones para determinar cuál tiene mejor rendimiento."
+        }
+      },
+      "inquiry": {
+        "focus_group": {
+          "name": "Grupo Focal",
+          "description": "Discusión grupal moderada para recopilar percepciones cualitativas de los participantes."
+        },
+        "survey": {
+          "name": "Encuesta",
+          "description": "Recopila comentarios estructurados de los participantes mediante cuestionarios."
+        },
+        "interview": {
+          "name": "Entrevista",
+          "description": "Conversaciones cualitativas individuales para explorar las experiencias de los participantes."
         }
       },
       "inspection": {

--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -6,6 +6,7 @@ import CardSorting from '@/ux/CardSorting/router.js'
 import HeuristicRoutes from '@/ux/Heuristic/router.js'
 import accessibilityRoutes from '@/ux/accessibility/router.js'
 import UserTestRoutes from '@/ux/UserTest/router.js'
+import FocusGroupRoutes from '@/ux/FocusGroup/router.js'
 import store from '@/store'
 
 const routes = [
@@ -16,6 +17,7 @@ const routes = [
   ...accessibilityRoutes,
   ...HeuristicRoutes,
   ...UserTestRoutes,
+  ...FocusGroupRoutes,
 ]
 
 const router = createRouter({

--- a/src/features/ux_creation/ChooseStudyMethods.vue
+++ b/src/features/ux_creation/ChooseStudyMethods.vue
@@ -113,6 +113,34 @@ const methodsByCategory = {
       comingSoon: true,
     },
   ],
+  inquiry: [
+    {
+      id: METHOD_DEFINITIONS.FOCUS_GROUP.id,
+      nameKey: 'studyCreation.methods.inquiry.focus_group.name',
+      descKey: 'studyCreation.methods.inquiry.focus_group.description',
+      icon: 'mdi-account-group',
+      color: 'secondary',
+      available: true,
+    },
+    {
+      id: METHOD_DEFINITIONS.SURVEY.id,
+      nameKey: 'studyCreation.methods.inquiry.survey.name',
+      descKey: 'studyCreation.methods.inquiry.survey.description',
+      icon: 'mdi-clipboard-text',
+      color: 'primary',
+      available: false,
+      comingSoon: true,
+    },
+    {
+      id: METHOD_DEFINITIONS.INTERVIEW.id,
+      nameKey: 'studyCreation.methods.inquiry.interview.name',
+      descKey: 'studyCreation.methods.inquiry.interview.description',
+      icon: 'mdi-microphone',
+      color: 'info',
+      available: false,
+      comingSoon: true,
+    },
+  ],
   inspection: [
     {
       id: METHOD_DEFINITIONS.HEURISTICS.id,

--- a/src/features/ux_creation/StudyDetailsForm.vue
+++ b/src/features/ux_creation/StudyDetailsForm.vue
@@ -422,6 +422,8 @@ const submit = async () => {
     category.value == 'test' ? STUDY_TYPES.USER : STUDY_TYPES.HEURISTIC
   if (method.value === STUDY_TYPES.CARD_SORTING)
     testType = STUDY_TYPES.CARD_SORTING
+  if (method.value === STUDY_TYPES.FOCUS_GROUP)
+    testType = STUDY_TYPES.FOCUS_GROUP
 
   isLoading.value = true
   const user = store.getters.user

--- a/src/shared/constants/methodDefinitions.js
+++ b/src/shared/constants/methodDefinitions.js
@@ -10,6 +10,8 @@ import StudyAnswer from '../models/StudyAnswer'
 import UserStudyAnswer from '@/ux/UserTest/models/UserStudyAnswer'
 import HeuristicStudyAnswer from '@/ux/Heuristic/models/HeuristicStudyAnswer'
 import CardSortingStudyAnswer from '@/ux/CardSorting/models/CardSortingStudyAnswer'
+import FocusGroupStudy from '@/ux/FocusGroup/models/FocusGroupStudy'
+import FocusGroupStudyAnswer from '@/ux/FocusGroup/models/FocusGroupStudyAnswer'
 
 /**
  * Factory function to instantiate the correct study model based on type.
@@ -41,6 +43,8 @@ export function instantiateStudyByType(type, rawData) {
       return new ManualAccessibilityTest(normalizedData)
     case STUDY_TYPES.ACCESSIBILITY_AUTOMATIC:
       return new AutomaticAccessibilityTest(normalizedData)
+    case STUDY_TYPES.FOCUS_GROUP:
+      return new FocusGroupStudy(normalizedData)
     default:
       return new Study(normalizedData)
   }
@@ -61,6 +65,8 @@ export function instantiateStudyAnswerByType(type, rawData) {
       return new HeuristicStudyAnswer(rawData)
     case STUDY_TYPES.CARD_SORTING:
       return new CardSortingStudyAnswer(rawData)
+    case STUDY_TYPES.FOCUS_GROUP:
+      return new FocusGroupStudyAnswer(rawData)
     default:
       return new StudyAnswer(rawData)
   }
@@ -75,6 +81,7 @@ export const STUDY_TYPES = {
   CARD_SORTING: 'CARD_SORTING',
   ACCESSIBILITY_MANUAL: 'MANUAL',
   ACCESSIBILITY_AUTOMATIC: 'AUTOMATIC',
+  FOCUS_GROUP: 'FOCUS_GROUP',
 }
 
 /**
@@ -243,6 +250,16 @@ export const METHOD_DEFINITIONS = {
     category: METHOD_CATEGORIES.inquiry.id,
     status: METHOD_STATUSES.COMING_SOON.id,
   },
+  FOCUS_GROUP: {
+    id: 'FOCUS_GROUP',
+    name: 'Grupo Focal',
+    nameEn: 'Focus Group',
+    icon: 'mdi-account-group',
+    color: '#FF425A',
+    description: 'Moderated group discussion to gather qualitative insights',
+    category: METHOD_CATEGORIES.inquiry.id,
+    status: METHOD_STATUSES.IMPROVING.id,
+  },
   CARD_SORTING: {
     id: 'CARD_SORTING',
     name: 'Card Sorting',
@@ -316,6 +333,8 @@ export const getMethodDefinition = (testType, subType = '') => {
       return METHOD_DEFINITIONS.HEURISTICS
     case STUDY_TYPES.CARD_SORTING:
       return METHOD_DEFINITIONS.CARD_SORTING
+    case STUDY_TYPES.FOCUS_GROUP:
+      return METHOD_DEFINITIONS.FOCUS_GROUP
     default:
       return null
   }
@@ -327,6 +346,8 @@ export const getMethodManagerView = (type, subType) => {
   if (normalizedType === STUDY_TYPES.HEURISTIC) return 'HeuristicManagerView'
   else if (normalizedType === STUDY_TYPES.CARD_SORTING)
     return 'CardSortingManagerView'
+  else if (normalizedType === STUDY_TYPES.FOCUS_GROUP)
+    return 'FocusGroupManagerView'
   else if (normalizedType === STUDY_TYPES.USER) {
     if (subType === USER_STUDY_SUBTYPES.UNMODERATED)
       return 'UserUnmoderatedManagerView'

--- a/src/shared/constants/studyCategories.js
+++ b/src/shared/constants/studyCategories.js
@@ -28,8 +28,8 @@ export const STUDY_CATEGORIES = [
       'Gather insights through surveys, interviews, and other research methods.',
     icon: 'mdi-comment-question-outline',
     color: 'warning',
-    hasSubMethods: false,
-    comingSoon: true,
+    hasSubMethods: true,
+    comingSoon: false,
   },
   {
     id: 'inspection',

--- a/src/ux/FocusGroup/models/FocusGroupStudy.js
+++ b/src/ux/FocusGroup/models/FocusGroupStudy.js
@@ -1,0 +1,24 @@
+import { STUDY_TYPES } from '@/shared/constants/methodDefinitions'
+import Study from '@/shared/models/Study'
+
+/**
+ * Represents a Focus Group study.
+ *
+ * Inquiry-category method for moderated group discussions. This is the initial
+ * skeleton model; discussion-specific fields (guide, stimuli, sessions) will be
+ * added as the build-out phase progresses.
+ */
+export default class FocusGroupStudy extends Study {
+  constructor(params = {}) {
+    super(params)
+
+    this.testType = STUDY_TYPES.FOCUS_GROUP
+    this.discussionGuide = params.discussionGuide ?? []
+  }
+
+  toFirestore() {
+    return Object.assign(super.toFirestore(), {
+      discussionGuide: this.discussionGuide,
+    })
+  }
+}

--- a/src/ux/FocusGroup/models/FocusGroupStudyAnswer.js
+++ b/src/ux/FocusGroup/models/FocusGroupStudyAnswer.js
@@ -1,0 +1,20 @@
+import StudyAnswer from '@/shared/models/StudyAnswer'
+
+/**
+ * Answer envelope for a Focus Group study.
+ *
+ * Initial skeleton: holds per-session discussion data keyed by session id.
+ * Expanded alongside the live-session build-out.
+ */
+export default class FocusGroupStudyAnswer extends StudyAnswer {
+  constructor(params = {}) {
+    super(params)
+    this.sessions = params.sessions ?? {}
+  }
+
+  toFirestore() {
+    return Object.assign(super.toFirestore(), {
+      sessions: this.sessions,
+    })
+  }
+}

--- a/src/ux/FocusGroup/router.js
+++ b/src/ux/FocusGroup/router.js
@@ -1,0 +1,29 @@
+import ManagerView from '@/ux/FocusGroup/views/ManagerView.vue'
+import SettingsView from '@/shared/views/SettingsView.vue'
+import CooperatorsView from '@/shared/views/CooperatorsView.vue'
+
+export default [
+  {
+    path: '/focusGroup/manager/:id',
+    name: 'FocusGroupManagerView',
+    meta: { authorize: [0, 1] },
+    component: ManagerView,
+    props: true,
+    children: [
+      {
+        path: '/focusGroup/settings/:id',
+        name: 'FocusGroupSettingsView',
+        props: true,
+        meta: { authorize: [0, 1] },
+        component: SettingsView,
+      },
+      {
+        path: '/focusGroup/cooperators/:id',
+        name: 'FocusGroupCooperatorsView',
+        props: true,
+        meta: { authorize: [0, 1] },
+        component: CooperatorsView,
+      },
+    ],
+  },
+]

--- a/src/ux/FocusGroup/views/ManagerView.vue
+++ b/src/ux/FocusGroup/views/ManagerView.vue
@@ -1,0 +1,77 @@
+<template>
+  <ManagerView :navigator="navigator" :top-cards="[]" :bottom-cards="[]">
+    <template v-if="$route.path.includes('manager')" #default>
+      <ManagerBanner :title="test?.testTitle" />
+
+      <v-container class="card-container">
+        <v-card class="pa-6" elevation="2" rounded="lg">
+          <div class="d-flex align-center mb-4">
+            <v-icon
+              icon="mdi-account-group"
+              color="primary"
+              size="32"
+              class="me-3"
+            />
+            <h2 class="text-h5 font-weight-bold">
+              {{ $t('focusGroup.manager.title') }}
+            </h2>
+          </div>
+
+          <v-alert
+            type="info"
+            variant="tonal"
+            border="start"
+            class="mb-2"
+          >
+            {{ $t('focusGroup.manager.underConstruction') }}
+          </v-alert>
+
+          <p class="text-body-2 text-grey-darken-1 mt-4 mb-0">
+            {{ $t('focusGroup.manager.description') }}
+          </p>
+        </v-card>
+      </v-container>
+    </template>
+  </ManagerView>
+</template>
+
+<script setup>
+import ManagerView from '@/shared/views/template/ManagerView.vue'
+import ManagerBanner from '@/shared/components/ManagerBanner.vue'
+import { ICONS } from '@/shared/constants/theme'
+import { computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { useStore } from 'vuex'
+
+const store = useStore()
+const route = useRoute()
+
+const test = computed(() => store.getters.test)
+
+// Trimmed navigator — only routes that exist in the skeleton module.
+// Edit / Reports / Answers links are added as those views are built.
+const navigator = computed(() => {
+  if (!test.value) return []
+  return [
+    {
+      title: 'Manager',
+      icon: ICONS.MANAGER,
+      path: `/focusGroup/manager/${route.params.id}`,
+    },
+    {
+      title: 'Cooperators',
+      icon: ICONS.ACCOUNT_GROUP,
+      path: `/focusGroup/cooperators/${test.value.id}`,
+    },
+    {
+      title: 'Settings',
+      icon: ICONS.COG,
+      path: `/focusGroup/settings/${test.value.id}`,
+    },
+  ]
+})
+
+onMounted(async () => {
+  await store.dispatch('getStudy', { id: route.params.id })
+})
+</script>


### PR DESCRIPTION
Adds Focus Group as the first Inquiry-category method, creatable through the existing study creation wizard, with a skeleton manager module.

## Changes
- `FocusGroupStudy` / `FocusGroupStudyAnswer` models + `FOCUS_GROUP` registered in the study-type enum and both factory switches
- Unlocked the Inquiry category; added Focus Group to the method picker and study details form
- Skeleton `FocusGroupManagerView` (reuses shared manager) with Cooperators + Settings routes

## Notes
Foundation for the Focus Group module. Session setup, live room, and reporting come in follow-up PRs.

Part of #2134 #2135 #2136

<img width="1470" height="956" alt="Screenshot 2026-06-29 at 6 36 44 PM" src="https://github.com/user-attachments/assets/c017206f-5df4-4adc-834c-05e47d31a42c" />
<img width="1470" height="956" alt="Screenshot 2026-06-29 at 6 37 32 PM" src="https://github.com/user-attachments/assets/0dae9769-3e70-427a-ab01-413c1efa4a2f" />
<img width="1470" height="956" alt="Screenshot 2026-06-29 at 6 38 37 PM" src="https://github.com/user-attachments/assets/9558d874-706f-4eb8-9b57-a72c8d74a335" />
