### PR TITLE
feat(focus-group): discussion guide editor, models, controller and store

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -1975,8 +1975,24 @@
   "focusGroup": {
     "manager": {
       "title": "Focus Group",
-      "underConstruction": "The Focus Group module is under active development. Session setup, the live discussion room, and reporting are coming soon.",
-      "description": "For now you can manage cooperators and study settings. Use the navigation menu to invite participants and configure your study."
+      "underConstruction": "The Focus Group module is under active development. The live discussion room and reporting are coming soon.",
+      "description": "You can build your discussion guide, manage cooperators, and configure study settings from the navigation menu."
+    },
+    "edit": {
+      "title": "Discussion Guide",
+      "subtitle": "Define the topics and prompts your facilitator will guide the group through.",
+      "save": "Save guide",
+      "saved": "Discussion guide saved",
+      "noTopics": "No topics yet. Add your first discussion topic to get started.",
+      "addTopic": "Add topic",
+      "removeTopic": "Remove topic",
+      "topicTitle": "Topic",
+      "moveUp": "Move up",
+      "moveDown": "Move down",
+      "prompt": "Prompt",
+      "addPrompt": "Add prompt",
+      "removePrompt": "Remove prompt",
+      "duration": "Minutes"
     }
   },
   "studyCreation": {

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -1895,8 +1895,24 @@
   "focusGroup": {
     "manager": {
       "title": "Grupo Focal",
-      "underConstruction": "El módulo de Grupo Focal está en desarrollo activo. La configuración de sesiones, la sala de discusión en vivo y los informes estarán disponibles pronto.",
-      "description": "Por ahora puedes gestionar colaboradores y la configuración del estudio. Usa el menú de navegación para invitar participantes y configurar tu estudio."
+      "underConstruction": "El módulo de Grupo Focal está en desarrollo activo. La sala de discusión en vivo y los informes estarán disponibles pronto.",
+      "description": "Puedes crear tu guía de discusión, gestionar colaboradores y configurar el estudio desde el menú de navegación."
+    },
+    "edit": {
+      "title": "Guía de Discusión",
+      "subtitle": "Define los temas y preguntas que el facilitador usará para guiar al grupo.",
+      "save": "Guardar guía",
+      "saved": "Guía de discusión guardada",
+      "noTopics": "Aún no hay temas. Agrega tu primer tema de discusión para comenzar.",
+      "addTopic": "Agregar tema",
+      "removeTopic": "Eliminar tema",
+      "topicTitle": "Tema",
+      "moveUp": "Mover arriba",
+      "moveDown": "Mover abajo",
+      "prompt": "Pregunta",
+      "addPrompt": "Agregar pregunta",
+      "removePrompt": "Eliminar pregunta",
+      "duration": "Minutos"
     }
   },
   "studyCreation": {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -14,6 +14,7 @@ import automaticReport from '@/ux/accessibility/store/automaticReport'
 import UserStudy from '@/ux/UserTest/store/UserStudy'
 import notification from '@/features/notifications/store/notification'
 import CardStudy from '@/ux/CardSorting/stores/CardStudy'
+import FocusGroup from '@/ux/FocusGroup/store/FocusGroup'
 
 export default createStore({
   state: {
@@ -92,5 +93,6 @@ export default createStore({
     UserStudy,
     CardStudy,
     notification,
+    FocusGroup,
   },
 })

--- a/src/ux/FocusGroup/components/DiscussionGuideEditor.vue
+++ b/src/ux/FocusGroup/components/DiscussionGuideEditor.vue
@@ -1,0 +1,136 @@
+<template>
+  <div>
+    <div
+      v-if="topics.length === 0"
+      class="text-center py-8 text-medium-emphasis"
+    >
+      <v-icon icon="mdi-forum-outline" size="48" class="mb-2" />
+      <p class="text-body-2 mb-0">{{ $t('focusGroup.edit.noTopics') }}</p>
+    </div>
+
+    <v-card
+      v-for="(topic, index) in topics"
+      :key="topic.id"
+      variant="outlined"
+      rounded="lg"
+      class="mb-4"
+    >
+      <v-card-text class="pa-4">
+        <div class="d-flex align-center ga-2 mb-3">
+          <v-chip size="small" color="primary" variant="tonal">{{
+            index + 1
+          }}</v-chip>
+          <v-text-field
+            v-model="topic.title"
+            :label="$t('focusGroup.edit.topicTitle')"
+            variant="outlined"
+            density="compact"
+            hide-details
+          />
+          <v-btn
+            icon="mdi-arrow-up"
+            size="small"
+            variant="text"
+            :disabled="index === 0"
+            :aria-label="$t('focusGroup.edit.moveUp')"
+            @click="move(index, -1)"
+          />
+          <v-btn
+            icon="mdi-arrow-down"
+            size="small"
+            variant="text"
+            :disabled="index === topics.length - 1"
+            :aria-label="$t('focusGroup.edit.moveDown')"
+            @click="move(index, 1)"
+          />
+          <v-btn
+            icon="mdi-delete-outline"
+            size="small"
+            variant="text"
+            color="error"
+            :aria-label="$t('focusGroup.edit.removeTopic')"
+            @click="removeTopic(index)"
+          />
+        </div>
+
+        <!-- Prompts -->
+        <div class="ml-8">
+          <div
+            v-for="(prompt, pIndex) in topic.prompts"
+            :key="pIndex"
+            class="d-flex align-center ga-2 mb-2"
+          >
+            <v-text-field
+              v-model="topic.prompts[pIndex]"
+              :label="$t('focusGroup.edit.prompt')"
+              variant="outlined"
+              density="compact"
+              hide-details
+            />
+            <v-btn
+              icon="mdi-close"
+              size="x-small"
+              variant="text"
+              :aria-label="$t('focusGroup.edit.removePrompt')"
+              @click="topic.prompts.splice(pIndex, 1)"
+            />
+          </div>
+
+          <div class="d-flex align-center justify-space-between mt-2">
+            <v-btn
+              size="small"
+              variant="text"
+              color="primary"
+              prepend-icon="mdi-plus"
+              class="text-none"
+              @click="topic.prompts.push('')"
+            >
+              {{ $t('focusGroup.edit.addPrompt') }}
+            </v-btn>
+            <v-text-field
+              v-model.number="topic.durationMinutes"
+              :label="$t('focusGroup.edit.duration')"
+              type="number"
+              min="1"
+              variant="outlined"
+              density="compact"
+              hide-details
+              style="max-width: 140px"
+            />
+          </div>
+        </div>
+      </v-card-text>
+    </v-card>
+
+    <v-btn
+      variant="tonal"
+      color="primary"
+      prepend-icon="mdi-plus"
+      class="text-none"
+      @click="addTopic"
+    >
+      {{ $t('focusGroup.edit.addTopic') }}
+    </v-btn>
+  </div>
+</template>
+
+<script setup>
+import DiscussionTopic from '@/ux/FocusGroup/models/DiscussionTopic'
+
+const topics = defineModel({ type: Array, default: () => [] })
+
+const addTopic = () => {
+  topics.value.push(new DiscussionTopic({}))
+}
+
+const removeTopic = (index) => {
+  topics.value.splice(index, 1)
+}
+
+const move = (index, delta) => {
+  const target = index + delta
+  if (target < 0 || target >= topics.value.length) return
+  const [item] = topics.value.splice(index, 1)
+  topics.value.splice(target, 0, item)
+}
+</script>

--- a/src/ux/FocusGroup/controllers/FocusGroupController.js
+++ b/src/ux/FocusGroup/controllers/FocusGroupController.js
@@ -1,0 +1,34 @@
+import Controller from '@/app/plugins/firebase/FirebaseFirestoreRepository'
+import { instantiateStudyByType, STUDY_TYPES } from '@/shared/constants/methodDefinitions'
+
+const COLLECTION = 'tests'
+
+/**
+ * Data access for Focus Group studies. Reads and persists the discussion guide
+ * and session configuration on the underlying study document.
+ */
+export default class FocusGroupController extends Controller {
+  async getById(id) {
+    const res = await this.readOne(COLLECTION, id)
+    return instantiateStudyByType(STUDY_TYPES.FOCUS_GROUP, {
+      id: res.id,
+      ...res.data(),
+    })
+  }
+
+  async updateDiscussionGuide(id, discussionGuide) {
+    return this.update(COLLECTION, id, {
+      discussionGuide: discussionGuide.map((topic) =>
+        typeof topic.toFirestore === 'function' ? topic.toFirestore() : topic,
+      ),
+      updateDate: Date.now(),
+    })
+  }
+
+  async updateConfig(id, config) {
+    return this.update(COLLECTION, id, {
+      config: typeof config.toFirestore === 'function' ? config.toFirestore() : config,
+      updateDate: Date.now(),
+    })
+  }
+}

--- a/src/ux/FocusGroup/models/DiscussionTopic.js
+++ b/src/ux/FocusGroup/models/DiscussionTopic.js
@@ -1,0 +1,28 @@
+/**
+ * A single topic in a Focus Group discussion guide.
+ *
+ * @param {string} title - Topic heading shown to the facilitator.
+ * @param {string[]} prompts - Optional follow-up questions for the topic.
+ * @param {number} durationMinutes - Planned time budget for the topic.
+ */
+export default class DiscussionTopic {
+  constructor({ id, title, prompts, durationMinutes } = {}) {
+    this.id = id ?? `topic-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+    this.title = title ?? ''
+    this.prompts = prompts ?? []
+    this.durationMinutes = durationMinutes ?? 5
+  }
+
+  toFirestore() {
+    return {
+      id: this.id,
+      title: this.title,
+      prompts: this.prompts,
+      durationMinutes: this.durationMinutes,
+    }
+  }
+
+  static fromFirestore(data = {}) {
+    return new DiscussionTopic(data)
+  }
+}

--- a/src/ux/FocusGroup/models/DiscussionTopic.js
+++ b/src/ux/FocusGroup/models/DiscussionTopic.js
@@ -7,10 +7,19 @@
  */
 export default class DiscussionTopic {
   constructor({ id, title, prompts, durationMinutes } = {}) {
-    this.id = id ?? `topic-${Date.now()}-${Math.floor(Math.random() * 1000)}`
+    this.id = id ?? DiscussionTopic.generateId()
     this.title = title ?? ''
     this.prompts = prompts ?? []
     this.durationMinutes = durationMinutes ?? 5
+  }
+
+  static generateId() {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+      return `topic-${crypto.randomUUID()}`
+    }
+    const array = new Uint32Array(2)
+    crypto.getRandomValues(array)
+    return `topic-${Date.now()}-${array[0].toString(36)}${array[1].toString(36)}`
   }
 
   toFirestore() {

--- a/src/ux/FocusGroup/models/FocusGroupConfig.js
+++ b/src/ux/FocusGroup/models/FocusGroupConfig.js
@@ -1,0 +1,34 @@
+/**
+ * Session configuration for a Focus Group study.
+ *
+ * @param {boolean} enableWaitingRoom - Hold participants before admitting them.
+ * @param {boolean} requireConsent - Require consent before joining a session.
+ * @param {boolean} hideObservers - Keep observers invisible to participants (backroom).
+ * @param {number} maxParticipants - Maximum active participants per session.
+ */
+export default class FocusGroupConfig {
+  constructor({
+    enableWaitingRoom,
+    requireConsent,
+    hideObservers,
+    maxParticipants,
+  } = {}) {
+    this.enableWaitingRoom = enableWaitingRoom ?? true
+    this.requireConsent = requireConsent ?? true
+    this.hideObservers = hideObservers ?? true
+    this.maxParticipants = maxParticipants ?? 8
+  }
+
+  toFirestore() {
+    return {
+      enableWaitingRoom: this.enableWaitingRoom,
+      requireConsent: this.requireConsent,
+      hideObservers: this.hideObservers,
+      maxParticipants: this.maxParticipants,
+    }
+  }
+
+  static fromFirestore(data = {}) {
+    return new FocusGroupConfig(data)
+  }
+}

--- a/src/ux/FocusGroup/models/FocusGroupStudy.js
+++ b/src/ux/FocusGroup/models/FocusGroupStudy.js
@@ -1,24 +1,32 @@
 import { STUDY_TYPES } from '@/shared/constants/methodDefinitions'
 import Study from '@/shared/models/Study'
+import DiscussionTopic from './DiscussionTopic'
+import FocusGroupConfig from './FocusGroupConfig'
 
 /**
  * Represents a Focus Group study.
  *
- * Inquiry-category method for moderated group discussions. This is the initial
- * skeleton model; discussion-specific fields (guide, stimuli, sessions) will be
- * added as the build-out phase progresses.
+ * Inquiry-category method for moderated group discussions. Holds the discussion
+ * guide (ordered topics) and session configuration.
  */
 export default class FocusGroupStudy extends Study {
   constructor(params = {}) {
     super(params)
 
     this.testType = STUDY_TYPES.FOCUS_GROUP
-    this.discussionGuide = params.discussionGuide ?? []
+    this.discussionGuide = (params.discussionGuide ?? []).map((topic) =>
+      topic instanceof DiscussionTopic ? topic : new DiscussionTopic(topic),
+    )
+    this.config =
+      params.config instanceof FocusGroupConfig
+        ? params.config
+        : new FocusGroupConfig(params.config ?? {})
   }
 
   toFirestore() {
     return Object.assign(super.toFirestore(), {
-      discussionGuide: this.discussionGuide,
+      discussionGuide: this.discussionGuide.map((topic) => topic.toFirestore()),
+      config: this.config.toFirestore(),
     })
   }
 }

--- a/src/ux/FocusGroup/router.js
+++ b/src/ux/FocusGroup/router.js
@@ -1,4 +1,5 @@
 import ManagerView from '@/ux/FocusGroup/views/ManagerView.vue'
+import EditFocusGroupView from '@/ux/FocusGroup/views/EditFocusGroupView.vue'
 import SettingsView from '@/shared/views/SettingsView.vue'
 import CooperatorsView from '@/shared/views/CooperatorsView.vue'
 
@@ -10,6 +11,13 @@ export default [
     component: ManagerView,
     props: true,
     children: [
+      {
+        path: '/focusGroup/edit/:id',
+        name: 'FocusGroupEditTest',
+        props: true,
+        meta: { authorize: [0, 1] },
+        component: EditFocusGroupView,
+      },
       {
         path: '/focusGroup/settings/:id',
         name: 'FocusGroupSettingsView',

--- a/src/ux/FocusGroup/store/FocusGroup.js
+++ b/src/ux/FocusGroup/store/FocusGroup.js
@@ -1,0 +1,47 @@
+import FocusGroupController from '@/ux/FocusGroup/controllers/FocusGroupController'
+import i18n from '@/app/plugins/i18n'
+
+const focusGroupController = new FocusGroupController()
+
+export default {
+  state: {
+    currentFocusGroup: null,
+  },
+
+  getters: {
+    currentFocusGroup: (state) => state.currentFocusGroup,
+  },
+
+  mutations: {
+    SET_FOCUS_GROUP(state, payload) {
+      state.currentFocusGroup = payload
+    },
+  },
+
+  actions: {
+    async getFocusGroup({ commit }, id) {
+      const study = await focusGroupController.getById(id)
+      commit('SET_FOCUS_GROUP', study)
+      return study
+    },
+
+    async saveDiscussionGuide({ commit }, { studyId, discussionGuide }) {
+      commit('setLoading', true)
+      try {
+        await focusGroupController.updateDiscussionGuide(studyId, discussionGuide)
+        commit('SET_TOAST', {
+          message: i18n.global.t('focusGroup.edit.saved'),
+          type: 'success',
+        })
+      } catch (err) {
+        commit('SET_TOAST', {
+          message: i18n.global.t('errors.globalError'),
+          type: 'error',
+        })
+        throw err
+      } finally {
+        commit('setLoading', false)
+      }
+    },
+  },
+}

--- a/src/ux/FocusGroup/views/EditFocusGroupView.vue
+++ b/src/ux/FocusGroup/views/EditFocusGroupView.vue
@@ -1,0 +1,64 @@
+<template>
+  <v-container class="py-6" style="max-width: 900px">
+    <div class="d-flex align-center mb-2">
+      <v-icon icon="mdi-forum-outline" color="primary" size="28" class="me-3" />
+      <h2 class="text-h5 font-weight-bold">
+        {{ $t('focusGroup.edit.title') }}
+      </h2>
+    </div>
+    <p class="text-body-2 text-medium-emphasis mb-6">
+      {{ $t('focusGroup.edit.subtitle') }}
+    </p>
+
+    <v-card elevation="2" rounded="lg" class="pa-6">
+      <DiscussionGuideEditor v-model="topics" />
+    </v-card>
+
+    <div class="d-flex justify-end mt-6">
+      <v-btn
+        color="primary"
+        variant="elevated"
+        :loading="loading"
+        prepend-icon="mdi-content-save"
+        class="text-none"
+        @click="save"
+      >
+        {{ $t('focusGroup.edit.save') }}
+      </v-btn>
+    </div>
+  </v-container>
+</template>
+
+<script setup>
+import DiscussionGuideEditor from '@/ux/FocusGroup/components/DiscussionGuideEditor.vue'
+import DiscussionTopic from '@/ux/FocusGroup/models/DiscussionTopic'
+import { computed, ref, watch, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { useStore } from 'vuex'
+
+const store = useStore()
+const route = useRoute()
+
+const topics = ref([])
+const test = computed(() => store.getters.test)
+const loading = computed(() => store.state.loading)
+
+const hydrate = (study) => {
+  if (!study) return
+  topics.value = (study.discussionGuide ?? []).map((t) => new DiscussionTopic(t))
+}
+
+watch(test, hydrate)
+
+const save = async () => {
+  await store.dispatch('saveDiscussionGuide', {
+    studyId: route.params.id,
+    discussionGuide: topics.value,
+  })
+}
+
+onMounted(async () => {
+  if (!test.value) await store.dispatch('getStudy', { id: route.params.id })
+  hydrate(test.value)
+})
+</script>

--- a/src/ux/FocusGroup/views/ManagerView.vue
+++ b/src/ux/FocusGroup/views/ManagerView.vue
@@ -59,6 +59,11 @@ const navigator = computed(() => {
       path: `/focusGroup/manager/${route.params.id}`,
     },
     {
+      title: 'Test',
+      icon: ICONS.DOCUMENT_EDIT,
+      path: `/focusGroup/edit/${test.value.id}`,
+    },
+    {
       title: 'Cooperators',
       icon: ICONS.ACCOUNT_GROUP,
       path: `/focusGroup/cooperators/${test.value.id}`,


### PR DESCRIPTION
Builds out the Focus Group module on top of the creation skeleton (#2146): data models, data layer, and a working discussion guide editor with persistence.

## Changes
- `DiscussionTopic` and `FocusGroupConfig` models, integrated into `FocusGroupStudy`
- `FocusGroupController` (reads and persists the discussion guide + config) and a `FocusGroup` Vuex module, registered in the store
- `EditFocusGroupView` + `DiscussionGuideEditor`: add, edit, delete, reorder topics, manage prompts, set durations
- Edit route and "Test" navigation item in the manager view
- EN/ES translations

## Testing
Verified end to end on the Firebase emulator: create a Focus Group study, edit the guide, save, and confirm the `discussionGuide` array and `config` map persist correctly on the `tests` document. Lint clean, i18n parity passes, build succeeds.

## Discussion Guide - Video

https://github.com/user-attachments/assets/88cd767e-74bf-4c1c-92e5-2d1c8592fa10



Closes #2134 
Closes #2135 
Closes #2136 
