### PR TITLE
feat(focus-group): migrate manager view to dashboard layout

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -2162,6 +2162,39 @@
       "addPrompt": "Add prompt",
       "removePrompt": "Remove prompt",
       "duration": "Minutes"
+    },
+    "dashboard": {
+      "typeLabel": "Focus Group",
+      "subtitle": "Manage your discussion guide, participants, and moderated sessions from one dashboard."
+    },
+    "studyOverview": {
+      "topics": "Discussion Topics",
+      "topicsSubtitle": "In the guide",
+      "totalDuration": "Total Duration",
+      "durationSubtitle": "Planned",
+      "maxParticipants": "Max Participants",
+      "perSession": "Per session",
+      "team": "Team",
+      "teamSubtitle": "Facilitators & observers"
+    },
+    "modules": {
+      "guideTitle": "Discussion Guide",
+      "topicCount": "{count} topics",
+      "guideDescription": "{minutes} min planned",
+      "untitledTopic": "Untitled topic",
+      "moreTopics": "+{count} more",
+      "guideEmpty": "No topics yet. Add your first topic in the guide editor.",
+      "manageGuide": "Manage guide",
+      "configTitle": "Session Configuration",
+      "maxParticipantsLabel": "Max participants per session",
+      "waitingRoom": "Waiting room enabled",
+      "consent": "Consent required",
+      "backroom": "Observers hidden from participants",
+      "configure": "Configure",
+      "liveSessionTitle": "Live Session",
+      "liveSessionComingSoon": "Moderated live discussion is coming soon.",
+      "reportsTitle": "Results & Reports",
+      "reportsComingSoon": "Session results and analysis will appear here."
     }
   },
   "studyCreation": {

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -2064,6 +2064,39 @@
       "addPrompt": "Agregar pregunta",
       "removePrompt": "Eliminar pregunta",
       "duration": "Minutos"
+    },
+    "dashboard": {
+      "typeLabel": "Grupo Focal",
+      "subtitle": "Gestiona tu guía de discusión, participantes y sesiones moderadas desde un solo panel."
+    },
+    "studyOverview": {
+      "topics": "Temas de Discusión",
+      "topicsSubtitle": "En la guía",
+      "totalDuration": "Duración Total",
+      "durationSubtitle": "Planificada",
+      "maxParticipants": "Máx. Participantes",
+      "perSession": "Por sesión",
+      "team": "Equipo",
+      "teamSubtitle": "Facilitadores y observadores"
+    },
+    "modules": {
+      "guideTitle": "Guía de Discusión",
+      "topicCount": "{count} temas",
+      "guideDescription": "{minutes} min planificados",
+      "untitledTopic": "Tema sin título",
+      "moreTopics": "+{count} más",
+      "guideEmpty": "Aún no hay temas. Agrega tu primer tema en el editor de la guía.",
+      "manageGuide": "Gestionar guía",
+      "configTitle": "Configuración de la Sesión",
+      "maxParticipantsLabel": "Máx. participantes por sesión",
+      "waitingRoom": "Sala de espera activada",
+      "consent": "Consentimiento requerido",
+      "backroom": "Observadores ocultos a los participantes",
+      "configure": "Configurar",
+      "liveSessionTitle": "Sesión en Vivo",
+      "liveSessionComingSoon": "La discusión moderada en vivo estará disponible pronto.",
+      "reportsTitle": "Resultados e Informes",
+      "reportsComingSoon": "Los resultados y el análisis de la sesión aparecerán aquí."
     }
   },
   "studyCreation": {

--- a/src/shared/utils/statusUtils.js
+++ b/src/shared/utils/statusUtils.js
@@ -20,6 +20,7 @@ export const getStatusColor = (status) => {
     // Success states
     active: 'success',
     completed: 'success',
+    finished: 'success',
     success: 'success',
     pass: 'success',
     accepted: 'success',
@@ -43,6 +44,7 @@ export const getStatusColor = (status) => {
     // Info states
     info: 'info',
     draft: 'info',
+    upcoming: 'info',
   }
 
   return statusMap[statusStr] || 'grey'
@@ -65,6 +67,7 @@ export const getStatusIcon = (status) => {
     // Success states
     active: 'mdi-play-circle',
     completed: 'mdi-check-circle',
+    finished: 'mdi-check-circle',
     success: 'mdi-check-circle',
     pass: 'mdi-check-circle',
     accepted: 'mdi-check-circle',
@@ -88,6 +91,7 @@ export const getStatusIcon = (status) => {
     // Info states
     info: 'mdi-information',
     draft: 'mdi-file-document-outline',
+    upcoming: 'mdi-calendar-clock',
   }
 
   return iconMap[statusStr] || 'mdi-help-circle'
@@ -109,6 +113,8 @@ export const getStatusText = (status) => {
   const textMap = {
     active: 'Active',
     completed: 'Completed',
+    finished: 'Finished',
+    upcoming: 'Upcoming',
     success: 'Success',
     pass: 'Pass',
     accepted: 'Accepted',

--- a/src/ux/FocusGroup/components/manager/StudyOverview.vue
+++ b/src/ux/FocusGroup/components/manager/StudyOverview.vue
@@ -1,0 +1,75 @@
+<template>
+  <v-row>
+    <v-col cols="12" md="6" class="py-0">
+      <ManagerMetricCard
+        :title="t('focusGroup.studyOverview.topics')"
+        :value="topicCount"
+        :subtitle="t('focusGroup.studyOverview.topicsSubtitle')"
+        icon="mdi-format-list-numbered"
+      />
+    </v-col>
+
+    <v-col cols="12" md="6" class="py-0">
+      <ManagerMetricCard
+        :title="t('focusGroup.studyOverview.totalDuration')"
+        :value="t('manager.studyOverview.minUnit', { value: totalDuration })"
+        :subtitle="t('focusGroup.studyOverview.durationSubtitle')"
+        icon="mdi-timer-outline"
+      />
+    </v-col>
+
+    <v-col cols="12" md="6" class="py-0">
+      <ManagerMetricCard
+        :title="t('focusGroup.studyOverview.maxParticipants')"
+        :value="maxParticipants"
+        :subtitle="t('focusGroup.studyOverview.perSession')"
+        icon="mdi-account-group"
+      />
+    </v-col>
+
+    <v-col cols="12" md="6" class="py-0">
+      <ManagerMetricCard
+        :title="t('focusGroup.studyOverview.team')"
+        :value="teamSize"
+        :subtitle="t('focusGroup.studyOverview.teamSubtitle')"
+        icon="mdi-account-multiple-outline"
+      />
+    </v-col>
+  </v-row>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import ManagerMetricCard from '@/shared/components/manager/ManagerMetricCard.vue'
+
+const { t } = useI18n()
+
+const props = defineProps({
+  test: {
+    type: Object,
+    default: () => ({}),
+  },
+})
+
+const discussionGuide = computed(() =>
+  Array.isArray(props.test?.discussionGuide) ? props.test.discussionGuide : [],
+)
+
+const topicCount = computed(() => discussionGuide.value.length)
+
+const totalDuration = computed(() =>
+  discussionGuide.value.reduce(
+    (total, topic) => total + (topic?.durationMinutes || 0),
+    0,
+  ),
+)
+
+const maxParticipants = computed(() => props.test?.config?.maxParticipants ?? '—')
+
+const teamSize = computed(() => {
+  const cooperators = props.test?.cooperators
+  if (!Array.isArray(cooperators)) return 0
+  return cooperators.filter((cooperator) => cooperator.accepted === true).length
+})
+</script>

--- a/src/ux/FocusGroup/views/ManagerView.vue
+++ b/src/ux/FocusGroup/views/ManagerView.vue
@@ -1,58 +1,270 @@
 <template>
   <ManagerView :navigator="navigator" :top-cards="[]" :bottom-cards="[]">
-    <template
-      v-if="$route.path.includes('dashboard') || $route.path.includes('manager')"
-      #default
+    <ManagerDashboardLayout
+      v-if="test"
+      :test="test"
+      :title="test.testTitle || t('focusGroup.dashboard.typeLabel')"
+      :subtitle="test.testDescription || t('focusGroup.dashboard.subtitle')"
+      icon="mdi-account-group"
+      :type-label="t('focusGroup.dashboard.typeLabel')"
+      type-icon="mdi-account-group"
+      :status-icon="getStatusIcon(test.testStatus)"
+      :status-text="test.testStatus || t('manager.dashboard.active')"
+      :modules-title="t('manager.managementModules.title')"
+      :modules-description="t('manager.managementModules.description')"
     >
-      <ManagerBanner :title="test?.testTitle" />
+      <template #overview>
+        <StudyOverview :test="test" />
+      </template>
 
-      <v-container class="card-container">
-        <v-card class="pa-6" elevation="2" rounded="lg">
-          <div class="d-flex align-center mb-4">
-            <v-icon
-              icon="mdi-account-group"
-              color="primary"
-              size="32"
-              class="me-3"
-            />
-            <h2 class="text-h5 font-weight-bold">
-              {{ $t('focusGroup.manager.title') }}
-            </h2>
-          </div>
+      <template #modules>
+        <!-- Discussion guide -->
+        <v-col cols="12" md="6">
+          <v-card class="h-100">
+            <v-card-title class="d-flex align-center justify-space-between">
+              <span>
+                <v-icon start color="primary">mdi-format-list-numbered</v-icon>
+                {{ t('focusGroup.modules.guideTitle') }}
+              </span>
+              <v-chip size="small" color="primary" variant="tonal">
+                {{ t('focusGroup.modules.topicCount', { count: topicCount }) }}
+              </v-chip>
+            </v-card-title>
 
-          <v-alert
-            type="info"
-            variant="tonal"
-            border="start"
-            class="mb-2"
+            <v-card-text>
+              <div v-if="topicCount" class="text-body-2 text-medium-emphasis mb-3">
+                {{
+                  t('focusGroup.modules.guideDescription', {
+                    minutes: totalDuration,
+                  })
+                }}
+              </div>
+
+              <v-list v-if="topicCount" density="compact" class="pa-0">
+                <v-list-item
+                  v-for="(topic, index) in previewTopics"
+                  :key="topic.id || index"
+                  class="px-0"
+                >
+                  <template #prepend>
+                    <span class="text-primary font-weight-bold me-3">
+                      {{ index + 1 }}
+                    </span>
+                  </template>
+                  <v-list-item-title class="text-body-2">
+                    {{ topic.title || t('focusGroup.modules.untitledTopic') }}
+                  </v-list-item-title>
+                </v-list-item>
+              </v-list>
+
+              <div
+                v-if="topicCount > previewTopics.length"
+                class="text-caption text-medium-emphasis mt-1"
+              >
+                {{
+                  t('focusGroup.modules.moreTopics', {
+                    count: topicCount - previewTopics.length,
+                  })
+                }}
+              </div>
+
+              <div v-if="!topicCount" class="text-body-2 text-medium-emphasis">
+                {{ t('focusGroup.modules.guideEmpty') }}
+              </div>
+            </v-card-text>
+
+            <v-card-actions>
+              <v-spacer />
+              <v-btn variant="text" color="primary" size="small" @click="goToEdit">
+                <v-icon start size="16">mdi-pencil-outline</v-icon>
+                {{ t('focusGroup.modules.manageGuide') }}
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+
+        <!-- Session configuration -->
+        <v-col cols="12" md="6">
+          <v-card class="h-100">
+            <v-card-title>
+              <v-icon start color="primary">mdi-cog-outline</v-icon>
+              {{ t('focusGroup.modules.configTitle') }}
+            </v-card-title>
+
+            <v-card-text>
+              <div class="d-flex align-center justify-space-between mb-3">
+                <span class="text-body-2">
+                  {{ t('focusGroup.modules.maxParticipantsLabel') }}
+                </span>
+                <span class="text-body-1 font-weight-bold">
+                  {{ maxParticipants }}
+                </span>
+              </div>
+
+              <v-list density="compact" class="pa-0">
+                <v-list-item
+                  v-for="flag in configFlags"
+                  :key="flag.key"
+                  class="px-0"
+                >
+                  <template #prepend>
+                    <v-icon
+                      :color="flag.enabled ? 'success' : 'grey'"
+                      size="18"
+                      class="me-2"
+                    >
+                      {{ flag.enabled ? 'mdi-check-circle' : 'mdi-minus-circle-outline' }}
+                    </v-icon>
+                  </template>
+                  <v-list-item-title class="text-body-2">
+                    {{ t(flag.label) }}
+                  </v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-card-text>
+
+            <v-card-actions>
+              <v-spacer />
+              <v-btn variant="text" color="primary" size="small" @click="goToSettings">
+                <v-icon start size="16">mdi-tune</v-icon>
+                {{ t('focusGroup.modules.configure') }}
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+
+        <!-- Live session (coming soon) -->
+        <v-col cols="12" md="6">
+          <v-card
+            class="h-100 d-flex align-center justify-center"
+            variant="outlined"
+            style="min-height: 200px"
           >
-            {{ $t('focusGroup.manager.underConstruction') }}
-          </v-alert>
+            <div class="text-center text-grey-lighten-1 pa-4">
+              <v-icon size="48" class="mb-2">mdi-video-outline</v-icon>
+              <p class="text-subtitle-2 mb-1">
+                {{ t('focusGroup.modules.liveSessionTitle') }}
+              </p>
+              <p class="text-body-2 mb-0">
+                {{ t('focusGroup.modules.liveSessionComingSoon') }}
+              </p>
+            </div>
+          </v-card>
+        </v-col>
 
-          <p class="text-body-2 text-grey-darken-1 mt-4 mb-0">
-            {{ $t('focusGroup.manager.description') }}
-          </p>
-        </v-card>
-      </v-container>
-    </template>
+        <!-- Results & reports (coming soon) -->
+        <v-col cols="12" md="6">
+          <v-card
+            class="h-100 d-flex align-center justify-center"
+            variant="outlined"
+            style="min-height: 200px"
+          >
+            <div class="text-center text-grey-lighten-1 pa-4">
+              <v-icon size="48" class="mb-2">mdi-chart-box-outline</v-icon>
+              <p class="text-subtitle-2 mb-1">
+                {{ t('focusGroup.modules.reportsTitle') }}
+              </p>
+              <p class="text-body-2 mb-0">
+                {{ t('focusGroup.modules.reportsComingSoon') }}
+              </p>
+            </div>
+          </v-card>
+        </v-col>
+      </template>
+    </ManagerDashboardLayout>
   </ManagerView>
 </template>
 
 <script setup>
 import ManagerView from '@/shared/views/template/ManagerView.vue'
-import ManagerBanner from '@/shared/components/ManagerBanner.vue'
+import ManagerDashboardLayout from '@/shared/components/manager/ManagerDashboardLayout.vue'
+import StudyOverview from '@/ux/FocusGroup/components/manager/StudyOverview.vue'
 import { ICONS } from '@/shared/constants/theme'
-import { computed, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { getStatusIcon } from '@/shared/utils/statusUtils'
+import { ACCESS_LEVEL } from '@/shared/utils/accessLevel'
+import { computed, onMounted, watchEffect } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
+import { useI18n } from 'vue-i18n'
 
 const store = useStore()
 const route = useRoute()
+const router = useRouter()
+const { t } = useI18n()
 
+const PREVIEW_TOPIC_LIMIT = 4
+
+const user = computed(() => store.getters.user)
 const test = computed(() => store.getters.test)
 
-// Trimmed navigator — only routes that exist in the skeleton module.
-// Edit / Reports / Answers links are added as those views are built.
+const discussionGuide = computed(() =>
+  Array.isArray(test.value?.discussionGuide) ? test.value.discussionGuide : [],
+)
+const topicCount = computed(() => discussionGuide.value.length)
+const previewTopics = computed(() =>
+  discussionGuide.value.slice(0, PREVIEW_TOPIC_LIMIT),
+)
+const totalDuration = computed(() =>
+  discussionGuide.value.reduce(
+    (total, topic) => total + (topic?.durationMinutes || 0),
+    0,
+  ),
+)
+const maxParticipants = computed(() => test.value?.config?.maxParticipants ?? '—')
+
+const configFlags = computed(() => {
+  const config = test.value?.config || {}
+  return [
+    {
+      key: 'waitingRoom',
+      label: 'focusGroup.modules.waitingRoom',
+      enabled: config.enableWaitingRoom === true,
+    },
+    {
+      key: 'consent',
+      label: 'focusGroup.modules.consent',
+      enabled: config.requireConsent === true,
+    },
+    {
+      key: 'backroom',
+      label: 'focusGroup.modules.backroom',
+      enabled: config.hideObservers === true,
+    },
+  ]
+})
+
+const accessLevel = computed(() => {
+  const currentUser = user.value
+  const currentTest = test.value
+  if (!currentUser) return ACCESS_LEVEL.GUEST
+  if (currentUser.accessLevel === 0) return ACCESS_LEVEL.ADMIN
+  if (currentTest?.testAdmin?.userDocId === currentUser.id)
+    return ACCESS_LEVEL.ADMIN
+
+  const coop = currentTest?.cooperators?.find(
+    (c) => c.userDocId === currentUser.id,
+  )
+  if (coop?.accepted === true) return coop.accessLevel
+
+  if (currentTest?.isPublic) return ACCESS_LEVEL.GUEST
+  return null
+})
+
+watchEffect(() => {
+  if (user.value != null && test.value != null) {
+    const hasAccess =
+      accessLevel.value === ACCESS_LEVEL.ADMIN ||
+      accessLevel.value === ACCESS_LEVEL.EVALUATOR ||
+      accessLevel.value === ACCESS_LEVEL.GUEST
+
+    if (!hasAccess || accessLevel.value === null) {
+      router.push('/')
+    }
+  }
+})
+
+// Trimmed navigator — only routes that exist in the module today.
+// Reports / Answers links are added as those views are built.
 const navigator = computed(() => {
   if (!test.value) return []
   return [
@@ -78,6 +290,13 @@ const navigator = computed(() => {
     },
   ]
 })
+
+const goToEdit = () => {
+  router.push(`/focusGroup/edit/${test.value.id}`).catch(() => {})
+}
+const goToSettings = () => {
+  router.push(`/focusGroup/settings/${test.value.id}`).catch(() => {})
+}
 
 onMounted(async () => {
   await store.dispatch('getStudy', { id: route.params.id })

--- a/src/ux/FocusGroup/views/ManagerView.vue
+++ b/src/ux/FocusGroup/views/ManagerView.vue
@@ -8,8 +8,8 @@
       icon="mdi-account-group"
       :type-label="t('focusGroup.dashboard.typeLabel')"
       type-icon="mdi-account-group"
-      :status-icon="getStatusIcon(test.testStatus)"
-      :status-text="test.testStatus || t('manager.dashboard.active')"
+      :status-icon="getStatusIcon(statusValue)"
+      :status-text="t(`studyCreation.details.status.${statusValue}`)"
       :modules-title="t('manager.managementModules.title')"
       :modules-description="t('manager.managementModules.description')"
     >
@@ -196,6 +196,15 @@ const PREVIEW_TOPIC_LIMIT = 4
 
 const user = computed(() => store.getters.user)
 const test = computed(() => store.getters.test)
+
+// Status chip reflects the study's `status` field (set in Settings).
+// Fall back to 'active' for unset/legacy values so the chip always shows a
+// valid, translatable status with a real icon (not the ? fallback).
+const KNOWN_STATUSES = ['active', 'pending', 'finished', 'upcoming']
+const statusValue = computed(() => {
+  const status = test.value?.status
+  return KNOWN_STATUSES.includes(status) ? status : 'active'
+})
 
 const discussionGuide = computed(() =>
   Array.isArray(test.value?.discussionGuide) ? test.value.discussionGuide : [],


### PR DESCRIPTION
## What & Why

Rebuilds the Focus Group manager view on the shared `ManagerDashboardLayout`, with a real study dashboard that is consistent with the User Test and Heuristic manager dashboards.

Builds on the discussion-guide work merged in #2147 and adopts the menu/route renaming from #2154 (`/focusGroup/dashboard/:id`, "Dashboard" nav item).

---

## Changes

- **Study overview metrics** (`StudyOverview.vue`): four metric cards — Discussion Topics, Total Duration (summed from the guide), Max Participants, and Team (accepted cooperators).
- **Management modules**: Discussion Guide card (topic preview + count, links to the guide editor), Session Configuration card (max participants + waiting-room / consent / hidden-observers flags), plus placeholders for Live Session and Results & Reports.
- **Status chip fix**: the dashboard now reads the study's real `status` field (previously read a non-existent `testStatus`, so it was stuck on "Active" and did not reflect changes made in Settings). Status label is translated via the existing `studyCreation.details.status.*` keys.
- **Shared `statusUtils`**: added icon/color/text coverage for the `finished` and `upcoming` statuses (offered in Settings but previously unmapped, so they rendered a fallback `?` icon).
- **i18n**: new Focus Group dashboard strings in `en` and `es`.

---

## Related Images

<img width="3176" height="1804" alt="ManagerViewUpdate" src="https://github.com/user-attachments/assets/117de18f-a390-4276-91bb-27c53a6d6d7d" />


## Notes

- The same `testStatus` field mistake exists in the Heuristic and UserTest dashboards; left out of scope here.