### PR TITLE
fix(i18n): missing status labels and hardcoded session date locale

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -591,13 +591,17 @@
       "recruiting": "Recruiting",
       "paused": "Paused",
       "finished": "Finished",
-      "unknown": "Unknown"
+      "unknown": "Unknown",
+      "pending": "Pending",
+      "upcoming": "Upcoming"
     },
     "officeHours": {
       "title": "Monthly Office Hours",
       "description": "Starting in November, we will host monthly office hours to discuss project updates, answer questions, and connect with our community.",
       "nextSessionDate": "Nov 2025",
-      "frequency": "Monthly"
+      "frequency": "Monthly",
+      "pending": "Pending",
+      "upcoming": "Upcoming"
     },
     "webinar": {
       "ended": "Ended",
@@ -2401,6 +2405,9 @@
     "signOutMessage": "Are you sure you want to sign out?"
   },
   "tags": {
+    "finished": "Finished",
+    "pending": "Pending",
+    "upcoming": "Upcoming",
     "active": "Active",
     "draft": "Draft",
     "completed": "Completed",

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -584,6 +584,8 @@
     "time": "Hora",
     "status": {
       "active": "Activo",
+      "pending": "Pendiente",  
+     "upcoming": "Próximo",
       "recruiting": "Reclutando",
       "paused": "Pausado",
       "finished": "Finalizado",
@@ -2304,6 +2306,9 @@
   },
   "tags": {
     "active": "Activo",
+     "finished": "Finalizado",
+     "pending": "Pendiente",  
+     "upcoming": "Próximo",
     "draft": "Borrador",
     "completed": "Completado",
     "archived": "Archivado",

--- a/src/shared/components/tables/ListComponent.vue
+++ b/src/shared/components/tables/ListComponent.vue
@@ -76,7 +76,7 @@
     </template>
 
     <template #item.testDate="{ item }">
-      {{ formatDateTime(item.testDate, 'es') }}
+      {{ formatDateTime(item.testDate, locale.value) }}
     </template>
 
     <!-- Owner Column -->
@@ -180,7 +180,7 @@ const props = defineProps({
 
 const emit = defineEmits(['clicked', 'preview-clicked'])
 
-const { t } = useI18n()
+const { t,locale } = useI18n()
 
 // Composables
 const typeRef = toRef(props, 'type')


### PR DESCRIPTION
## Summary
Closes #2148.

- Added missing `pending`/`upcoming` keys to the `tags` and `Dashboard.status` i18n namespaces in `en.json`/`es.json` — these existed in the status picker (`studyCreation.details.status`) but were never added to the other two places that render a study's status label, so selecting Pending/Upcoming rendered the raw key (`tags.pending`) on screen in both languages.
- Fixed `ListComponent.vue` hardcoding `'es'` as the locale argument to `formatDateTime` for the session date column, so it always rendered in Spanish regardless of the app's selected language. Now reads the live locale via `useI18n().locale`.

## Test plan
- [x] Ran locally via Docker + Firebase emulators
- [x] Verified Pending/Upcoming status chips now show translated labels (not raw keys) in both English and Spanish
- [x] Verified session date on the Sessions page renders in the app's selected language, not always Spanish
- [x] `npm run lint` passes with no new errors/warnings introduced by this change