### PR TITLE
docs: fix incorrect Prettier config docs in CONTRIBUTING.md and typos in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -430,14 +430,12 @@ npx prettier --write src/your-file.vue
 
 #### Prettier Configuration
 
-RUXAILAB uses Prettier for consistent code formatting. While there's no `.prettierrc` file, Prettier uses sensible defaults:
+RUXAILAB uses Prettier for consistent code formatting. The configuration is defined in the `.prettierrc` file at the project root:
 
-- **Print Width**: 80 characters
-- **Tabs**: 2 spaces (no tabs)
-- **Quotes**: Double quotes for strings
-- **Semicolons**: Enabled
-- **Trailing Commas**: ES5 style (where valid in older JS)
-- **Arrow Functions**: Always add parentheses around parameters
+- **Quotes**: Single quotes for strings (`singleQuote: true`)
+- **Trailing Commas**: All trailing commas (`trailingComma: "all"`)
+- **Semicolons**: Disabled (`semi: false`)
+- **Arrow Functions**: Always add parentheses around parameters (`arrowParens: "always"`)
 
 #### ESLint Configuration
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Then get the url, go to the .env file and add the following sentence:
 VUE_APP_FIREBASE_PYTHON_FUNCTION = 'url'
 ```
 
-If you want to deply the fuction, change your account from spark to blaze, run:
+If you want to deploy the function, change your account from spark to blaze, run:
 
 ```bash
    firebase deploy --only functions


### PR DESCRIPTION
## Summary

This PR fixes **incorrect documentation** in `CONTRIBUTING.md` and **typos** in `README.md`.

### Changes

#### 1. CONTRIBUTING.md — Fix incorrect Prettier configuration documentation

The Prettier Configuration section (line ~433) contained **factually incorrect information**:

- ❌ Claimed *"While there's no `.prettierrc` file"* — but a `.prettierrc` file **does exist** at the project root
- ❌ Documented defaults were **wrong** (double quotes, semicolons enabled, ES5 trailing commas)

**Actual `.prettierrc` settings:**
```json
{
  "singleQuote": true,
  "trailingComma": "all",
  "semi": false,
  "arrowParens": "always"
}

This mismatch misled contributors into writing code with the wrong formatting style.

Fix: Updated the section to accurately reference the .prettierrc file and document its actual settings.

2. README.md — Fix typos in deployment instructions
Line 182: "deply the fuction" → "deploy the function"
Why this matters
New contributors relying on CONTRIBUTING.md would write code with double quotes and semicolons, only to have the pre-commit hooks auto-correct everything — causing confusion and unnecessary formatting churn in PRs.