### PR TITLE
docs: fix incorrect Prettier configuration docs in CONTRIBUTING.md and typos in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -430,14 +430,12 @@ npx prettier --write src/your-file.vue
 
 #### Prettier Configuration
 
-RUXAILAB uses Prettier for consistent code formatting. While there's no `.prettierrc` file, Prettier uses sensible defaults:
+RUXAILAB uses Prettier for consistent code formatting. The configuration is defined in the `.prettierrc` file at the project root:
 
-- **Print Width**: 80 characters
-- **Tabs**: 2 spaces (no tabs)
-- **Quotes**: Double quotes for strings
-- **Semicolons**: Enabled
-- **Trailing Commas**: ES5 style (where valid in older JS)
-- **Arrow Functions**: Always add parentheses around parameters
+- **Quotes**: Single quotes for strings (`singleQuote: true`)
+- **Trailing Commas**: All trailing commas (`trailingComma: "all"`)
+- **Semicolons**: Disabled (`semi: false`)
+- **Arrow Functions**: Always add parentheses around parameters (`arrowParens: "always"`)
 
 #### ESLint Configuration
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Then get the url, go to the .env file and add the following sentence:
 VUE_APP_FIREBASE_PYTHON_FUNCTION = 'url'
 ```
 
-If you want to deply the fuction, change your account from spark to blaze, run:
+If you want to deploy the function, change your account from spark to blaze, run:
 
 ```bash
    firebase deploy --only functions


### PR DESCRIPTION
## Description

Closes #2190

The project documentation contained outdated and incorrect information about the Prettier configuration, which could mislead new contributors regarding the expected code style.

## Changes Made

### CONTRIBUTING.md
- **Fixed incorrect statement**: Removed the claim _"While there's no `.prettierrc` file..."_ — a `.prettierrc` file exists in the project root
- **Updated formatting rules** to match the actual `.prettierrc` configuration:
  - ✅ Single quotes (`singleQuote: true`)
  - ✅ No semicolons (`semi: false`)
  - ✅ Trailing commas everywhere (`trailingComma: "all"`)
  - ✅ Parentheses around arrow function parameters (`arrowParens: "always"`)
- Removed incorrect defaults that were previously documented (double quotes, semicolons enabled, print width, tabs, ES5 trailing commas)

### README.md
- Fixed typo: `deply the fuction` → `deploy the function`

## Why This Matters

Accurate contributor documentation helps developers:
- Follow the correct coding style from the start
- Avoid unnecessary formatting changes in PRs
- Reduce failed formatting checks
- Improve the onboarding experience for new contributors

## Testing

- Verified the `.prettierrc` file exists and matches the documented configuration
- No code logic changes — documentation only
