### PR TITLE
docs: update broken Discord invite link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ UX Remote LAB provides a collaborative environment for creators to share their p
 
 For commercial support, academic collaborations, and answers to common questions, please contact us by one of our communications channels:
 
-- [Discord Server](https://discord.gg/YnkDk9BNYK)
+- [Discord Server](https://discord.gg/Uz6sEsyp2G)
 - [Discussions](https://github.com/ruxailab/RUXAILAB/discussions)
 - Email: `ruxailab@gmail.com`
 


### PR DESCRIPTION
Closes #2168

## Description
The Discord invite link in README.md was expired/invalid, preventing new contributors from joining the community server. Updated it with the working link provided in the issue comments.

## Changes Made
- Replaced `https://discord.gg/YnkDk9BNYK` with `https://discord.gg/Uz6sEsyp2G` in README.md (line 45)

## Verification
- Verified the new Discord invite link (`https://discord.gg/Uz6sEsyp2G`) opens a valid server