### PR TITLE
2160 feature implement sessions module - sessions table on dashboard

### DIFF
--- a/functions/src/https/email.js
+++ b/functions/src/https/email.js
@@ -102,6 +102,7 @@ export const sendEmail = functions.onCall({
           .replace(/{{sessionTitle}}/g, content.data.sessionTitle || '')
           .replace(/{{sessionMessage}}/g, content.data.sessionMessage || '')
           .replace(/{{scheduledAt}}/g, content.data.scheduledAt || '')
+          .replace(/{{invitedBy}}/g, content.data.invitedBy || '')
           .replace(
             /{{sessionLink}}/g,
             content.data.sessionLink || process.env.SITE_URL,

--- a/functions/src/templates/mails/sessionInvite.html
+++ b/functions/src/templates/mails/sessionInvite.html
@@ -70,6 +70,10 @@
               <strong>{{studyTitle}}</strong>.
             </p>
 
+            <p style="margin-bottom: 24px; color: #555">
+              <strong>Invited by:</strong> {{invitedBy}}
+            </p>
+
             <table
               width="100%"
               cellpadding="10"

--- a/src/app/plugins/firebase/FirebaseFirestoreRepository.js
+++ b/src/app/plugins/firebase/FirebaseFirestoreRepository.js
@@ -13,6 +13,7 @@ import {
   limit,
   setDoc,
   deleteField,
+  collectionGroup,
 } from 'firebase/firestore'
 
 /**
@@ -164,6 +165,40 @@ export default class Controller {
 
   async delete(col, docId) {
     return deleteDoc(doc(db, col, docId))
+  }
+
+  /**
+   * Reads documents from a Firestore collection group.
+   *
+   * @param {string} collectionName
+   * @param {Array<Object>} conditions
+   * @returns {Promise<any[]>}
+   *
+   * @example
+   * await controller.readCollectionGroup('sessions', [
+   *   {
+   *     field: 'participantEmails',
+   *     operator: 'array-contains',
+   *     value: email,
+   *   },
+   * ])
+   */
+  async readCollectionGroup(collectionName, conditions = []) {
+    const constraints = conditions.map((condition) =>
+      where(condition.field, condition.operator, condition.value),
+    )
+
+    const q = query(collectionGroup(db, collectionName), ...constraints)
+
+    const snapshot = await getDocs(q)
+
+    return snapshot.docs.map((document) => ({
+      id: document.id,
+      ref: document.ref,
+      path: document.ref.path,
+      parentId: document.ref.parent.parent?.id,
+      ...document.data(),
+    }))
   }
 
   // Utility method to get deleteField for field removal

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -1955,7 +1955,8 @@
         "completed": "Completed",
         "allStudies": "All Studies",
         "myStudies": "My Studies",
-        "whereICollaborate": "Where I Collaborate"
+        "whereICollaborate": "Where I Collaborate",
+        "whereIParticipate": "Where I Participate"
       }
     },
     "templates": {

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -1863,7 +1863,8 @@
         "completed": "Completado",
         "allStudies": "Todos los estudios",
         "myStudies": "Mis estudios",
-        "whereICollaborate": "Donde colaboro"
+        "whereICollaborate": "Donde colaboro",
+        "whereIParticipate": "Donde participo"
       }
     },
     "templates": {

--- a/src/features/navigation/components/navbarSections/SessionsSection.vue
+++ b/src/features/navigation/components/navbarSections/SessionsSection.vue
@@ -2,7 +2,6 @@
   <!-- 🔍 Search + Filters for sessions -->
   <v-card class="mb-4 pa-4 elevation-2 overflow-hidden">
     <div class="d-flex align-center mb-3 flex-wrap button-bar">
-      <!-- Search input -->
       <v-text-field
         v-model="searchSessions"
         prepend-inner-icon="mdi-magnify"
@@ -13,26 +12,16 @@
         class="flex-grow-1"
       />
 
-      <!-- Reset filters button -->
       <v-btn
         color="primary"
         class="search-btn"
         prepend-icon="mdi-filter-remove"
         :disabled="!hasActiveSessionFilters"
-        @click="
-          () => {
-            searchSessions = ''
-            selectedSessionStatusFilter = ['all']
-            selectedSessionOwnershipFilter = 'all'
-            selectedSessionEvaluatorFilter = 'all'
-            selectedSessionDateRange = []
-          }
-        "
+        @click="resetSessionFilters"
       >
         {{ t('pages.sessions.reset') }}
       </v-btn>
 
-      <!-- Toggle filters visibility -->
       <v-btn
         :color="showFilters ? 'primary' : 'grey'"
         variant="tonal"
@@ -40,19 +29,21 @@
         size="small"
         @click="toggleFilters"
       >
-        <v-icon>{{
-          showFilters ? 'mdi-filter-off-outline' : 'mdi-filter-variant'
-        }}</v-icon>
+        <v-icon>
+          {{ showFilters ? 'mdi-filter-off-outline' : 'mdi-filter-variant' }}
+        </v-icon>
       </v-btn>
     </div>
 
-    <!-- Expandable section with filters -->
     <v-expand-transition>
       <div v-show="showFilters">
         <v-row dense>
-          <!-- 👤 Ownership filter -->
-          <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">{{ t('pages.sessions.ownership') }}</div>
+          <!-- Ownership filter -->
+          <v-col cols="12" sm="6" md="4">
+            <div class="filter-label">
+              {{ t('pages.sessions.ownership') }}
+            </div>
+
             <v-select
               v-model="selectedSessionOwnershipFilter"
               :items="ownershipOptions"
@@ -64,25 +55,12 @@
             />
           </v-col>
 
-          <!-- 👥 Evaluator filter -->
-          <v-col cols="12" sm="6" md="3">
-            <div class="filter-label">{{ t('pages.sessions.evaluator') }}</div>
-            <v-select
-              v-model="selectedSessionEvaluatorFilter"
-              :items="evaluatorOptions"
-              item-title="text"
-              item-value="value"
-              density="compact"
-              variant="outlined"
-              hide-details
-            />
-          </v-col>
-
-          <!-- 📅 Session date range filter -->
-          <v-col cols="12" sm="6" md="3">
+          <!-- Date filter -->
+          <v-col cols="12" sm="6" md="4">
             <div class="filter-label">
               {{ t('pages.sessions.sessionDate') }}
             </div>
+
             <v-menu
               :close-on-content-click="false"
               transition="scale-transition"
@@ -110,7 +88,7 @@
                   prepend-inner-icon="mdi-calendar"
                 />
               </template>
-              <!-- Vuetify date picker (supports range mode) -->
+
               <v-date-picker
                 v-model="selectedSessionDateRange"
                 multiple="range"
@@ -118,11 +96,12 @@
             </v-menu>
           </v-col>
 
-          <!-- ⚙️ Status filter -->
-          <v-col cols="12" sm="6" md="3">
+          <!-- Status filter -->
+          <v-col cols="12" sm="6" md="4">
             <div class="filter-label">
               {{ t('pages.sessions.statusLabel') }}
             </div>
+
             <v-select
               v-model="selectedSessionStatusFilter"
               :items="sessionStatusOptions"
@@ -140,16 +119,16 @@
     </v-expand-transition>
   </v-card>
 
-  <!-- 🧾 Session list -->
+  <!-- Session list -->
   <List
     v-if="filteredSessions.length > 0"
     :items="filteredSessions"
     type="sessions"
-    :sort-by="[{ key: 'testDate', order: 'desc' }]"
+    :sort-by="[{ key: 'scheduledAt', order: 'desc' }]"
     @clicked="goTo"
   />
 
-  <!-- 🕓 Empty state (no sessions found) -->
+  <!-- Empty state -->
   <div v-else class="empty-state">
     <div v-if="hasActiveSessionFilters">
       <v-icon
@@ -158,9 +137,16 @@
         color="grey-lighten-1"
         class="mb-2"
       />
-      <div class="text-h6 mt-2">{{ t('common.table.noSearchResults') }}</div>
-      <div class="text-body-2">{{ t('common.table.tryAdjustingSearch') }}</div>
+
+      <div class="text-h6 mt-2">
+        {{ t('common.table.noSearchResults') }}
+      </div>
+
+      <div class="text-body-2">
+        {{ t('common.table.tryAdjustingSearch') }}
+      </div>
     </div>
+
     <div v-else>
       <v-icon
         icon="mdi-clock-remove-outline"
@@ -168,23 +154,22 @@
         color="grey-lighten-1"
         class="mb-2"
       />
-      <p class="text-h6">{{ t('pages.sessions.noActiveSessions') }}</p>
+
+      <p class="text-h6">
+        {{ t('pages.sessions.noActiveSessions') }}
+      </p>
     </div>
   </div>
 </template>
 
 <script setup>
-// ===== Imports =====
 import { ref, computed } from 'vue'
 import { useStore } from 'vuex'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+
 import List from '@/shared/components/tables/ListComponent.vue'
-import { STUDY_TYPES } from '@/shared/constants/methodDefinitions'
-import {
-  getSessionStatus,
-  SESSION_STATUSES,
-} from '@/shared/utils/sessionsUtils'
+import { getSessionStatus } from '@/shared/utils/sessionsUtils'
 import { matchesSearch } from '@/shared/utils/searchUtils'
 
 const { t } = useI18n()
@@ -196,160 +181,159 @@ const props = defineProps({
   },
 })
 
-// ===== State and setup =====
 const store = useStore()
 const router = useRouter()
-const activeSection = ref('dashboard')
 
-// ===== Filter options =====
+const user = computed(() => store.getters.user)
 
-// Ownership dropdown options
-const ownershipOptions = computed(() => [
-  { value: 'all', text: t('pages.sessions.filters.allStudies') },
-  { value: 'mine', text: t('pages.sessions.filters.myStudies') },
-  { value: 'cooperator', text: t('pages.sessions.filters.whereICollaborate') },
-])
-
-// Filter visibility toggle
 const showFilters = ref(false)
-const toggleFilters = () => (showFilters.value = !showFilters.value)
-
-// Selected filter states
-const selectedSessionOwnershipFilter = ref('all')
-const selectedSessionEvaluatorFilter = ref('all')
-const selectedSessionStatusFilter = ref(['all'])
-const selectedSessionDateRange = ref([])
 const searchSessions = ref('')
 
-// Dynamically build evaluator dropdown based on sessions
-const evaluatorOptions = computed(() => {
-  const evaluatorsSet = new Set()
-  props.sessions.forEach((s) => evaluatorsSet.add(s.evaluator))
-  return [
-    { text: t('common.all'), value: 'all' },
-    ...Array.from(evaluatorsSet).map((ev) => ({ text: ev, value: ev })),
-  ]
-})
+const selectedSessionOwnershipFilter = ref('all')
+const selectedSessionStatusFilter = ref(['all'])
+const selectedSessionDateRange = ref([])
 
-// Session status options
-const sessionStatusOptions = computed(() => [
-  { value: 'all', text: t('pages.sessions.filters.allStatuses') },
-  { value: 'today', text: t('pages.sessions.filters.today') },
-  { value: 'upcoming', text: t('pages.sessions.filters.upcoming') },
-  { value: 'completed', text: t('pages.sessions.filters.completed') },
+const toggleFilters = () => {
+  showFilters.value = !showFilters.value
+}
+
+const ownershipOptions = computed(() => [
+  {
+    value: 'all',
+    text: t('pages.sessions.filters.allStudies'),
+  },
+  {
+    value: 'whereICollaborate',
+    text: t('pages.sessions.filters.whereICollaborate'),
+  },
+  {
+    value: 'whereIParticipate',
+    text: t('pages.sessions.filters.whereIParticipate'),
+  },
 ])
 
-// Whether filters are currently active (to enable/disable reset button)
+const sessionStatusOptions = computed(() => [
+  {
+    value: 'all',
+    text: t('pages.sessions.filters.allStatuses'),
+  },
+  {
+    value: 'today',
+    text: t('pages.sessions.filters.today'),
+  },
+  {
+    value: 'upcoming',
+    text: t('pages.sessions.filters.upcoming'),
+  },
+  {
+    value: 'completed',
+    text: t('pages.sessions.filters.completed'),
+  },
+])
+
+const resetSessionFilters = () => {
+  searchSessions.value = ''
+  selectedSessionOwnershipFilter.value = 'all'
+  selectedSessionStatusFilter.value = ['all']
+  selectedSessionDateRange.value = []
+}
+
 const hasActiveSessionFilters = computed(() => {
   return (
     searchSessions.value.length > 0 ||
+    selectedSessionOwnershipFilter.value !== 'all' ||
     (selectedSessionStatusFilter.value.length > 1 &&
       !selectedSessionStatusFilter.value.includes('all')) ||
-    (selectedSessionEvaluatorFilter.value !== 'all' &&
-      selectedSessionEvaluatorFilter.value?.length > 0) ||
-    selectedSessionOwnershipFilter.value !== 'all' ||
-    selectedSessionDateRange.value.length === 2
+    selectedSessionDateRange.value.length > 0
   )
 })
 
-// ===== Main session filtering logic =====
-const user = computed(() => store.getters.user)
+const getSessionOwnership = (session) => {
+  const currentId = user.value?.id
+  const currentEmail = user.value?.email?.toLowerCase()
+
+  const isStaff = session.staff?.some(
+    (staff) =>
+      staff.userDocId === currentId ||
+      staff.email?.toLowerCase() === currentEmail,
+  )
+
+  const isParticipant = session.participants?.some(
+    (participant) =>
+      participant.userDocId === currentId ||
+      participant.email?.toLowerCase() === currentEmail,
+  )
+
+  if (isStaff) {
+    return 'whereICollaborate'
+  }
+
+  if (isParticipant) {
+    return 'whereIParticipate'
+  }
+
+  return 'other'
+}
 
 const filteredSessions = computed(() => {
   return props.sessions.filter((session) => {
-    // 🔍 Search filter
     const matchesSearchQuery = matchesSearch(
-      session.testTitle,
+      `${session.title || ''} ${session.study?.title || ''}`,
       searchSessions.value,
     )
 
-    // ⚙️ Status filter (based on test date)
-    const sessionStatus = getSessionStatus(session.testDate).status
-    const matchesStatus =
-      !selectedSessionStatusFilter.value.length ||
-      selectedSessionStatusFilter.value.includes('all') ||
-      selectedSessionStatusFilter.value.includes(sessionStatus)
+    const status = getSessionStatus(session.scheduledAt).status
 
-    // 👤 Ownership filter
-    const isMine = session.testAdmin.userDocId === user.value?.id
-    const isCooperator = session.userDocId === user.value?.id
-    const ownership = isMine ? 'mine' : isCooperator ? 'cooperator' : 'other'
+    const matchesStatus =
+      selectedSessionStatusFilter.value.includes('all') ||
+      selectedSessionStatusFilter.value.includes(status)
+
+    const ownership = getSessionOwnership(session)
+
     const matchesOwnership =
       selectedSessionOwnershipFilter.value === 'all' ||
       selectedSessionOwnershipFilter.value === ownership
 
-    // 👥 Evaluator filter
-    const matchesEvaluator =
-      selectedSessionEvaluatorFilter.value === 'all' ||
-      selectedSessionEvaluatorFilter.value === session.evaluator
+    let matchesDate = true
 
-    // 📅 Date range filter
-    let inDateRange = true
-    if (selectedSessionDateRange.value.length > 1 && session.testDate) {
-      const date = new Date(session.testDate)
+    if (selectedSessionDateRange.value.length > 1 && session.scheduledAt) {
+      const sessionDate = new Date(session.scheduledAt)
+
       const start = new Date(selectedSessionDateRange.value[0])
+
       const end = new Date(
         selectedSessionDateRange.value[
           selectedSessionDateRange.value.length - 1
         ],
       )
-      inDateRange = date >= start && date <= end
+
+      matchesDate = sessionDate >= start && sessionDate <= end
     }
 
-    // ✅ Final inclusion condition
     return (
-      matchesSearchQuery &&
-      matchesStatus &&
-      matchesOwnership &&
-      matchesEvaluator &&
-      inDateRange
+      matchesSearchQuery && matchesStatus && matchesOwnership && matchesDate
     )
   })
 })
 
-// ===== Navigation logic =====
-const goTo = (test) => {
-  // Open MANUAL accessibility test view
-  if (test.testType === STUDY_TYPES.ACCESSIBILITY_MANUAL) {
-    const baseUrl =
-      activeSection.value === 'studies' ? test.testDocId || test.id : test.id
-    router.push(`/accessibility/manual/${baseUrl}`)
-    return
-  }
-
-  // Open AUTOMATIC accessibility test view
-  if (test.testType === STUDY_TYPES.ACCESSIBILITY_AUTOMATIC) {
-    const baseUrl =
-      activeSection.value === 'studies' ? test.testDocId || test.id : test.id
-    router.push(`/accessibility/automatic/${baseUrl}`)
-    return
-  }
-
-  // Navigate to live session view if available today
-  const canNavigateToSession = (testDate) =>
-    getSessionStatus(testDate) === SESSION_STATUSES.TODAY
-  if (canNavigateToSession(test.testDate)) {
-    router.push(`testview/${test.id}/${user.value.id}`)
-  }
+const goTo = (session) => {
+  router.push(`/testview/${session.id}/${user.value.id}`)
 }
 </script>
 
 <style scoped>
-/* 🧾 Empty state styling */
 .empty-state {
   text-align: center;
   padding: 4rem 2rem;
-  background-color: white;
+  background: white;
   border-radius: 16px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
-/* Filter section button bar */
 .button-bar {
   gap: 14px;
 }
 
-/* Reset/Search button styling */
 .search-btn {
   min-width: 140px;
   height: 40px;
@@ -357,30 +341,12 @@ const goTo = (test) => {
   letter-spacing: 0.3px;
 }
 
-/* Filter label (small uppercase label above inputs) */
 .filter-label {
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 4px;
-  line-height: 1.15;
   color: #475569;
-}
-
-/* Compact filter fields */
-.filter-field :deep(.v-field__input) {
-  min-height: 36px;
-}
-
-/* Utility class to truncate text to 2 lines */
-.truncate-2 {
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  min-height: calc(11px * 1.15 * 2);
-  max-height: calc(11px * 1.15 * 2);
 }
 </style>

--- a/src/features/navigation/views/AdminView.vue
+++ b/src/features/navigation/views/AdminView.vue
@@ -25,15 +25,15 @@
               activeSection === 'studies'
                 ? $t('pages.navigation.studiesSubtitle')
                 : activeSection === 'templates'
-                ? $t('pages.navigation.templatesSubtitle')
-                : ''
+                  ? $t('pages.navigation.templatesSubtitle')
+                  : ''
             }}
           </p>
         </div>
 
         <!-- 🔸 Dynamic rendering of sections -->
         <div v-if="activeSection === 'dashboard'">
-          <DashboardView :items="tests" :sessions="filteredModeratedSessions" />
+          <DashboardView :items="tests" :sessions="sessions" />
         </div>
 
         <div v-if="activeSection === 'studies'">
@@ -41,7 +41,7 @@
         </div>
 
         <div v-if="activeSection === 'sessions'">
-          <SessionsSection :sessions="filteredModeratedSessions" />
+          <SessionsSection :sessions="sessions" />
         </div>
 
         <div v-if="activeSection === 'templates'">
@@ -107,9 +107,6 @@ import CommunityStudies from '../components/navbarSections/CommunityStudiesSecti
 import CommunityTemplatesSection from '../components/navbarSections/CommunityTemplatesSection.vue'
 import StorageSection from '../components/navbarSections/StorageSection.vue'
 
-// Utilities and constants
-import { USER_STUDY_SUBTYPES } from '@/shared/constants/methodDefinitions'
-
 // 🔹 State management
 const store = useStore()
 const router = useRouter()
@@ -124,6 +121,8 @@ const activeSubSection = ref(null)
 // 🔸 Data
 
 let unsubscribeTests = null // Unsub function for real-time tests
+
+const sessions = computed(() => store.getters.sessions || [])
 
 // 🔹 Dynamic page title
 const currentPageTitle = computed(() => {
@@ -179,59 +178,6 @@ const currentPageIcon = computed(() => {
 
 // 🔸 Vuex getters
 const tests = computed(() => store.getters.tests || [])
-const user = computed(() => store.getters.user)
-
-/**
- * 🧮 Filters moderated sessions
- * Creates a list of sessions where the user is either the test admin
- * or a cooperator in a moderated session.
- */
-const filteredModeratedSessions = computed(() => {
-  const cooperatorArray = []
-  if (!tests.value) return []
-
-  tests.value.forEach((testObj) => {
-    if (!testObj) return
-
-    // User as cooperator
-    const cooperatorObj = testObj.cooperators?.find(
-      (coop) => coop.userDocId === user.value?.id,
-    )
-    if (cooperatorObj && testObj.subType === USER_STUDY_SUBTYPES.MODERATED) {
-      cooperatorArray.push({
-        ...cooperatorObj,
-        testTitle: testObj.testTitle,
-        testAdmin: testObj.testAdmin,
-        id: testObj.id,
-        testType: testObj.testType,
-        subType: testObj.subType,
-        testDescription: testObj.testDescription,
-        evaluator: cooperatorObj.email,
-      })
-    }
-
-    // User as test admin
-    if (
-      testObj.testAdmin?.userDocId === user.value?.id &&
-      testObj.subType === USER_STUDY_SUBTYPES.MODERATED
-    ) {
-      testObj.cooperators?.forEach((coop) => {
-        cooperatorArray.push({
-          ...coop,
-          testTitle: testObj.testTitle,
-          testAdmin: testObj.testAdmin,
-          id: testObj.id,
-          testType: testObj.testType,
-          subType: testObj.subType,
-          evaluator: coop.email,
-          testDescription: testObj.testDescription,
-        })
-      })
-    }
-  })
-
-  return cooperatorArray
-})
 
 /**
  * 🧭 Navigation logic
@@ -260,6 +206,7 @@ const getMyPersonalTests = () => store.dispatch('getTestsAdminByUser')
 const getPublicStudies = () => store.dispatch('getPublicStudies')
 const getMyTemplates = () => store.dispatch('getTemplatesOfUser')
 const getPublicTemplates = () => store.dispatch('getPublicTemplates')
+const loadSessions = () => store.dispatch('fetchUserSessions')
 
 /**
  * 🧭 Route watcher
@@ -271,7 +218,7 @@ watch([activeSection, activeSubSection], async ([section, sub]) => {
       await getMyPersonalTests()
       break
     case 'sessions':
-      // filterModeratedSessions()
+      await loadSessions()
       break
     case 'templates':
       await getMyTemplates()
@@ -291,7 +238,7 @@ watch([activeSection, activeSubSection], async ([section, sub]) => {
  */
 onMounted(async () => {
   // unsubscribeTests = await store.dispatch('bindMyTests');
-  await getMyPersonalTests()
+  await Promise.all([getMyPersonalTests(), loadSessions()])
 
   // Load navigation state from query params
   if (route.query.section) {

--- a/src/features/notifications/views/NotificationPage.vue
+++ b/src/features/notifications/views/NotificationPage.vue
@@ -476,11 +476,16 @@ function showAcceptDialog() {
 const handleNotificationClick = async (notification) => {
   if (!notification) return
 
-  const result = await store.dispatch('loadInvite', {
-    token: notification.inviteToken,
-  })
+  if (
+    notification.type === 'Collaboration' &&
+    notification.action === 'invitation'
+  ) {
+    const result = await store.dispatch('loadInvite', {
+      token: notification.inviteToken,
+    })
 
-  invite.value = result.invite
+    invite.value = result.invite
+  }
 
   // If notification has a redirect, use the existing flow
   if (notification.redirectsTo) {

--- a/src/shared/components/dialogs/CreateSessionDialog.vue
+++ b/src/shared/components/dialogs/CreateSessionDialog.vue
@@ -711,29 +711,55 @@ function removeStaff(index) {
 
 // Participants actions
 
-function addExistingParticipant(user) {
+async function addExistingParticipant(user) {
   if (!user) {
     return
   }
 
+  let userDocId = user.userDocId
+
+  if (!userDocId && user.email) {
+    try {
+      const foundUser = await store.dispatch('findUserByEmail', {
+        email: user.email,
+      })
+
+      userDocId = foundUser?.id || foundUser?.userDocId || null
+    } catch {
+      userDocId = null
+    }
+  }
+
   addParticipant({
-    userDocId: user.userDocId,
+    userDocId,
     email: user.email,
   })
 
   selectedParticipant.value = null
 }
 
-function addParticipantEmail() {
-  const email = participantEmailInput.value.trim()
+async function addParticipantEmail() {
+  const email = participantEmailInput.value.trim().toLowerCase()
 
   if (!email) {
     return
   }
 
-  addParticipant({
-    email,
-  })
+  try {
+    const user = await store.dispatch('findUserByEmail', {
+      email,
+    })
+
+    addParticipant({
+      userDocId: user?.id || user?.userDocId || null,
+      email,
+    })
+  } catch {
+    addParticipant({
+      userDocId: null,
+      email,
+    })
+  }
 
   participantEmailInput.value = ''
 }

--- a/src/shared/components/dialogs/CreateSessionDialog.vue
+++ b/src/shared/components/dialogs/CreateSessionDialog.vue
@@ -561,6 +561,8 @@ const cooperators = computed(() => test.value?.cooperators || [])
 
 const isEditMode = computed(() => !!props.session)
 
+const user = computed(() => store.getters.user)
+
 const date = computed({
   get() {
     return sessionDateTime.value
@@ -607,11 +609,28 @@ const formattedDate = computed(() => {
   }).format(date.value)
 })
 
+const availableStaffUsers = computed(() => {
+  const users = [...cooperators.value]
+
+  const isTestAdmin = test.value?.testAdmin?.userDocId === user.value?.id
+
+  const alreadyExists = users.some((item) => item.userDocId === user.value?.id)
+
+  if (isTestAdmin && !alreadyExists) {
+    users.unshift({
+      userDocId: user.value.id,
+      email: user.value.email,
+    })
+  }
+
+  return users
+})
+
 const availableStaff = computed(() =>
-  cooperators.value.filter(
-    (cooperator) =>
+  availableStaffUsers.value.filter(
+    (candidate) =>
       !sessionStaff.value.some(
-        (staff) => staff.userDocId === cooperator.userDocId,
+        (staff) => staff.userDocId === candidate.userDocId,
       ),
   ),
 )

--- a/src/shared/components/tables/ListComponent.vue
+++ b/src/shared/components/tables/ListComponent.vue
@@ -39,18 +39,6 @@
         <div class="text-subtitle-1 font-weight-medium text-on-surface">
           {{ getItemTitle(item) }}
         </div>
-        <!-- <div v-if="type == 'sessions'" class="text-caption text-medium-emphasis">
-          Session Date: {{formatDateTime(item.testDate, 'es')}}
-        </div>
-        <div v-else class="text-caption text-medium-emphasis">
-          <span v-if="item.testAuthorEmail">
-            Last Updated:
-          </span>
-          <span v-else>
-            Creation Date:
-          </span>
-           {{ formatItemDate(item) }}
-        </div> -->
       </div>
     </template>
 
@@ -72,12 +60,8 @@
     </template>
 
     <template #item.creationDate="{ item }">
-  {{ formatItemDate(item) }}
-</template>
-
-    <template #item.testDate="{ item }">
-  {{ formatDateTime(item.testDate, store.getters['Language/lang']) }}
-</template>
+      {{ formatItemDate(item) }}
+    </template>
 
     <!-- Owner Column -->
     <template #item.owner="{ item }">
@@ -90,7 +74,30 @@
 
     <!-- Participants Column -->
     <template #item.participants="{ item }">
+      <!-- Sessions: show participant emails -->
+      <div v-if="type === 'sessions'" class="d-flex flex-wrap align-center">
+        <v-chip
+          v-for="(participant, index) in item.participants || []"
+          :key="participant.userDocId || participant.email || index"
+          size="small"
+          variant="tonal"
+          color="info"
+          class="ma-1"
+        >
+          {{ participant.email }}
+        </v-chip>
+
+        <span
+          v-if="!item.participants?.length"
+          class="text-medium-emphasis text-body-2"
+        >
+          -
+        </span>
+      </div>
+
+      <!-- Other tables: keep participant count -->
       <v-chip
+        v-else
         size="small"
         variant="tonal"
         :color="getParticipantCount(item) > 0 ? 'info' : 'light'"
@@ -100,14 +107,42 @@
       </v-chip>
     </template>
 
+    <!-- Staff Column -->
+    <template #item.staff="{ item }">
+      <div class="d-flex flex-wrap align-center">
+        <v-chip
+          v-for="(staff, index) in item.staff || []"
+          :key="staff.userDocId || staff.email || index"
+          size="small"
+          variant="tonal"
+          color="primary"
+          class="ma-1"
+        >
+          {{ staff.email }} - {{ getStaffRoleLabel(staff.role) }}
+        </v-chip>
+
+        <span
+          v-if="!item.staff?.length"
+          class="text-medium-emphasis text-body-2"
+        >
+          -
+        </span>
+      </div>
+    </template>
+
+    <!-- Session Date Column -->
+    <template #item.scheduledAt="{ item }">
+      {{ formatDateTime(item.scheduledAt, store.getters['Language/lang']) }}
+    </template>
+
     <!-- Status Column -->
     <template #item.status="{ item }">
       <v-chip
         label
         variant="tonal"
-        :color="getSessionStatus(item.testDate).variant"
+        :color="getSessionStatus(item.scheduledAt).variant"
       >
-        {{ getSessionStatus(item.testDate).label }}
+        {{ getSessionStatus(item.scheduledAt).label }}
       </v-chip>
     </template>
 
@@ -180,9 +215,7 @@ const props = defineProps({
 
 const emit = defineEmits(['clicked', 'preview-clicked'])
 
-
 const { t } = useI18n()
-
 
 // Composables
 const typeRef = toRef(props, 'type')
@@ -200,6 +233,7 @@ const {
   getTags,
   getParticipantCount,
   formatItemDate,
+  getStaffRoleLabel,
 } = useItemFormatting(typeRef)
 const { getTypeIcon, getTestType, getAvatarColor } = useItemTypes()
 

--- a/src/shared/composables/useDataTableConfig.js
+++ b/src/shared/composables/useDataTableConfig.js
@@ -74,24 +74,35 @@ export function useDataTableConfig(type, t, options = {}) {
     ]
 
     if (currentType === 'sessions') {
-      baseHeaders.push({
-        title: t('common.table.evaluator'),
-        key: 'evaluator',
-        sortable: true,
-        value: (item) => item.email ?? '',
-      })
-      baseHeaders.push({
-        title: t('common.table.status'),
-        key: 'status',
-        sortable: true,
-        value: (item) => getSessionStatus(item.testDate).status,
-      })
-      baseHeaders.push({
-        title: t('common.table.sessionDate'),
-        key: 'testDate',
-        sortable: true,
-        value: (item) => toSortableTimestamp(item.testDate),
-      })
+      if (currentType === 'sessions') {
+        baseHeaders.push({
+          title: t('Sessions.headers.staff'),
+          key: 'staff',
+          sortable: false,
+          align: 'start',
+        })
+
+        baseHeaders.push({
+          title: t('common.table.participants'),
+          key: 'participants',
+          sortable: false,
+          align: 'start',
+        })
+
+        baseHeaders.push({
+          title: t('common.table.status'),
+          key: 'status',
+          sortable: true,
+          value: (item) => getSessionStatus(item.scheduledAt).status,
+        })
+
+        baseHeaders.push({
+          title: t('common.table.sessionDate'),
+          key: 'scheduledAt',
+          sortable: true,
+          value: (item) => toSortableTimestamp(item.scheduledAt),
+        })
+      }
     }
 
     if (

--- a/src/shared/composables/useItemFormatting.js
+++ b/src/shared/composables/useItemFormatting.js
@@ -11,6 +11,11 @@ export function useItemFormatting(type) {
   const getItemTitle = (item) => {
     if (type.value === 'myTemplates' || type.value === 'publicTemplates')
       return item.header?.templateTitle
+
+    if (type.value === 'sessions') {
+      return item.title || 'Session'
+    }
+
     return item.testTitle ?? item.email ?? 'Untitled'
   }
 
@@ -20,6 +25,14 @@ export function useItemFormatting(type) {
       return (
         item.header?.templateAuthor?.userEmail || t('pages.listTests.unknown')
       )
+
+    if (type.value === 'sessions') {
+      return (
+        item.study.testAdmin?.email ??
+        item.study.testAuthorEmail ??
+        t('pages.listTests.me')
+      )
+    }
     return (
       item.testAdmin?.email ?? item.testAuthorEmail ?? t('pages.listTests.me')
     )
@@ -35,20 +48,32 @@ export function useItemFormatting(type) {
     return item.numberColaborators ?? item.cooperators?.length ?? 0
   }
 
+  const getStaffRoleLabel = (role) => {
+    const roleLabels = {
+      FACILITATOR: t('Sessions.staff.roles.facilitator'),
+      OBSERVER: t('Sessions.staff.roles.observer'),
+    }
+
+    return roleLabels[role] || role
+  }
+
   const formatItemDate = (item) => {
     const date =
-      type.value === 'myTemplates' || type.value === 'publicTemplates'
-        ? item.header?.creationDate
-        : item.creationDate || item.updateDate
+      type.value == 'sessions'
+        ? item.createdAt
+        : type.value === 'myTemplates' || type.value === 'publicTemplates'
+          ? item.header?.creationDate
+          : item.creationDate || item.updateDate
 
     return formatDateLong(date, i18n.locale.value)
   }
 
   const getTags = (item) => {
     const tags = []
+    const study = item.study || item
 
     // method definition
-    const definition = getMethodDefinition(item.testType, item.subType)
+    const definition = getMethodDefinition(study.testType, study.subType)
     if (definition) {
       tags.push({
         label: t(`methods.definitions.${definition.id}`),
@@ -58,7 +83,7 @@ export function useItemFormatting(type) {
     }
 
     // method category (ex: Test / Inquiry / Inspection / Accessibility)
-    const category = getMethodCategory(item)
+    const category = getMethodCategory(study)
     if (category) {
       tags.push({
         label: t(`methods.categories.${category.id}`),
@@ -68,35 +93,35 @@ export function useItemFormatting(type) {
     }
 
     // status
-    if (item.status) {
+    if (study.status) {
       tags.push({
-        label: t(`tags.${item.status}`),
+        label: t(`tags.${study.status}`),
         color:
-          item.status === 'active'
+          study.status === 'active'
             ? 'green'
-            : item.status === 'draft'
+            : study.status === 'draft'
               ? 'orange'
               : 'grey',
         icon:
-          item.status === 'active'
+          study.status === 'active'
             ? 'mdi-check-circle'
-            : item.status === 'draft'
+            : study.status === 'draft'
               ? 'mdi-pencil'
               : 'mdi-clock-outline',
       })
     }
 
     // visibility
-    if (item.isPublic !== undefined) {
+    if (study.isPublic !== undefined) {
       tags.push({
-        label: item.isPublic ? t('tags.public') : t('tags.private'),
-        color: item.isPublic ? 'green' : 'grey',
-        icon: item.isPublic ? 'mdi-earth' : 'mdi-lock',
+        label: study.isPublic ? t('tags.public') : t('tags.private'),
+        color: study.isPublic ? 'green' : 'grey',
+        icon: study.isPublic ? 'mdi-earth' : 'mdi-lock',
       })
     }
 
     // if created from a template
-    if (item.templateDoc) {
+    if (study.templateDoc) {
       tags.push({
         label: t('tags.fromTemplate'),
         color: '#9C27B0',
@@ -105,7 +130,7 @@ export function useItemFormatting(type) {
     }
 
     // has cooperators
-    if (item.cooperators?.length > 0) {
+    if (study.cooperators?.length > 0) {
       tags.push({
         label: t('tags.withCollaborators'),
         color: '#ff6161ff',
@@ -123,5 +148,6 @@ export function useItemFormatting(type) {
     getParticipantCount,
     formatItemDate,
     getTags,
+    getStaffRoleLabel,
   }
 }

--- a/src/shared/composables/useItemTypes.js
+++ b/src/shared/composables/useItemTypes.js
@@ -6,19 +6,20 @@ import {
 
 export function useItemTypes() {
   const getTypeIcon = (item) => {
-    return getMethodIcon(item)
+    return getMethodIcon(item.study || item)
   }
 
   const getTestType = (item) => {
-    const testType = item.testType ?? item.header?.templateType ?? ''
-    const subType = item.subType ?? ''
+    const testType =
+      item.study?.testType ?? item.testType ?? item.header?.templateType ?? ''
+    const subType = item.study?.subType ?? item.subType ?? ''
     const definition = getMethodDefinition(testType, subType)
     return definition?.name ?? ''
   }
 
   // Get color from method definitions
   const getAvatarColor = (item) => {
-    return getMethodColor(item)
+    return getMethodColor(item.study || item)
   }
 
   return {

--- a/src/shared/controllers/SessionController.js
+++ b/src/shared/controllers/SessionController.js
@@ -1,4 +1,5 @@
 import Controller from '@/app/plugins/firebase/FirebaseFirestoreRepository'
+import StudyController from '@/controllers/StudyController'
 
 export default class SessionController extends Controller {
   constructor() {
@@ -106,6 +107,81 @@ export default class SessionController extends Controller {
 
       return {
         success: true,
+      }
+    } catch (error) {
+      return {
+        success: false,
+        error,
+      }
+    }
+  }
+
+  /**
+   * Gets every session where the user participates.
+   *
+   * @param {Object} params
+   * @param {string} params.email
+   * @param {string} params.userId
+   */
+  async getInvitedSessions({ email, userId }) {
+    try {
+      const normalizedEmail = email.toLowerCase()
+
+      const [participantSessions, staffSessions] = await Promise.all([
+        super.readCollectionGroup('sessions', [
+          {
+            field: 'participantEmails',
+            operator: 'array-contains',
+            value: normalizedEmail,
+          },
+        ]),
+        super.readCollectionGroup('sessions', [
+          {
+            field: 'staffIds',
+            operator: 'array-contains',
+            value: userId,
+          },
+        ]),
+      ])
+
+      const sessions = [...participantSessions, ...staffSessions].filter(
+        (session, index, array) =>
+          array.findIndex((item) => item.path === session.path) === index,
+      )
+
+      const studyIds = [
+        ...new Set(sessions.map((session) => session.parentId).filter(Boolean)),
+      ]
+
+      const studies = await Promise.all(
+        studyIds.map((studyId) =>
+          new StudyController().getStudy({ id: studyId }),
+        ),
+      )
+
+      const studiesById = new Map(studies.map((study) => [study.id, study]))
+
+      return {
+        success: true,
+        sessions: sessions.map((session) => ({
+          id: session.id,
+          studyId: session.parentId,
+
+          title: session.title || 'Session',
+          scheduledAt: session.scheduledAt,
+
+          staff: session.staff || [],
+          participants: session.participants || [],
+
+          participantEmails: session.participantEmails || [],
+
+          message: session.message,
+
+          createdAt: session.createdAt,
+          updatedAt: session.updatedAt,
+
+          study: studiesById.get(session.parentId) || null,
+        })),
       }
     } catch (error) {
       return {

--- a/src/shared/store/Session.js
+++ b/src/shared/store/Session.js
@@ -52,7 +52,10 @@ export default {
       commit('setLoading', true)
 
       try {
-        const result = await new SessionController().createSession(payload)
+        const result = await new SessionController().createSession({
+          ...payload,
+          session: enrichSession(payload.session),
+        })
 
         if (!result.success) {
           throw result.error
@@ -118,7 +121,7 @@ export default {
     /**
      * Update session
      */
-    async updateSession({ state, commit, dispatch, getters }, payload) {
+    async updateSession({ state, commit, dispatch }, payload) {
       commit('setLoading', true)
 
       try {
@@ -126,8 +129,10 @@ export default {
           (item) => item.id === payload.sessionId,
         )
 
-        const result = await new SessionController().updateSession(payload)
-
+        const result = await new SessionController().updateSession({
+          ...payload,
+          session: enrichSession(payload.session),
+        })
         if (!result.success) {
           throw result.error
         }
@@ -368,5 +373,57 @@ export default {
         }),
       )
     },
+    /**
+     * Load sessions where the current user was invited.
+     */
+    async fetchUserSessions({ getters, commit }) {
+      commit('setLoading', true)
+
+      try {
+        const user = getters.user
+
+        const result = await new SessionController().getInvitedSessions({
+          email: user.email,
+          userId: user.id,
+        })
+
+        if (!result.success) {
+          throw result.error
+        }
+
+        commit('SET_SESSIONS', result.sessions)
+
+        return result.sessions
+      } catch (error) {
+        commit('setError', {
+          errorCode: 'sessionFetchError',
+          message: error,
+        })
+
+        throw error
+      } finally {
+        commit('setLoading', false)
+      }
+    },
   },
+}
+
+function enrichSession(session) {
+  return {
+    ...session,
+
+    staffIds: [
+      ...new Set(
+        (session.staff || []).map((staff) => staff.userDocId).filter(Boolean),
+      ),
+    ],
+
+    participantEmails: [
+      ...new Set(
+        (session.participants || [])
+          .map((participant) => participant.email?.trim().toLowerCase())
+          .filter(Boolean),
+      ),
+    ],
+  }
 }

--- a/src/shared/store/Session.js
+++ b/src/shared/store/Session.js
@@ -6,6 +6,8 @@
 import SessionController from '@/shared/controllers/SessionController'
 import EmailController from '@/shared/controllers/EmailController'
 import Notification from '@/shared/models/Notification'
+import { formatDateTime } from '../utils/dateUtils'
+import i18n from '@/app/plugins/i18n'
 
 export default {
   state: {
@@ -61,8 +63,11 @@ export default {
         await dispatch('notifySessionMembers', {
           session,
           studyId: payload.studyId,
-          studyTitle: getters.test.title,
-          scheduledAt: session.scheduledAt,
+          studyTitle: payload.study.testTitle,
+          scheduledAt: formatDateTime(
+            session.scheduledAt,
+            i18n.global.locale.value,
+          ),
           members: [...(session.staff || []), ...(session.participants || [])],
         })
 
@@ -149,8 +154,11 @@ export default {
               message: payload.session.message,
             },
             studyId: payload.studyId,
-            studyTitle: payload.study.title,
-            scheduledAt: payload.session.scheduledAt,
+            studyTitle: payload.study.testTitle,
+            scheduledAt: formatDateTime(
+              payload.session.scheduledAt,
+              i18n.global.locale.value,
+            ),
             members: addedMembers,
           })
         }
@@ -305,7 +313,8 @@ export default {
       { session, members, studyId, studyTitle, scheduledAt },
     ) {
       const user = getters.user
-      const author = user?.email || ''
+      const author = `${user.username || ''} ${user.email}`
+      const sessionLink = `${window.location.origin}/testview/${studyId}/${session.id}`
 
       const emailController = new EmailController()
 
@@ -324,9 +333,9 @@ export default {
                 userId: member.userDocId,
                 notification: new Notification({
                   title: session.title,
-                  description: message,
+                  description: session.message,
                   author,
-                  redirectsTo: null,
+                  redirectsTo: sessionLink,
                   testId: studyId,
                   type: 'Session',
                   read: false,
@@ -348,7 +357,8 @@ export default {
                   sessionTitle: session.title,
                   sessionMessage: session.message,
                   scheduledAt,
-                  sessionLink: `${window.location.origin}/testview/${studyId}/${session.id}`,
+                  sessionLink: sessionLink,
+                  invitedBy: author,
                 },
               }),
             )

--- a/src/shared/utils/dateUtils.js
+++ b/src/shared/utils/dateUtils.js
@@ -86,7 +86,8 @@ export const formatDateTime = (date, locale = 'en') => {
       hour: '2-digit',
       minute: '2-digit',
     })
-  } catch {
+  } catch (e) {
+    console.error('Error formatting date-time:', e)
     return INVALID_DATE_FALLBACK
   }
 }

--- a/tests/unit/useDataTableConfig.spec.js
+++ b/tests/unit/useDataTableConfig.spec.js
@@ -7,30 +7,35 @@ describe('useDataTableConfig', () => {
       ref('sessions'),
       (key) => key,
     )
+
     const firstSession = {
       id: 'halo-study',
       email: 'first@example.com',
-      testDate: '2026-07-01T08:38:00.000Z',
+      scheduledAt: '2026-07-01T08:38:00.000Z',
     }
+
     const secondSession = {
       id: 'halo-study',
       email: 'second@example.com',
-      testDate: '2026-07-01T08:38:00.000Z',
+      scheduledAt: '2026-07-01T08:38:00.000Z',
     }
 
     expect(itemValue(firstSession)).not.toBe(itemValue(secondSession))
 
     const statusHeader = headers.value.find(({ key }) => key === 'status')
     const sessionDateHeader = headers.value.find(
-      ({ key }) => key === 'testDate',
+      ({ key }) => key === 'scheduledAt',
     )
 
-    expect(statusHeader.value({
-      ...firstSession,
-      testDate: '2000-01-01T00:00:00.000Z',
-    })).toBe('completed')
+    expect(
+      statusHeader.value({
+        ...firstSession,
+        scheduledAt: '2000-01-01T00:00:00.000Z',
+      }),
+    ).toBe('completed')
+
     expect(sessionDateHeader.value(firstSession)).toBe(
-      new Date(firstSession.testDate).getTime(),
+      new Date(firstSession.scheduledAt).getTime(),
     )
   })
 


### PR DESCRIPTION
## Sessions table update

Updated the sessions table to support the new session data structure stored in Firestore and added the logic required to retrieve sessions related to a user.

### Changes made

- Added a new session query flow to retrieve all sessions where the current user is involved:
  - Searches sessions where the user is a participant using `participantEmails`.
  - Searches sessions where the user is part of the staff using `staffIds`.
  - Merges both results while removing duplicated sessions.
  - Includes the related `studyId` from the session parent document reference to allow retrieving associated study data.

- Updated the table columns to use the current session model:
  - Added **Staff** column displaying session staff members with their roles.
  - Updated **Participants** column to display participant emails as chips for sessions while keeping the existing participant count behavior for other tables.
  - Updated session date handling to use `scheduledAt` instead of the previous `testDate` field.
  - Updated status calculation to use `scheduledAt`.

- Improved session data presentation:
  - Staff members are displayed as chips with the format:
    - `email - role`
  - Participants are displayed as individual chips.
  - Added support for empty states when no staff or participants are available.

- Updated session filtering:
  - Restored the ownership filter based on the current user's relationship with the session.
  - Added support for filtering sessions where the user is a participant.
  - Updated date range filtering to use `scheduledAt`.
  - Updated sorting to use the session scheduled date.

- Updated session table configuration:
  - Added sortable `scheduledAt` column.
  - Added session-specific `staff` and `participants` columns.
  - Updated row key generation to use session fields compatible with the new data structure.

- Updated tests to match the new session schema and fields.

Issue #2160

<img width="1919" height="960" alt="image" src="https://github.com/user-attachments/assets/fb01555c-6326-4e1a-9aa9-d03fbe9febee" />
