### PR TITLE
fix(auth): prevent infinite recursion on VerifyEmail sign out

### DIFF
--- a/src/features/auth/views/VerifyEmailView.vue
+++ b/src/features/auth/views/VerifyEmailView.vue
@@ -72,7 +72,7 @@
 
       <!-- Sign Out Link -->
       <div class="sign-out-link">
-        <button class="link-btn" @click="logout">
+        <button class="link-btn" @click="handleLogout">
           {{ $t('auth.signOut') }}
         </button>
       </div>
@@ -118,7 +118,10 @@ export default {
   },
 
   methods: {
-    ...mapActions(['sendVerificationEmail', 'logout']),
+    ...mapActions({
+      sendVerificationEmail: 'sendVerificationEmail',
+      logoutAction: 'logout',
+    }),
 
     async checkEmailVerificationStatus() {
       try {
@@ -176,9 +179,9 @@ export default {
       this.$router.push('/admin')
     },
 
-    async logout() {
+    async handleLogout() {
       try {
-        await this.logout()
+        await this.logoutAction()
         this.$router.push('/signin')
       } catch {}
     },


### PR DESCRIPTION
This PR fixes #1881.
On the email verification page, clicking Sign Out crashed the app with a stack overflow. The component mapped the Vuex logout action and also defined a method named logout, so this.logout() kept calling itself instead of the store action.
This PR renames the mapped action to logoutAction and the handler to handleLogout, so Sign Out correctly logs the user out and redirects to /signin.

## Changes which I did
- Mapped Vuex logout as logoutAction to avoid the name clash
- Renamed the component method to handleLogout
- Wired the Sign Out button to handleLogout

## Proof of Working
Signed out cleanly, no recursion/stack overflow
<img width="975" height="428" alt="image" src="https://github.com/user-attachments/assets/c2659f04-dc75-43af-bb33-a80ce890b07c" />

I'd be happy to get a feedback or make any further changes if needed.
