### PR TITLE
fix(invite-dialog): guard against null email on clear

### DIFF
--- a/src/shared/components/dialogs/InviteDialog.vue
+++ b/src/shared/components/dialogs/InviteDialog.vue
@@ -25,7 +25,7 @@
             class="ml-2"
             icon
             variant="outlined"
-            :disabled="!emailInput.trim()"
+            :disabled="!emailInput?.trim()"
             @click="addEmailToSelection"
             ><v-icon>mdi-plus</v-icon></v-btn
           >
@@ -295,7 +295,7 @@ const isCoopAlreadySelected = (emailToCheck) => {
 }
 
 const addEmailToSelection = () => {
-  const rawValue = emailInput.value.trim()
+  const rawValue = emailInput.value?.trim()
   if (!rawValue) return
 
   const validationError = getCooperatorInviteValidationError({


### PR DESCRIPTION
Fixes #2239

## What's the problem?
The email input in InviteDialog.vue uses Vuetify's `clearable` prop, which sets the field's model value to `null` when the clear (X) icon is clicked — not an empty string. Two places in the file called `.trim()` directly on that value without checking for null first, so clicking the clear button crashed with:

TypeError: Cannot read properties of null (reading 'trim')

## What changed?
Both call sites now use optional chaining (`?.trim()`) instead of `.trim()`:
- Line 28 (template): the "+" button's `:disabled` check
- Line 298 (script): `addEmailToSelection()`, which runs on Enter or clicking "+"

When the field is null, `?.trim()` safely evaluates to `undefined`, which the existing `if (!rawValue) return` guard already handles correctly — so no new logic was needed, just a safe way to reach the existing empty-input path.

## How I tested
- Reproduced the crash locally (screenshot in issue #2239)
- Confirmed the fix resolves it: click X → no crash
- Confirmed normal flows still work: adding an email via "+" and via Enter, validation errors, duplicate-email warning, and sending an invitation
- Ran `npm run lint` — no new warnings/errors introduced in the changed file

Demonstration of the fix (no error in the console) :

https://github.com/user-attachments/assets/63c06d59-f061-4eb2-9862-ea241188e991

