### PR TITLE
Update Discord invite link in multiple components

### DIFF
--- a/src/shared/components/introduction_cards/IntroAnalytics.vue
+++ b/src/shared/components/introduction_cards/IntroAnalytics.vue
@@ -48,7 +48,7 @@ const goToDoc = () => {
 }
 
 const goToDisc = () => {
-  window.open('https://discord.gg/MFWNpwTq9q', '_blank', 'noopener')
+  window.open('https://discord.gg/Uz6sEsyp2G', '_blank', 'noopener')
 }
 
 const callFunc = (func) => {

--- a/src/shared/components/introduction_cards/IntroAnswer.vue
+++ b/src/shared/components/introduction_cards/IntroAnswer.vue
@@ -48,7 +48,7 @@ const goToDoc = () => {
 }
 
 const goToDisc = () => {
-  window.open('https://discord.gg/MFWNpwTq9q')
+  window.open('https://discord.gg/Uz6sEsyp2G')
 }
 
 const callFunc = (func) => {

--- a/src/shared/components/introduction_cards/IntroCoops.vue
+++ b/src/shared/components/introduction_cards/IntroCoops.vue
@@ -44,7 +44,7 @@ const goToDoc = () => {
 }
 
 const goToDisc = () => {
-  window.open('https://discord.gg/MFWNpwTq9q')
+  window.open('https://discord.gg/Uz6sEsyp2G')
 }
 
 const closeIntro = () => {


### PR DESCRIPTION
This pull request updates the Discord invite link in several introduction card components to use a new URL. This ensures all links direct users to the correct Discord server.

**Discord invite link update:**

* Updated the Discord invite link from `https://discord.gg/MFWNpwTq9q` to `https://discord.gg/Uz6sEsyp2G` in the following files and components:
  * `IntroAnalytics.vue` (`goToDisc` function)
  * `IntroAnswer.vue` (`goToDisc` function)
  * `IntroCoops.vue` (`goToDisc` function)
  
  fixes issue  #2237