### PR TITLE
2161 task review invitation redirects by role

### DIFF
--- a/functions/src/https/invite.js
+++ b/functions/src/https/invite.js
@@ -95,6 +95,8 @@ export const resolveInvite = functions.onCall({
         email: invite.email ?? null,
         isPublic: !!invite.isPublic,
         requiredLogin: !!invite.requiredLogin,
+        accessLevel: invite.accessLevel,
+        membershipType: invite.membershipType,
       },
     }
   },
@@ -132,17 +134,33 @@ export const validateInvite = functions.onCall({
 
       // private invites should be used only once, so if they have been accepted, they are not valid anymore
       if (!dataInvite.isPublic && dataInvite.acceptedAt) {
-        throw new functions.https.HttpsError(
-          'failed-precondition',
-          'Invite already used',
-        )
+        return {
+          valid: false,
+          invite: {
+            id: doc.id,
+            studyId: dataInvite.studyId,
+            studyTitle: dataInvite.studyTitle,
+            email: dataInvite.email ?? null,
+            isPublic: !!dataInvite.isPublic,
+            requiredLogin: !!dataInvite.requiredLogin,
+            membershipType: dataInvite.membershipType,
+          },
+        }
       }
 
       if (expired) {
-        throw new functions.https.HttpsError(
-          'failed-precondition',
-          'Invite expired',
-        )
+        return {
+          valid: false,
+          invite: {
+            id: doc.id,
+            studyId: dataInvite.studyId,
+            studyTitle: dataInvite.studyTitle,
+            email: dataInvite.email ?? null,
+            isPublic: !!dataInvite.isPublic,
+            requiredLogin: !!dataInvite.requiredLogin,
+            membershipType: dataInvite.membershipType,
+          },
+        }
       }
 
       return {

--- a/functions/src/https/studyMembership.js
+++ b/functions/src/https/studyMembership.js
@@ -360,43 +360,68 @@ export const manageStudyMembership = functions.onCall({
         }
 
         /*
-         |--------------------------------------------------------------------------
-         | ACCEPT INVITATION
-         |--------------------------------------------------------------------------
-         */
+        |--------------------------------------------------------------------------
+        | ACCEPT INVITATION
+        |--------------------------------------------------------------------------
+        */
         if (action === 'accept') {
           const targetDoc = participantsSnapshot.docs.find((doc) => {
             const participant = doc.data()
 
             return (
               !InviteUtils.isAccepted(participant) &&
-              (participant?.userDocId === actorId ||
+              (participant?.userDocId === targetUserId ||
+                participant?.userDocId === actorId ||
                 sameEmail(participant?.email, actorEmail))
             )
           })
 
-          if (!targetDoc) {
-            throw error(
-              'permission-denied',
-              'No participant invitation matches this account',
-            )
-          }
-
-          const target = targetDoc.data()
           const now = Date.now()
+          let participant
+          let participantId
 
-          const participant = {
-            ...target,
-            userDocId: actorId,
-            accepted: true,
-            updateDate: now,
-            acceptedDate: now,
-            status: INVITE_STATUS.ACCEPTED,
+          if (targetDoc) {
+            // Existing private invitation
+            participant = {
+              ...targetDoc.data(),
+              userDocId: actorId,
+              accepted: true,
+              updateDate: now,
+              acceptedDate: now,
+              status: INVITE_STATUS.ACCEPTED,
+            }
+
+            participantId = targetDoc.id
+
+            transaction.update(targetDoc.ref, participant)
+          } else {
+            // Public invitation
+            if (!targetUserId) {
+              throw error(
+                'permission-denied',
+                'A user ID is required to accept a public participant invitation',
+              )
+            }
+
+            participant = {
+              userDocId: targetUserId,
+              email: actorEmail || null,
+              accessLevel: role,
+              accepted: true,
+              acceptedDate: now,
+              updateDate: now,
+              status: INVITE_STATUS.ACCEPTED,
+            }
+
+            const participantRef = participantsRef.doc()
+
+            participantId = participantRef.id
+
+            transaction.set(participantRef, participant)
           }
 
           studyRoleMap[actorId] = participant.accessLevel
 
-          transaction.update(targetDoc.ref, participant)
           transaction.update(studyRef, {
             studyRoleMap,
           })
@@ -412,7 +437,7 @@ export const manageStudyMembership = functions.onCall({
               subType: study.subType || null,
               testTitle: study.testTitle || '',
               total: 0,
-              updateDate: Date.now(),
+              updateDate: now,
             },
           })
 
@@ -431,7 +456,7 @@ export const manageStudyMembership = functions.onCall({
           return {
             status: 'accepted',
             participant: {
-              id: targetDoc.id,
+              id: participantId,
               ...participant,
             },
           }
@@ -704,11 +729,10 @@ export const manageStudyMembership = functions.onCall({
       }
 
       /*
-       |--------------------------------------------------------------------------
-       | ACCEPT INVITATION
-       |--------------------------------------------------------------------------
-       */
-
+      |--------------------------------------------------------------------------
+      | ACCEPT INVITATION
+      |--------------------------------------------------------------------------
+      */
       if (action === 'accept') {
         const index = cooperators.findIndex(
           (cooperator) =>
@@ -717,22 +741,47 @@ export const manageStudyMembership = functions.onCall({
               sameEmail(cooperator?.email, actorEmail)),
         )
 
-        if (index < 0) {
-          throw error('permission-denied', 'No invitation matches this account')
-        }
-
         const now = Date.now()
 
-        const membership = {
-          ...cooperators[index],
-          userDocId: actorId,
-          accepted: true,
-          updateDate: now,
-          acceptedDate: now,
-          status: INVITE_STATUS.ACCEPTED,
-        }
+        let membership
 
-        cooperators[index] = membership
+        if (index >= 0) {
+          // Existing invitation
+          membership = {
+            ...cooperators[index],
+            userDocId: actorId,
+            accepted: true,
+            updateDate: now,
+            acceptedDate: now,
+            status: INVITE_STATUS.ACCEPTED,
+          }
+
+          cooperators[index] = membership
+        } else {
+          console.log('accepting public invitation', role)
+          // Public invite: create the cooperator membership
+          const accessLevel = role
+
+          if (accessLevel === null) {
+            throw error(
+              'invalid-argument',
+              'A role is required to accept a public invitation',
+            )
+          }
+
+          membership = {
+            userDocId: actorId,
+            email: actorEmail || null,
+            accessLevel,
+            accepted: true,
+            status: INVITE_STATUS.ACCEPTED,
+            createdDate: now,
+            updateDate: now,
+            acceptedDate: now,
+          }
+
+          cooperators.push(membership)
+        }
 
         studyRoleMap[actorId] = membership.accessLevel
 
@@ -752,7 +801,7 @@ export const manageStudyMembership = functions.onCall({
             subType: study.subType || null,
             testTitle: study.testTitle || '',
             total: 0,
-            updateDate: Date.now(),
+            updateDate: now,
           },
         })
 
@@ -765,6 +814,7 @@ export const manageStudyMembership = functions.onCall({
           targetType: 'cooperator',
           details: {
             role: membership.accessLevel,
+            publicInvite: index < 0,
           },
         })
 

--- a/src/controllers/StudyController.js
+++ b/src/controllers/StudyController.js
@@ -131,6 +131,9 @@ export default class StudyController extends Controller {
           studyId: payload.studyId ?? payload.test?.id,
           action: 'accept',
           membershipType: payload.membershipType,
+          targetUserId: payload?.cooperator.id,
+          targetEmail: payload?.cooperator.email,
+          role: payload.role,
         },
       )
     return response.data

--- a/src/features/dashboard/components/ActiveStudies.vue
+++ b/src/features/dashboard/components/ActiveStudies.vue
@@ -159,6 +159,7 @@ import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 import { useI18n } from 'vue-i18n'
+import { STUDY_ROLE } from '../../../shared/utils/studyAccessPolicy'
 
 const { t } = useI18n()
 
@@ -317,7 +318,11 @@ const canManageStudy = (study) => {
   if (currentUser.accessLevel === 0) return true
   if (study.testAdmin?.userDocId === currentUser.id) return true
   const coop = study.cooperators?.find((c) => c.userDocId === currentUser.id)
-  return coop?.accessLevel === 0 || coop?.accessLevel === 1
+  return (
+    coop?.accessLevel === STUDY_ROLE.ADMIN ||
+    coop?.accessLevel === STUDY_ROLE.EVALUATOR ||
+    coop?.accessLevel === STUDY_ROLE.MANAGER
+  )
 }
 
 const goToStudy = async (study) => {

--- a/src/features/navigation/components/NotificationButton.vue
+++ b/src/features/navigation/components/NotificationButton.vue
@@ -165,10 +165,12 @@ const goToNotificationRedirect = async (notification) => {
       token: notification.inviteToken,
     })
 
-    invite.value = result.invite
+    if (result != null) {
+      invite.value = result.invite
+    }
   }
 
-  if (notification.type === 'Collaboration') {
+  if (notification.type === 'Collaboration' && invite.value) {
     const accepted = await showAcceptDialog()
 
     if (!accepted) {

--- a/src/features/navigation/components/NotificationButton.vue
+++ b/src/features/navigation/components/NotificationButton.vue
@@ -188,8 +188,6 @@ const goToNotificationRedirect = async (notification) => {
 
     const token = notification.inviteToken
 
-    console.log('Accepting invite:', invite.value)
-
     await store.dispatch('acceptInvite', {
       token,
       user: user.value,

--- a/src/features/navigation/components/navbarSections/StudiesSection.vue
+++ b/src/features/navigation/components/navbarSections/StudiesSection.vue
@@ -201,6 +201,7 @@ import {
   USER_STUDY_SUBTYPES,
 } from '@/shared/constants/methodDefinitions'
 import { matchesSearch } from '@/shared/utils/searchUtils'
+import { STUDY_ROLE } from '@/shared/utils/studyAccessPolicy'
 
 // ===== Setup =====
 const store = useStore()
@@ -379,6 +380,15 @@ const filteredTests = computed(() => {
 
 // ===== Navigation =====
 const goTo = (test) => {
+  const userId = user.value?.id
+  const studyId = test.id
+  const userRole = test.studyRoleMap?.[userId]
+
+  if (userRole === STUDY_ROLE.USER) {
+    router.push(`/testview/${studyId}/${userId}`)
+    return
+  }
+
   // Handle manual/automatic studies
   if (test.testType === STUDY_TYPES.ACCESSIBILITY_MANUAL) {
     router.push(`/accessibility/manual/${test.testDocId || test.id}`)

--- a/src/features/notifications/views/NotificationPage.vue
+++ b/src/features/notifications/views/NotificationPage.vue
@@ -494,13 +494,12 @@ const goToNotificationRedirect = async (notification) => {
       token: notification.inviteToken,
     })
 
-    invite.value = result.invite
+    if (result != null) {
+      invite.value = result.invite
+    }
   }
 
-  if (
-    notification.type === 'Collaboration' ||
-    notification.action === 'invitation'
-  ) {
+  if (notification.type === 'Collaboration' && invite.value) {
     const accepted = await showAcceptDialog()
 
     if (!accepted) {

--- a/src/shared/components/dialogs/GenerateInviteLinkDialog.vue
+++ b/src/shared/components/dialogs/GenerateInviteLinkDialog.vue
@@ -142,13 +142,12 @@ const generateLink = async () => {
     const result = await InviteController.generateInvitationLink({
       studyId: props.studyId,
       studyTitle: props.studyTitle,
-      accessLevel: selectedRole.value,
+      accessLevel: selectedRole.value ?? props.preDefinedRole,
       requiredLogin: props.requiredLogin,
       toEmail: null, // No email provided for public invites
       isPublic: true,
       membershipType: props.membershipType,
     })
-
     inviteLink.value = result.inviteLink
 
     emit('generated', result.inviteLink)

--- a/src/shared/components/dialogs/GenerateInviteLinkDialog.vue
+++ b/src/shared/components/dialogs/GenerateInviteLinkDialog.vue
@@ -70,21 +70,19 @@ import { ref, watch, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import InviteController from '@/shared/controllers/InviteController'
-import { useCooperatorUtils } from '@/shared/composables/useCooperatorUtils'
 import { showSuccess } from '@/shared/utils/toast'
 import { STUDY_ROLE } from '@/shared/utils/studyAccessPolicy'
 
 const { t } = useI18n()
-const { roleOptions } = useCooperatorUtils()
 
 const COOPERATOR_HIDDEN_ROLES = [STUDY_ROLE.USER, STUDY_ROLE.EVALUATOR]
 
 const visibleRoleOptions = computed(() => {
   if (props.membershipType !== 'cooperator') {
-    return roleOptions.value
+    return props.roleOptions
   }
 
-  return roleOptions.value.filter(
+  return props.roleOptions.filter(
     ({ value }) => !COOPERATOR_HIDDEN_ROLES.includes(value),
   )
 })
@@ -113,6 +111,10 @@ const props = defineProps({
   membershipType: {
     type: String,
     required: true,
+  },
+  roleOptions: {
+    type: Array,
+    default: () => [],
   },
 })
 

--- a/src/shared/components/dialogs/PendingInviteDialog.vue
+++ b/src/shared/components/dialogs/PendingInviteDialog.vue
@@ -24,6 +24,10 @@ import { onMounted, ref, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 import ConfirmDialog from '@/shared/components/dialogs/ConfirmDialog.vue'
+import {
+  getMethodManagerView,
+  normalizeStudyType,
+} from '@/shared/constants/methodDefinitions'
 
 const router = useRouter()
 const store = useStore()
@@ -52,10 +56,30 @@ const acceptInvite = async () => {
     dialogHandled.value = true
     show.value = false
 
+    const testId = result.study.id
+
+    if (invite.value.membershipType === 'participant') {
+      router.push({
+        name: 'TestView',
+        params: {
+          id: testId,
+        },
+      })
+
+      return
+    }
+
+    const normalizedTestType = normalizeStudyType(result.study.testType)
+
+    const methodView = getMethodManagerView(
+      normalizedTestType,
+      result.study.subType,
+    )
+
     router.push({
-      name: 'TestView',
+      name: methodView,
       params: {
-        id: result.study.id,
+        id: testId,
       },
     })
   } finally {

--- a/src/shared/store/Invite.js
+++ b/src/shared/store/Invite.js
@@ -402,6 +402,7 @@ export default {
           test: study,
           cooperator: user,
           membershipType,
+          role: result.invite.accessLevel,
         })
 
         localStorage.removeItem('pendingInviteToken')
@@ -536,7 +537,7 @@ export default {
       const result = await InviteController.validateInvite(token)
 
       if (!result.valid) {
-        throw new Error(result.message || 'Invalid invitation')
+        return null
       }
 
       let user = rootGetters.user

--- a/src/shared/utils/studyAccessPolicy.js
+++ b/src/shared/utils/studyAccessPolicy.js
@@ -142,19 +142,29 @@ export function resolveStudyAccess(study, user) {
   const userId = getUserId(user)
   const isOwner = isStudyOwner(study, userId)
   const isSuperAdmin = user?.accessLevel === 0
-  let membership = findAcceptedMembership(study, userId)
+
+  const membership = findAcceptedMembership(study, userId)
+
+  const roleFromMap =
+    userId && study?.studyRoleMap?.[userId] !== undefined
+      ? study.studyRoleMap[userId]
+      : null
+
   let role = null
 
-  if (isOwner || isSuperAdmin) role = R.ADMIN
-  else if (membership) role = membership.accessLevel ?? null
-  else if (study?.studyRoleMap?.[userId] !== undefined) {
-    role = study.studyRoleMap[userId] ?? null
+  if (isOwner || isSuperAdmin) {
+    role = R.ADMIN
+  } else if (membership) {
+    role = membership.accessLevel ?? null
+  } else if (roleFromMap !== null) {
+    role = roleFromMap
   }
+
   return {
     role,
     isOwner,
     isSuperAdmin,
-    isAcceptedMember: Boolean(membership),
+    isAcceptedMember: Boolean(membership || roleFromMap !== null),
     isPublicParticipant: Boolean(userId && study?.isPublic),
     membership,
   }

--- a/src/shared/views/CooperatorsView.vue
+++ b/src/shared/views/CooperatorsView.vue
@@ -119,6 +119,7 @@
       :study-title="test?.testTitle"
       :required-login="true"
       :membership-type="'cooperator'"
+      :role-options="assignableRoleOptions"
     />
 
     <!-- Confirmation Dialog -->
@@ -143,7 +144,7 @@
           <v-chip
             :color="
               getRoleColor(
-                roleOptions.find(
+                assignableRoleOptions.find(
                   (r) => r.value === roleDialog.item?.accessLevel,
                 )?.title,
               )
@@ -154,7 +155,7 @@
             <v-icon start size="16">
               {{
                 getRoleIcon(
-                  roleOptions.find(
+                  assignableRoleOptions.find(
                     (r) => r.value === roleDialog.item?.accessLevel,
                   )?.title,
                 )
@@ -162,8 +163,9 @@
             </v-icon>
 
             {{
-              roleOptions.find((r) => r.value === roleDialog.item?.accessLevel)
-                ?.title
+              assignableRoleOptions.find(
+                (r) => r.value === roleDialog.item?.accessLevel,
+              )?.title
             }}
           </v-chip>
 
@@ -172,7 +174,7 @@
           <v-select
             v-model="roleDialog.newRole"
             :items="
-              roleOptions.filter(
+              assignableRoleOptions.filter(
                 (r) => r.value !== roleDialog.item?.accessLevel,
               )
             "
@@ -253,7 +255,7 @@ const store = useStore()
 const route = useRoute()
 const { t } = useI18n()
 
-const { roleOptions, getRoleColor, getRoleIcon } = useCooperatorUtils()
+const { getRoleColor, getRoleIcon } = useCooperatorUtils()
 
 const confirmDialog = ref({
   show: false,
@@ -546,7 +548,9 @@ const handleSendInvitations = async ({
 const changeRole = (item) => {
   roleDialog.value = {
     item,
-    newRole: roleOptions.value.find((r) => r.value !== item.accessLevel),
+    newRole: assignableRoleOptions.value.find(
+      (r) => r.value !== item.accessLevel,
+    ),
   }
 
   confirmDialog.value = {

--- a/src/shared/views/public/InviteView.vue
+++ b/src/shared/views/public/InviteView.vue
@@ -131,6 +131,10 @@ import { onMounted, ref, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import store from '@/store'
 import { useI18n } from 'vue-i18n'
+import {
+  getMethodManagerView,
+  normalizeStudyType,
+} from '@/shared/constants/methodDefinitions'
 
 const { t } = useI18n()
 
@@ -178,7 +182,32 @@ const acceptInvite = async () => {
       membershipType: invite.value.membershipType,
     })
 
-    router.replace(`/testview/${result.study.id}`)
+    const testId = result.study.id
+
+    if (invite.value.membershipType === 'participant') {
+      router.push({
+        name: 'TestView',
+        params: {
+          id: testId,
+        },
+      })
+
+      return
+    }
+
+    const normalizedTestType = normalizeStudyType(result.study.testType)
+
+    const methodView = getMethodManagerView(
+      normalizedTestType,
+      result.study.subType,
+    )
+
+    router.push({
+      name: methodView,
+      params: {
+        id: testId,
+      },
+    })
   } catch (err) {
     error.value =
       err?.response?.data?.message || err?.message || t('invite.acceptFailed')

--- a/tests/unit/StudyController.spec.js
+++ b/tests/unit/StudyController.spec.js
@@ -1,464 +1,595 @@
 import StudyController from '@/controllers/StudyController'
-import { createControllerSpies} from './helpers/testUtils'
+import { createControllerSpies } from './helpers/testUtils'
 import { FirebaseFunctionsController } from '@/app/plugins/firebase/FirebaseFunctionsService'
 
 jest.mock('@/app/plugins/firebase/FirebaseFunctionsService', () => ({
-    FirebaseFunctionsController: {
-        callHttpsCallableFunction: jest.fn()
-    }
+  FirebaseFunctionsController: {
+    callHttpsCallableFunction: jest.fn(),
+  },
 }))
 
 const mockCallHttpsCallableFunction =
-    FirebaseFunctionsController.callHttpsCallableFunction
+  FirebaseFunctionsController.callHttpsCallableFunction
 
 jest.mock('firebase/firestore', () => ({
-    doc: jest.fn(),
-    onSnapshot: jest.fn(),
-    updateDoc: jest.fn(),
-    collection: jest.fn(),
-    getDocs: jest.fn(),
-    getDoc: jest.fn(),
-    deleteDoc: jest.fn(),
-    increment: jest.fn((val) => ({ _increment: val }))
+  doc: jest.fn(),
+  onSnapshot: jest.fn(),
+  updateDoc: jest.fn(),
+  collection: jest.fn(),
+  getDocs: jest.fn(),
+  getDoc: jest.fn(),
+  deleteDoc: jest.fn(),
+  increment: jest.fn((val) => ({ _increment: val })),
 }))
 
 jest.mock('@/app/plugins/firebase', () => ({
-    db: {}
+  db: {},
 }))
 
 jest.mock('@/shared/controllers/AnswerController', () => {
-    return jest.fn().mockImplementation(() => ({
-        createAnswer: jest.fn(),
-        updateUserAnswer: jest.fn(),
-        removeUserAnswer: jest.fn()
-    }))
+  return jest.fn().mockImplementation(() => ({
+    createAnswer: jest.fn(),
+    updateUserAnswer: jest.fn(),
+    removeUserAnswer: jest.fn(),
+  }))
 })
 
 jest.mock('@/features/auth/controllers/UserController', () => {
-    return jest.fn().mockImplementation(() => ({
-        removeTestFromUser: jest.fn(),
-        removeNotificationsForTest: jest.fn(),
-        update: jest.fn(),
-        getById: jest.fn()
-    }))
+  return jest.fn().mockImplementation(() => ({
+    removeTestFromUser: jest.fn(),
+    removeNotificationsForTest: jest.fn(),
+    update: jest.fn(),
+    getById: jest.fn(),
+  }))
 })
 
 jest.mock('@/features/auth/models/UserAnswer', () => {
-    return jest.fn().mockImplementation((data) => ({
-        ...data,
-        toFirestore: jest.fn().mockReturnValue(data)
-    }))
+  return jest.fn().mockImplementation((data) => ({
+    ...data,
+    toFirestore: jest.fn().mockReturnValue(data),
+  }))
 })
 
 jest.mock('@/shared/models/StudyAnswer', () => {
-    return jest.fn().mockImplementation((data) => ({
-        ...data,
-        toFirestore: jest.fn().mockReturnValue(data)
-    }))
+  return jest.fn().mockImplementation((data) => ({
+    ...data,
+    toFirestore: jest.fn().mockReturnValue(data),
+  }))
 })
 
 jest.mock('@/shared/constants/methodDefinitions', () => ({
-    instantiateStudyByType: jest.fn((type, data) => ({
-        ...data,
-        testType: type
-    }))
+  instantiateStudyByType: jest.fn((type, data) => ({
+    ...data,
+    testType: type,
+  })),
 }))
 
 describe('StudyController', () => {
-    let studyController
-    let spies
-    let mockAnswerController
-    let mockUserController
+  let studyController
+  let spies
+  let mockAnswerController
+  let mockUserController
 
-    beforeEach(() => {
-        jest.clearAllMocks()
-        mockCallHttpsCallableFunction.mockResolvedValue({ data: { status: 'ok' } })
-        
-        // Setup mocks for injected dependencies
-        const AnswerController = require('@/shared/controllers/AnswerController')
-        const UserController = require('@/features/auth/controllers/UserController')
-        
-        mockAnswerController = {
-            createAnswer: jest.fn().mockResolvedValue({ id: 'answer-default' })
-        }
-        
-        mockUserController = {
-            removeTestFromUser: jest.fn().mockResolvedValue(),
-            removeNotificationsForTest: jest.fn().mockResolvedValue(),
-            update: jest.fn().mockResolvedValue(),
-            getById: jest.fn().mockResolvedValue()
-        }
-        
-        AnswerController.mockImplementation(() => mockAnswerController)
-        UserController.mockImplementation(() => mockUserController)
-        
-        studyController = new StudyController()
-        spies = createControllerSpies(studyController)
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockCallHttpsCallableFunction.mockResolvedValue({
+      data: { status: 'ok' },
     })
 
-    afterEach(() => {
-        spies.restore()
+    const AnswerController = require('@/shared/controllers/AnswerController')
+    const UserController = require('@/features/auth/controllers/UserController')
+
+    mockAnswerController = {
+      createAnswer: jest.fn().mockResolvedValue({ id: 'answer-default' }),
+    }
+
+    mockUserController = {
+      removeTestFromUser: jest.fn().mockResolvedValue(),
+      removeNotificationsForTest: jest.fn().mockResolvedValue(),
+      update: jest.fn().mockResolvedValue(),
+      getById: jest.fn().mockResolvedValue(),
+    }
+
+    AnswerController.mockImplementation(() => mockAnswerController)
+    UserController.mockImplementation(() => mockUserController)
+
+    studyController = new StudyController()
+    spies = createControllerSpies(studyController)
+  })
+
+  afterEach(() => {
+    spies.restore()
+  })
+
+  describe('Structure', () => {
+    it('should have createStudy method', () => {
+      expect(typeof studyController.createStudy).toBe('function')
     })
 
-    describe('Structure', () => {
-        it('should have createStudy method', () => {
-            expect(typeof studyController.createStudy).toBe('function')
-        })
-
-        it('should have duplicateStudy method', () => {
-            expect(typeof studyController.duplicateStudy).toBe('function')
-        })
-
-        it('should have deleteStudy method', () => {
-            expect(typeof studyController.deleteStudy).toBe('function')
-        })
-
-        it('should have updateStudy method', () => {
-            expect(typeof studyController.updateStudy).toBe('function')
-        })
-
-        it('should have acceptStudyCollaboration method', () => {
-            expect(typeof studyController.acceptStudyCollaboration).toBe('function')
-        })
-
-        it('should have getStudy method', () => {
-            expect(typeof studyController.getStudy).toBe('function')
-        })
-
-        it('should have getPublicStudies method', () => {
-            expect(typeof studyController.getPublicStudies).toBe('function')
-        })
-
-        it('should have getAllStudies method', () => {
-            expect(typeof studyController.getAllStudies).toBe('function')
-        })
-
-        it('should have subscribeToStudy method', () => {
-            expect(typeof studyController.subscribeToStudy).toBe('function')
-        })
+    it('should have duplicateStudy method', () => {
+      expect(typeof studyController.duplicateStudy).toBe('function')
     })
 
-    describe('createStudy', () => {
-        it('should call create method on parent with correct collection', async () => {
-
-            spies.create.mockResolvedValueOnce({ id: 'study-123' })
-            
-            // Verify that create method exists and is callable
-            expect(typeof studyController.createStudy).toBe('function')
-        })
-
-        it('should throw error when create fails', async () => {
-            const mockError = new Error('Failed to create study')
-            const mockPayload = {
-                testType: 'HEURISTIC',
-                toFirestore: jest.fn().mockReturnValue({})
-            }
-
-            spies.create.mockRejectedValueOnce(mockError)
-            
-            // Expect the createStudy to handle the error or throw it
-            await expect(studyController.createStudy(mockPayload)).rejects.toThrow()
-        })
+    it('should have deleteStudy method', () => {
+      expect(typeof studyController.deleteStudy).toBe('function')
     })
 
-    describe('duplicateStudy', () => {
-        it('should duplicate study with new answer document', async () => {
-            const mockPayload = {
-                test: {
-                    testType: 'HEURISTIC',
-                    id: 'original-study-123',
-                    toFirestore: jest.fn().mockReturnValue({
-                        testType: 'HEURISTIC',
-                        answersDocId: 'answer-456'
-                    })
-                }
-            }
-
-            spies.create.mockResolvedValueOnce({ id: 'duplicated-study-123' })
-            
-            // Expect duplicateStudy to throw when AnswerController dependency fails
-            await expect(studyController.duplicateStudy(mockPayload)).rejects.toThrow()
-        })
-
-        it('should throw error when duplicateStudy fails', async () => {
-            const mockPayload = {
-                test: {
-                    testType: 'HEURISTIC',
-                    toFirestore: jest.fn().mockReturnValue({})
-                }
-            }
-
-            // Expect duplicateStudy to throw when dependencies fail
-            await expect(studyController.duplicateStudy(mockPayload)).rejects.toThrow()
-        })
+    it('should have updateStudy method', () => {
+      expect(typeof studyController.updateStudy).toBe('function')
     })
 
-    describe('deleteStudy', () => {
-        it('should delete study and remove collaborators', async () => {
-            const mockPayload = {
-                id: 'study-123',
-                testAdmin: { userDocId: 'admin-123' }
-            }
-
-            const mockStudyData = {
-                cooperators: [
-                    { userDocId: 'coop-1', email: 'coop1@test.com' },
-                    { userDocId: 'coop-2', email: 'coop2@test.com' }
-                ]
-            }
-
-            const mockDoc = {
-                exists: () => true,
-                data: () => mockStudyData
-            }
-
-            spies.readOne.mockResolvedValueOnce(mockDoc)
-            spies.delete.mockResolvedValue()
-
-            await studyController.deleteStudy(mockPayload)
-
-            expect(spies.readOne).toHaveBeenCalledWith('tests', 'study-123')
-            // The study doc is deleted. The admin's myTests entry is removed
-            // via UserController.removeTestFromUser (fresh read) rather than a
-            // full overwrite of the user doc, so super.update is not called here.
-            expect(spies.delete).toHaveBeenCalledWith('tests', 'study-123')
-        })
-
-        it('should return null if study does not exist', async () => {
-            const mockPayload = { id: 'non-existent-study' }
-            
-            const mockDoc = {
-                exists: () => false
-            }
-            
-            spies.readOne.mockResolvedValueOnce(mockDoc)
-
-            const result = await studyController.deleteStudy(mockPayload)
-            expect(result).toBeNull()
-        })
-
-        it('should handle delete error', async () => {
-            const mockError = new Error('Delete failed')
-            const mockPayload = { id: 'study-123' }
-
-            spies.readOne.mockRejectedValueOnce(mockError)
-            await expect(studyController.deleteStudy(mockPayload)).rejects.toThrow(mockError)
-        })
+    it('should have acceptStudyCollaboration method', () => {
+      expect(typeof studyController.acceptStudyCollaboration).toBe('function')
     })
 
-    describe('updateStudy', () => {
-        it('should update study with new data', async () => {
-            const mockPayload = {
-                id: 'study-123',
-                testTitle: 'Updated Title',
-                toFirestore: jest.fn().mockReturnValue({
-                    testTitle: 'Updated Title'
-                })
-            }
-
-            await studyController.updateStudy(mockPayload)
-
-            expect(mockCallHttpsCallableFunction).toHaveBeenCalledWith(
-                'updateStudyWithAudit',
-                {
-                    studyId: 'study-123',
-                    study: { testTitle: 'Updated Title' }
-                }
-            )
-        })
-
-        it('should update study from a plain partial object', async () => {
-            const mockPayload = {
-                id: 'study-123',
-                configData: {
-                    complianceLevel: 'AA'
-                }
-            }
-
-            await studyController.updateStudy(mockPayload)
-
-            expect(mockCallHttpsCallableFunction).toHaveBeenCalledWith(
-                'updateStudyWithAudit',
-                {
-                    studyId: 'study-123',
-                    study: {
-                        configData: {
-                            complianceLevel: 'AA'
-                        }
-                    }
-                }
-            )
-        })
-
-        it('should throw error when update fails', async () => {
-            const mockError = new Error('Update failed')
-            const mockPayload = {
-                id: 'study-123',
-                toFirestore: jest.fn().mockReturnValue({})
-            }
-
-            mockCallHttpsCallableFunction.mockRejectedValueOnce(mockError)
-            await expect(studyController.updateStudy(mockPayload)).rejects.toThrow(mockError)
-        })
+    it('should have getStudy method', () => {
+      expect(typeof studyController.getStudy).toBe('function')
     })
 
-    describe('acceptStudyCollaboration', () => {
-        it('should accept study collaboration and update both user and study', async () => {
-            const mockTestPayload = {
-                id: 'study-123',
-                answersDocId: 'answer-123',
-                testAdmin: { email: 'admin@test.com' },
-                testDocId: 'study-123',
-                testType: 'HEURISTIC',
-                subType: 'standard',
-                testTitle: 'Test Study',
-                cooperators: [
-                    { email: 'coop@test.com', accessLevel: 'edit', accepted: false, userDocId: null }
-                ],
-                toFirestore: jest.fn().mockReturnValue({ id: 'study-123' })
-            }
-
-            const mockCooperatorPayload = {
-                id: 'coop-user-123',
-                email: 'coop@test.com',
-                accessLevel: 'edit',
-                myAnswers: {},
-                toFirestore: jest.fn().mockReturnValue({ id: 'coop-user-123' })
-            }
-
-            const mockPayload = {
-                test: mockTestPayload,
-                cooperator: mockCooperatorPayload
-            }
-
-            await expect(
-                studyController.acceptStudyCollaboration(mockPayload)
-            ).resolves.toEqual({ status: 'ok' })
-            expect(mockCallHttpsCallableFunction).toHaveBeenCalledWith(
-                'manageStudyMembership',
-                { studyId: 'study-123', action: 'accept' }
-            )
-        })
+    it('should have getPublicStudies method', () => {
+      expect(typeof studyController.getPublicStudies).toBe('function')
     })
 
-    describe('getStudy', () => {
-        it('should retrieve study by id when study exists', async () => {
-            const mockParameter = { id: 'study-123' }
-            const mockStudyData = {
-                id: 'study-123',
-                testType: 'HEURISTIC',
-                testTitle: 'Test Study'
-            }
-
-            const mockDoc = {
-                exists: () => true,
-                id: 'study-123',
-                data: () => mockStudyData
-            }
-            
-            spies.readOne.mockResolvedValueOnce(mockDoc)
-            const result = await studyController.getStudy(mockParameter)
-
-            expect(spies.readOne).toHaveBeenCalledWith('tests', 'study-123')
-            // The result is instantiated by the mock, which returns the data with testType
-            if (result) {
-                expect(result.testType).toBe('HEURISTIC')
-            }
-        })
-
-        it('should return null if study does not exist', async () => {
-            const mockParameter = { id: 'non-existent-study' }
-            
-            const mockDoc = {
-                exists: () => false
-            }
-            
-            spies.readOne.mockResolvedValueOnce(mockDoc)
-            const result = await studyController.getStudy(mockParameter)
-            
-            expect(result).toBeNull()
-        })
+    it('should have getAllStudies method', () => {
+      expect(typeof studyController.getAllStudies).toBe('function')
     })
 
-    describe('getPublicStudies', () => {
-        it('should retrieve all public studies', async () => {
-            spies.query = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(studyController)), 'query')
-            spies.query.mockResolvedValueOnce({
-                docs: [
-                    { id: 'public-study-1', data: () => ({ testType: 'HEURISTIC' }) },
-                    { id: 'public-study-2', data: () => ({ testType: 'USER' }) }
-                ]
-            })
+    it('should have subscribeToStudy method', () => {
+      expect(typeof studyController.subscribeToStudy).toBe('function')
+    })
+  })
 
-            const result = await studyController.getPublicStudies()
-            expect(result).toHaveLength(2)
-        })
+  describe('createStudy', () => {
+    it('should call create method on parent with correct collection', async () => {
+      spies.create.mockResolvedValueOnce({ id: 'study-123' })
 
-        it('should return empty array when no public studies exist', async () => {
-            spies.query = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(studyController)), 'query')
-            spies.query.mockResolvedValueOnce({ docs: [] })
-
-            const result = await studyController.getPublicStudies()
-            expect(result).toEqual([])
-        })
+      expect(typeof studyController.createStudy).toBe('function')
     })
 
-    describe('getAllStudies', () => {
-        it('should retrieve all studies', async () => {
-            spies.readAll = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(studyController)), 'readAll')
-            spies.readAll.mockResolvedValue([
-                { id: 'study-1', testType: 'HEURISTIC' },
-                { id: 'study-2', testType: 'USER' }
-            ])
+    it('should throw error when create fails', async () => {
+      const mockError = new Error('Failed to create study')
+      const mockPayload = {
+        testType: 'HEURISTIC',
+        toFirestore: jest.fn().mockReturnValue({}),
+      }
 
-            const result = await studyController.getAllStudies()
-            expect(result).toHaveLength(2)
-        })
+      spies.create.mockRejectedValueOnce(mockError)
 
-        it('should throw error when readAll fails', async () => {
-            spies.readAll = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(studyController)), 'readAll')
-            const mockError = new Error('Read failed')
-            spies.readAll.mockRejectedValue(mockError)
+      await expect(studyController.createStudy(mockPayload)).rejects.toThrow()
+    })
+  })
 
-            await expect(studyController.getAllStudies()).rejects.toThrow(mockError)
-        })
+  describe('duplicateStudy', () => {
+    it('should duplicate study with new answer document', async () => {
+      const mockPayload = {
+        test: {
+          testType: 'HEURISTIC',
+          id: 'original-study-123',
+          toFirestore: jest.fn().mockReturnValue({
+            testType: 'HEURISTIC',
+            answersDocId: 'answer-456',
+          }),
+        },
+      }
+
+      spies.create.mockResolvedValueOnce({
+        id: 'duplicated-study-123',
+      })
+
+      await expect(
+        studyController.duplicateStudy(mockPayload),
+      ).rejects.toThrow()
     })
 
-    describe('subscribeToStudy', () => {
-        it('should subscribe to study changes', () => {
-            const mockCallback = jest.fn()
-            const { onSnapshot } = require('firebase/firestore')
-            const unsubscribeMock = jest.fn()
-            const mockStudyDoc = {
-                exists: () => true,
-                id: 'study-123',
-                data: () => ({ testType: 'HEURISTIC' })
-            }
+    it('should throw error when duplicateStudy fails', async () => {
+      const mockPayload = {
+        test: {
+          testType: 'HEURISTIC',
+          toFirestore: jest.fn().mockReturnValue({}),
+        },
+      }
 
-            onSnapshot.mockImplementation((docRef, callback) => {
-                callback(mockStudyDoc)
-                return unsubscribeMock
-            })
-
-            const unsubscribe = studyController.subscribeToStudy('study-123', mockCallback)
-
-            expect(onSnapshot).toHaveBeenCalled()
-            expect(mockCallback).toHaveBeenCalled()
-            expect(unsubscribe).toBe(unsubscribeMock)
-        })
-
-        it('should not call callback if document does not exist', () => {
-            const mockCallback = jest.fn()
-            const { onSnapshot } = require('firebase/firestore')
-            const mockNonExistentDoc = { exists: () => false }
-
-            onSnapshot.mockImplementation((docRef, callback) => {
-                callback(mockNonExistentDoc)
-                return jest.fn()
-            })
-
-            studyController.subscribeToStudy('non-existent-study', mockCallback)
-            expect(mockCallback).not.toHaveBeenCalled()
-        })
+      await expect(
+        studyController.duplicateStudy(mockPayload),
+      ).rejects.toThrow()
     })
+  })
+
+  describe('deleteStudy', () => {
+    it('should delete study and remove collaborators', async () => {
+      const mockPayload = {
+        id: 'study-123',
+        testAdmin: { userDocId: 'admin-123' },
+      }
+
+      const mockStudyData = {
+        cooperators: [
+          {
+            userDocId: 'coop-1',
+            email: 'coop1@test.com',
+          },
+          {
+            userDocId: 'coop-2',
+            email: 'coop2@test.com',
+          },
+        ],
+      }
+
+      const mockDoc = {
+        exists: () => true,
+        data: () => mockStudyData,
+      }
+
+      spies.readOne.mockResolvedValueOnce(mockDoc)
+      spies.delete.mockResolvedValue()
+
+      await studyController.deleteStudy(mockPayload)
+
+      expect(spies.readOne).toHaveBeenCalledWith('tests', 'study-123')
+
+      expect(spies.delete).toHaveBeenCalledWith('tests', 'study-123')
+    })
+
+    it('should return null if study does not exist', async () => {
+      const mockPayload = {
+        id: 'non-existent-study',
+      }
+
+      const mockDoc = {
+        exists: () => false,
+      }
+
+      spies.readOne.mockResolvedValueOnce(mockDoc)
+
+      const result = await studyController.deleteStudy(mockPayload)
+
+      expect(result).toBeNull()
+    })
+
+    it('should handle delete error', async () => {
+      const mockError = new Error('Delete failed')
+      const mockPayload = {
+        id: 'study-123',
+      }
+
+      spies.readOne.mockRejectedValueOnce(mockError)
+
+      await expect(studyController.deleteStudy(mockPayload)).rejects.toThrow(
+        mockError,
+      )
+    })
+  })
+
+  describe('updateStudy', () => {
+    it('should update study with new data', async () => {
+      const mockPayload = {
+        id: 'study-123',
+        testTitle: 'Updated Title',
+        toFirestore: jest.fn().mockReturnValue({
+          testTitle: 'Updated Title',
+        }),
+      }
+
+      await studyController.updateStudy(mockPayload)
+
+      expect(mockCallHttpsCallableFunction).toHaveBeenCalledWith(
+        'updateStudyWithAudit',
+        {
+          studyId: 'study-123',
+          study: {
+            testTitle: 'Updated Title',
+          },
+        },
+      )
+    })
+
+    it('should update study from a plain partial object', async () => {
+      const mockPayload = {
+        id: 'study-123',
+        configData: {
+          complianceLevel: 'AA',
+        },
+      }
+
+      await studyController.updateStudy(mockPayload)
+
+      expect(mockCallHttpsCallableFunction).toHaveBeenCalledWith(
+        'updateStudyWithAudit',
+        {
+          studyId: 'study-123',
+          study: {
+            configData: {
+              complianceLevel: 'AA',
+            },
+          },
+        },
+      )
+    })
+
+    it('should throw error when update fails', async () => {
+      const mockError = new Error('Update failed')
+
+      const mockPayload = {
+        id: 'study-123',
+        toFirestore: jest.fn().mockReturnValue({}),
+      }
+
+      mockCallHttpsCallableFunction.mockRejectedValueOnce(mockError)
+
+      await expect(studyController.updateStudy(mockPayload)).rejects.toThrow(
+        mockError,
+      )
+    })
+  })
+
+  describe('acceptStudyCollaboration', () => {
+    it('should accept study collaboration and update both user and study', async () => {
+      const mockTestPayload = {
+        id: 'study-123',
+        answersDocId: 'answer-123',
+        testAdmin: {
+          email: 'admin@test.com',
+        },
+        testDocId: 'study-123',
+        testType: 'HEURISTIC',
+        subType: 'standard',
+        testTitle: 'Test Study',
+        cooperators: [
+          {
+            email: 'coop@test.com',
+            accessLevel: 5,
+            accepted: false,
+            userDocId: null,
+          },
+        ],
+        toFirestore: jest.fn().mockReturnValue({
+          id: 'study-123',
+        }),
+      }
+
+      const mockCooperatorPayload = {
+        id: 'coop-user-123',
+        email: 'coop@test.com',
+        accessLevel: 5,
+        myAnswers: {},
+        toFirestore: jest.fn().mockReturnValue({
+          id: 'coop-user-123',
+        }),
+      }
+
+      const mockPayload = {
+        studyId: 'study-123',
+        membershipType: 'cooperator',
+        role: 5,
+        test: mockTestPayload,
+        cooperator: mockCooperatorPayload,
+      }
+
+      await expect(
+        studyController.acceptStudyCollaboration(mockPayload),
+      ).resolves.toEqual({
+        status: 'ok',
+      })
+
+      expect(mockCallHttpsCallableFunction).toHaveBeenCalledWith(
+        'manageStudyMembership',
+        {
+          studyId: 'study-123',
+          action: 'accept',
+          membershipType: 'cooperator',
+          targetUserId: 'coop-user-123',
+          targetEmail: 'coop@test.com',
+          role: 5,
+        },
+      )
+    })
+
+    it('should accept study collaboration with the cooperator membership data', async () => {
+      const mockPayload = {
+        studyId: 'study-123',
+        membershipType: 'cooperator',
+        role: 5,
+        cooperator: {
+          id: 'coop-user-123',
+          email: 'coop@test.com',
+        },
+      }
+
+      await expect(
+        studyController.acceptStudyCollaboration(mockPayload),
+      ).resolves.toEqual({
+        status: 'ok',
+      })
+
+      expect(mockCallHttpsCallableFunction).toHaveBeenCalledWith(
+        'manageStudyMembership',
+        {
+          studyId: 'study-123',
+          action: 'accept',
+          membershipType: 'cooperator',
+          targetUserId: 'coop-user-123',
+          targetEmail: 'coop@test.com',
+          role: 5,
+        },
+      )
+    })
+  })
+
+  describe('getStudy', () => {
+    it('should retrieve study by id when study exists', async () => {
+      const mockParameter = {
+        id: 'study-123',
+      }
+
+      const mockStudyData = {
+        id: 'study-123',
+        testType: 'HEURISTIC',
+        testTitle: 'Test Study',
+      }
+
+      const mockDoc = {
+        exists: () => true,
+        id: 'study-123',
+        data: () => mockStudyData,
+      }
+
+      spies.readOne.mockResolvedValueOnce(mockDoc)
+
+      const result = await studyController.getStudy(mockParameter)
+
+      expect(spies.readOne).toHaveBeenCalledWith('tests', 'study-123')
+
+      if (result) {
+        expect(result.testType).toBe('HEURISTIC')
+      }
+    })
+
+    it('should return null if study does not exist', async () => {
+      const mockParameter = {
+        id: 'non-existent-study',
+      }
+
+      const mockDoc = {
+        exists: () => false,
+      }
+
+      spies.readOne.mockResolvedValueOnce(mockDoc)
+
+      const result = await studyController.getStudy(mockParameter)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getPublicStudies', () => {
+    it('should retrieve all public studies', async () => {
+      spies.query = jest.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(studyController)),
+        'query',
+      )
+
+      spies.query.mockResolvedValueOnce({
+        docs: [
+          {
+            id: 'public-study-1',
+            data: () => ({
+              testType: 'HEURISTIC',
+            }),
+          },
+          {
+            id: 'public-study-2',
+            data: () => ({
+              testType: 'USER',
+            }),
+          },
+        ],
+      })
+
+      const result = await studyController.getPublicStudies()
+
+      expect(result).toHaveLength(2)
+    })
+
+    it('should return empty array when no public studies exist', async () => {
+      spies.query = jest.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(studyController)),
+        'query',
+      )
+
+      spies.query.mockResolvedValueOnce({
+        docs: [],
+      })
+
+      const result = await studyController.getPublicStudies()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getAllStudies', () => {
+    it('should retrieve all studies', async () => {
+      spies.readAll = jest.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(studyController)),
+        'readAll',
+      )
+
+      spies.readAll.mockResolvedValue([
+        {
+          id: 'study-1',
+          testType: 'HEURISTIC',
+        },
+        {
+          id: 'study-2',
+          testType: 'USER',
+        },
+      ])
+
+      const result = await studyController.getAllStudies()
+
+      expect(result).toHaveLength(2)
+    })
+
+    it('should throw error when readAll fails', async () => {
+      spies.readAll = jest.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(studyController)),
+        'readAll',
+      )
+
+      const mockError = new Error('Read failed')
+
+      spies.readAll.mockRejectedValue(mockError)
+
+      await expect(studyController.getAllStudies()).rejects.toThrow(mockError)
+    })
+  })
+
+  describe('subscribeToStudy', () => {
+    it('should subscribe to study changes', () => {
+      const mockCallback = jest.fn()
+      const { onSnapshot } = require('firebase/firestore')
+
+      const unsubscribeMock = jest.fn()
+
+      const mockStudyDoc = {
+        exists: () => true,
+        id: 'study-123',
+        data: () => ({
+          testType: 'HEURISTIC',
+        }),
+      }
+
+      onSnapshot.mockImplementation((docRef, callback) => {
+        callback(mockStudyDoc)
+        return unsubscribeMock
+      })
+
+      const unsubscribe = studyController.subscribeToStudy(
+        'study-123',
+        mockCallback,
+      )
+
+      expect(onSnapshot).toHaveBeenCalled()
+      expect(mockCallback).toHaveBeenCalled()
+      expect(unsubscribe).toBe(unsubscribeMock)
+    })
+
+    it('should not call callback if document does not exist', () => {
+      const mockCallback = jest.fn()
+      const { onSnapshot } = require('firebase/firestore')
+
+      const mockNonExistentStudy = {
+        exists: () => false,
+      }
+
+      onSnapshot.mockImplementation((docRef, callback) => {
+        callback(mockNonExistentStudy)
+        return jest.fn()
+      })
+
+      studyController.subscribeToStudy('non-existent-study', mockCallback)
+
+      expect(mockCallback).not.toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
# Description

This PR fixes the study access and invitation flows for participants and staff members, ensuring that users are correctly added to studies, assigned their roles, and redirected to the appropriate study view.

## What was changed

- Fixed the participant invitation acceptance flow for **public invitation links**:
  - Users accepting a public invitation are now added to the study's `participants` collection.
  - The user's `studyRoleMap` is updated with the correct `accessLevel`.
  - The study is saved in the user's `myAnswers`.
  - The participant invitation is marked as accepted.

- Fixed the staff/cooperator invitation acceptance flow:
  - Users accepting a public cooperator invitation are now added to `cooperators` when they are not already registered as a member.
  - The role received from the invitation is preserved.
  - `studyRoleMap` and `myAnswers` are updated accordingly.

- Fixed study capability checks for accepted participants:
  - Ensured the user's role is correctly resolved from `studyRoleMap` and accepted memberships.
  - Public participants are correctly recognized when accessing the study.
  - Corrected capability validation for participant and staff roles.

- Updated study redirects:
  - Participants with the `USER` role are redirected to `TestView`.
  - Staff members continue to be redirected to the appropriate manager view based on the study type/subtype.
  - Invitation acceptance now determines the destination based on `membershipType`.

- Fixed invitation acceptance payloads and updated unit tests to cover the new membership data (`membershipType`, `role`, `targetUserId`, and `targetEmail`).

## Result

Users accepting study invitations can now complete the entire flow correctly:

**accept invitation → become a study member → receive the correct role → pass capability checks → access the appropriate study view**

Issue #2161 
<img width="670" height="969" alt="image" src="https://github.com/user-attachments/assets/8e783f17-794d-4ca6-9071-29803b310f36" />
