### PR TITLE
fix: redirect root path based on auth state instead of 404

### DIFF
--- a/src/app/router/index.js
+++ b/src/app/router/index.js
@@ -95,7 +95,14 @@ router.beforeEach(async (to, from, next) => {
   }
 
   /**
-   * 5. Enforce role-based access control
+   * 5. Redirect root path based on resolved auth state
+   */
+  if (to.path === '/') {
+    return next(redirect())
+  }
+
+  /**
+   * 6. Enforce role-based access control
    */
   if (authorize.length) {
     if (!user || !authorize.includes(user.accessLevel)) {

--- a/src/router/modules/public.js
+++ b/src/router/modules/public.js
@@ -54,13 +54,7 @@ export default [
     meta: { authorize: [] },
     component: Help,
     props: { showAllOnLoad: true },
-  } /*
-  {
-    path: '/',
-    name: 'Landing',
-    meta: { authorize: [] },
-    component: LandingPage,
-  },*/,
+  },
   {
     path: '/:catchAll(.*)',
     name: 'Page not Found',


### PR DESCRIPTION
Fixes #2274

## Problem
The `/` route was commented out in `src/router/modules/public.js` after `LandingPage` was deleted in an earlier refactor. Since no route matched `/`, it fell through to the catch-all wildcard and showed the 404 page for every visitor, authenticated or not.

## Fix
Added a redirect for `/` inside the global navigation guard (`src/app/router/index.js`), placed after `autoSignIn()` resolves so auth state is fully settled before the decision is made:
- Unauthenticated → `/signin`
- Authenticated → `/admin` or `/superadmin`, via the existing `redirect()` helper based on access level

Confirmed this is the intended behavior with @JulioManoel on the issue before implementing.

## Testing
- [x] Logged-out hard refresh at `/` → `/signin`
- [x] Logged-in hard refresh at `/` → `/admin`
- [x] Normal sign-in flow unchanged
- [x] Unknown routes still show the real 404

## Known follow-up (not in this PR)
There's a brief visual flash before redirecting when unauthenticated — the app mounts before the async guard resolves. Likely fix is awaiting `router.isReady()` before `.mount()` in `main.js`, but that's a broader change affecting every route's initial load, so keeping it out of scope here. Open to adjustments or splitting this into a follow-up if maintainers prefer.

Here is a visual Demonstration for the fix:

https://github.com/user-attachments/assets/46f5fd7b-a34a-439e-9ae6-d400bedd5d2e

