### PR TITLE
feat(sessions): when go to session button open new tab

### DIFF
--- a/src/features/navigation/components/navbarSections/SessionsSection.vue
+++ b/src/features/navigation/components/navbarSections/SessionsSection.vue
@@ -317,7 +317,8 @@ const filteredSessions = computed(() => {
 })
 
 const goTo = (session) => {
-  router.push(`/testview/${session.study.id}/${session.id}`)
+  const route = router.resolve(`/testview/${session.study.id}/${session.id}`)
+  window.open(route.href, '_blank')
 }
 </script>
 

--- a/src/shared/views/SessionsView.vue
+++ b/src/shared/views/SessionsView.vue
@@ -374,7 +374,8 @@ const deleteSession = (session) => {
 }
 
 const goToSession = (coopId) => {
-  router.push(`/testview/${test.value.id}/${coopId}`)
+  const route = router.resolve(`/testview/${test.value.id}/${coopId}`)
+  window.open(route.href, '_blank')
 }
 
 const confirmDeleteSession = async () => {


### PR DESCRIPTION
## Description

This PR updates the session navigation flow to open the selected session in a **new browser tab** instead of replacing the current page.

### Changes

- Updated `goToSession` to resolve the session route using Vue Router.
- Session links now open in a new tab using `window.open`.
- The current page remains open, allowing users to return to the previous context without losing their place.
Closes Issue #2269 
<img width="593" height="92" alt="image" src="https://github.com/user-attachments/assets/5cc3480e-bfe7-4ba3-a28e-2450cc690699" />
