### PR TITLE
feat(session): notify members of session when updates on time or message/description

### DIFF
--- a/src/shared/store/Session.js
+++ b/src/shared/store/Session.js
@@ -137,10 +137,22 @@ export default {
           (item) => item.id === payload.sessionId,
         )
 
+        const previousScheduledAt = normalizeDate(previousSession?.scheduledAt)
+        const newScheduledAt = normalizeDate(payload.session?.scheduledAt)
+
+        const scheduleChanged =
+          previousScheduledAt?.getTime() !== newScheduledAt?.getTime()
+
+        const descriptionChanged =
+          (previousSession?.message || '') !== (payload.session?.message || '')
+
+        const sessionDetailsChanged = scheduleChanged || descriptionChanged
+
         const result = await new SessionController().updateSession({
           ...payload,
           session: enrichSession(payload.session),
         })
+
         if (!result.success) {
           throw result.error
         }
@@ -159,7 +171,22 @@ export default {
           (member) => !oldMembers.some((old) => old.email === member.email),
         )
 
-        if (addedMembers.length) {
+        if (sessionDetailsChanged) {
+          await dispatch('notifySessionMembers', {
+            session: {
+              id: payload.sessionId,
+              title: payload.session.title,
+              message: payload.session.message,
+            },
+            studyId: payload.studyId,
+            studyTitle: payload.study.testTitle,
+            scheduledAt: formatDateTime(
+              payload.session.scheduledAt,
+              i18n.global.locale.value,
+            ),
+            members: newMembers,
+          })
+        } else if (addedMembers.length) {
           await dispatch('notifySessionMembers', {
             session: {
               id: payload.sessionId,
@@ -438,6 +465,28 @@ export default {
       }
     },
   },
+}
+
+function normalizeDate(value) {
+  if (!value) {
+    return null
+  }
+
+  if (typeof value.toDate === 'function') {
+    return value.toDate()
+  }
+
+  if (typeof value.toMillis === 'function') {
+    return new Date(value.toMillis())
+  }
+
+  if (value instanceof Date) {
+    return value
+  }
+
+  const date = new Date(value)
+
+  return Number.isNaN(date.getTime()) ? null : date
 }
 
 function enrichSession(session) {


### PR DESCRIPTION
## Description

This PR updates the session update flow to notify session members when relevant session information changes.

### Changes

- Notify all current session members when the **scheduled time** is changed.
- Notify all current session members when the **session description** is changed.
- Send a single notification when both the schedule and description are changed.
- Preserve the existing behavior of notifying only newly added members when no session details were changed.
- Avoid duplicate notifications for members who were newly added when a session update also changes its schedule or description.
- Added date normalization to reliably compare session schedules across different date formats.

### Result

Session members are now kept informed whenever important session details change, while avoiding unnecessary or duplicated notifications.

Fixes #2270 
<img width="681" height="456" alt="image" src="https://github.com/user-attachments/assets/01d4b946-e6a8-45a5-8ee4-d9cc363397e8" />
