### PR TITLE
fix(cooperators): fixed reactivity error on staff/participants + added intro for participants + fixed modal behaviour

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -585,6 +585,7 @@
       "analytics": "Take a deep look into your test and see what people are saying about it.",
       "invite": "Invite evaluators to answer your test!",
       "cooperators": "Add cooperators who can help you improve your project and gather data for your studies.",
+      "participants": "Add participants to your study to help you collect valuable data and insights from real users.",
       "start": "Get started!",
       "edit": "Create and customize your tasks and heuristics for your research needs.",
       "finalReport": "Prepare the final report for your heuristic evaluation by selecting the elements you want to include."

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -579,6 +579,7 @@
       "analytics": "Examina en profundidad tu prueba y descubre qué dicen las personas al respecto.",
       "invite": "¡Invita a evaluadores a responder tu prueba!",
       "cooperators": "Agrega colaboradores que puedan ayudarte a mejorar tu proyecto y recopilar datos para tus estudios.",
+      "participants": "Agrega participantes a tu estudio para ayudarte a recopilar datos valiosos y obtener información de usuarios reales.",
       "start": "¡Comienza!",
       "edit": "Crea y personaliza tus tareas y heurísticas para tus necesidades de investigación.",
       "finalReport": "Prepara el informe final para tu evaluación heurística seleccionando los elementos que deseas incluir."

--- a/src/shared/components/dialogs/InviteDialog.vue
+++ b/src/shared/components/dialogs/InviteDialog.vue
@@ -146,6 +146,7 @@
         <v-btn
           color="primary"
           class="rounded-lg"
+          :loading="loading"
           :disabled="selectedCoops.length === 0 || selectedRole === null"
           @click="onSend"
         >
@@ -212,6 +213,10 @@ const props = defineProps({
   preDefinedRole: {
     type: Array,
     default: null,
+  },
+  loading: {
+    type: Boolean,
+    default: false,
   },
 })
 
@@ -342,7 +347,6 @@ const onSend = () => {
   }
 
   emit('send-invitations', invitationData)
-  resetForm()
 }
 
 const resetForm = () => {

--- a/src/shared/components/introduction_cards/IntroParticipants.vue
+++ b/src/shared/components/introduction_cards/IntroParticipants.vue
@@ -1,0 +1,59 @@
+<template>
+  <IntrosComponent
+    :colors="['#FF3F59', '#00213f']"
+    :title="'Participants'"
+    :image="'IntroCoops.svg'"
+    :main="$t('descriptions.intro.participants')"
+    :link="$t('descriptions.intro.start')"
+    :items="items"
+    @link-clicked="closeIntro"
+    @call-func="callFunc"
+  />
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import IntrosComponent from './IntrosComponent.vue'
+
+const router = useRouter()
+const { t } = useI18n()
+
+const emit = defineEmits(['closeIntro'])
+
+const items = computed(() => [
+  {
+    iconColor: '#daf01a',
+    icon: 'mdi-file-document',
+    title: t('pages.intros.docTitle'),
+    subtitle:
+      t('pages.intros.docSubtitle') + t('Participants.title.participants'),
+    func: 'goToDoc',
+  },
+  {
+    iconColor: '#daf01a',
+    icon: 'mdi-emoticon-happy',
+    title: t('pages.intros.discTitle'),
+    subtitle: t('pages.intros.discSubtitle'),
+    func: 'goToDisc',
+  },
+])
+
+const goToDoc = () => {
+  router.push('/help').catch(() => {})
+}
+
+const goToDisc = () => {
+  window.open('https://discord.gg/MFWNpwTq9q')
+}
+
+const closeIntro = () => {
+  emit('closeIntro')
+}
+
+const callFunc = (func) => {
+  if (func === 'goToDoc') goToDoc()
+  if (func === 'goToDisc') goToDisc()
+}
+</script>

--- a/src/shared/views/CooperatorsView.vue
+++ b/src/shared/views/CooperatorsView.vue
@@ -109,6 +109,7 @@
       :role-label="$t('HeuristicsCooperators.headers.role')"
       :cancel-text="$t('HeuristicsCooperators.actions.cancel')"
       :send-text="$t('HeuristicsCooperators.actions.send')"
+      :loading="loading"
       @send-invitations="handleSendInvitations"
     />
 
@@ -201,7 +202,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import Intro from '@/shared/components/introduction_cards/IntroCoops.vue'
 import AccessNotAllowed from '@/shared/views/AccessNotAllowed.vue'
@@ -520,6 +521,7 @@ const handleSendInvitations = async ({
   inviteMessage,
 }) => {
   try {
+    showInviteDialog.value = false
     const newInvites = await store.dispatch('sendInvitations', {
       study: test.value,
       user: userAuth.value,
@@ -531,7 +533,9 @@ const handleSendInvitations = async ({
       resolveUserByEmail,
     })
 
-    showInviteDialog.value = false
+    await store.dispatch('getStudy', {
+      id: test.value.id,
+    })
 
     if (newInvites.length > 0) {
       showSuccess(
@@ -700,12 +704,6 @@ const executeInvitationCancellation = async (guest) => {
     id: test.value.id,
   })
 }
-
-watch(loading, (newVal) => {
-  if (!newVal) {
-    showIntroComponent.value = cooperatorsEdit.value.length === 0
-  }
-})
 
 onMounted(async () => {
   const testId = props.id || route.params.id

--- a/src/shared/views/ParticipantsView.vue
+++ b/src/shared/views/ParticipantsView.vue
@@ -1,7 +1,9 @@
 <template>
-  <PageWrapper :title="$t('Participants.title.participants')">
+  <PageWrapper
+    :title="!showIntroView ? $t('Participants.title.participants') : ''"
+  >
     <!-- Actions Slot -->
-    <template v-if="canManageParticipants" #actions>
+    <template v-if="!showIntroView && canManageParticipants" #actions>
       <v-menu>
         <template #activator="{ props }">
           <v-btn
@@ -40,13 +42,16 @@
     </template>
 
     <!-- Subtitle Slot -->
-    <template #subtitle>
+    <template v-if="!showIntroView" #subtitle>
       <p class="text-body-1 text-grey-darken-1">
         {{ $t('Participants.subtitles.manage_participants') }}
       </p>
     </template>
 
+    <Intro v-if="showIntroView" @close-intro="showIntroComponent = false" />
+
     <ParticipantTable
+      v-else
       :participants="participants"
       :loading="loading"
       :show-date-columns="showDateColumns"
@@ -98,6 +103,7 @@
       :no-data-text="$t('Participants.messages.no_users')"
       :cancel-text="$t('Participants.actions.cancel')"
       :send-text="$t('Participants.actions.send')"
+      :loading="loading"
       @send-invitations="handleSendInvitations"
     />
 
@@ -146,6 +152,7 @@ import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { showSuccess, showError, showWarning } from '@/shared/utils/toast'
 import PageWrapper from '@/shared/views/template/PageWrapper.vue'
+import Intro from '@/shared/components/introduction_cards/IntroParticipants.vue'
 import AccessNotAllowed from '@/shared/views/AccessNotAllowed.vue'
 import LeaveAlert from '@/shared/components/dialogs/LeaveAlert.vue'
 import MessageDialog from '@/shared/components/dialogs/MessageDialog.vue'
@@ -286,6 +293,10 @@ const requiredLoginOption = computed(() => getRequiredLoginConfig(test.value))
 
 const participants = computed(() => store.getters.participants)
 
+const showIntroView = computed(() => {
+  return participants.value.length <= 0 && showIntroComponent.value
+})
+
 /*
 |--------------------------------------------------------------------------
 | Permissions
@@ -383,6 +394,9 @@ const handleSendInvitations = async ({
   inviteMessage,
 }) => {
   try {
+    showInviteDialog.value = false
+    showIntroComponent.value = false
+
     const newInvites = await store.dispatch('sendParticipantInvitations', {
       study: test.value,
       user: userAuth.value,
@@ -394,8 +408,6 @@ const handleSendInvitations = async ({
       resolveUserByEmail,
       studyParticipants: participants.value,
     })
-
-    showInviteDialog.value = false
 
     if (newInvites.length > 0) {
       showSuccess(


### PR DESCRIPTION
## Summary

Added a new introduction view for **Participants** and fixed issues related to reactivity and the invitation dialog flow.

### Changes

- Added `IntroParticipants.vue`, following the existing Cooperators introduction pattern.
- Added Participants introduction content and i18n translations in English and Spanish.
- Added links to the documentation and Discord community.
- Reused the existing `IntrosComponent` for consistent UI and behavior.
- Fixed reactivity issues that could cause the introduction view to be displayed incorrectly after updates.
- Fixed the invitation dialog closing behavior so the dialog and loading overlay are synchronized.
- Improved the invitation flow to prevent the dialog from closing before the invitation request has finished.
- Ensured the invitation form is reset at the appropriate time after the dialog is closed.

Fixes #2264 #2265

<img width="1186" height="963" alt="image" src="https://github.com/user-attachments/assets/7f6f158d-7cfe-4b00-9c6b-a0853540bfc1" />

