### PR TITLE
feat(focus-group): stimulus upload and live present

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -2640,7 +2640,14 @@
       "endedTitle": "Session ended",
       "endedSubtitle": "Responses have been saved.",
       "sessionSaved": "Session responses saved.",
-      "noTopicsWarning": "Add topics to your discussion guide before starting a session."
+      "noTopicsWarning": "Add topics to your discussion guide before starting a session.",
+      "stimuli": "Stimuli",
+      "noStimuli": "No stimuli in the library yet. Add some from the Test screen.",
+      "present": "Present",
+      "presenting": "Presenting",
+      "presentingStimulus": "Presenting:",
+      "stopPresenting": "Stop presenting",
+      "openStimulusLink": "Open stimulus link"
     },
     "stimulus": {
       "empty": "No stimuli yet. Upload an image or video, or add a link below.",

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -2526,7 +2526,8 @@
       "tabs": {
         "configuration": "Session Configuration",
         "consent": "Consent Form",
-        "guide": "Discussion Guide"
+        "guide": "Discussion Guide",
+        "stimuli": "Stimuli"
       },
       "noTopics": "No topics yet. Add your first discussion topic to get started.",
       "addTopic": "Add topic",
@@ -2640,6 +2641,21 @@
       "endedSubtitle": "Responses have been saved.",
       "sessionSaved": "Session responses saved.",
       "noTopicsWarning": "Add topics to your discussion guide before starting a session."
+    },
+    "stimulus": {
+      "empty": "No stimuli yet. Upload an image or video, or add a link below.",
+      "types": {
+        "image": "Image",
+        "video": "Video",
+        "url": "Link"
+      },
+      "topic": "Topic",
+      "remove": "Remove stimulus",
+      "dropHint": "Drag and drop an image or video, or click to upload",
+      "addLinkTitle": "Add a link",
+      "linkName": "Name",
+      "linkUrl": "URL",
+      "addLink": "Add link"
     }
   },
   "studyCreation": {

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -2426,7 +2426,8 @@
       "tabs": {
         "configuration": "Configuración de la Sesión",
         "consent": "Formulario de Consentimiento",
-        "guide": "Guía de Discusión"
+        "guide": "Guía de Discusión",
+        "stimuli": "Estímulos"
       },
       "noTopics": "Aún no hay temas. Agrega tu primer tema de discusión para comenzar.",
       "addTopic": "Agregar tema",
@@ -2540,6 +2541,21 @@
       "endedSubtitle": "Las respuestas se han guardado.",
       "sessionSaved": "Respuestas de la sesión guardadas.",
       "noTopicsWarning": "Agrega temas a tu guía de discusión antes de iniciar una sesión."
+    },
+    "stimulus": {
+      "empty": "Aún no hay estímulos. Sube una imagen o video, o agrega un enlace abajo.",
+      "types": {
+        "image": "Imagen",
+        "video": "Video",
+        "url": "Enlace"
+      },
+      "topic": "Tema",
+      "remove": "Eliminar estímulo",
+      "dropHint": "Arrastra y suelta una imagen o video, o haz clic para subir",
+      "addLinkTitle": "Agregar un enlace",
+      "linkName": "Nombre",
+      "linkUrl": "URL",
+      "addLink": "Agregar enlace"
     }
   },
   "studyCreation": {

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -2540,7 +2540,14 @@
       "endedTitle": "Sesión finalizada",
       "endedSubtitle": "Las respuestas se han guardado.",
       "sessionSaved": "Respuestas de la sesión guardadas.",
-      "noTopicsWarning": "Agrega temas a tu guía de discusión antes de iniciar una sesión."
+      "noTopicsWarning": "Agrega temas a tu guía de discusión antes de iniciar una sesión.",
+      "stimuli": "Estímulos",
+      "noStimuli": "Aún no hay estímulos en la biblioteca. Agrega algunos desde la pantalla de prueba.",
+      "present": "Presentar",
+      "presenting": "Presentando",
+      "presentingStimulus": "Presentando:",
+      "stopPresenting": "Dejar de presentar",
+      "openStimulusLink": "Abrir enlace del estímulo"
     },
     "stimulus": {
       "empty": "Aún no hay estímulos. Sube una imagen o video, o agrega un enlace abajo.",

--- a/src/ux/FocusGroup/components/StimulusLibraryEditor.vue
+++ b/src/ux/FocusGroup/components/StimulusLibraryEditor.vue
@@ -159,6 +159,12 @@ const linkUrl = ref('')
 const typeIcon = (type) =>
   type === 'video' ? 'mdi-video-outline' : 'mdi-link-variant'
 
+// A protocol-less href (e.g. "randomurl.com") resolves as relative to the
+// current page instead of an external site, so the "Open link" affordance
+// silently navigates within the app. Default to https:// when missing.
+const normalizeUrl = (url) =>
+  /^[a-z][a-z0-9+.-]*:\/\//i.test(url) ? url : `https://${url}`
+
 const persist = (nextStimuli) =>
   store.dispatch('updateStimuli', {
     studyId: props.studyId,
@@ -202,7 +208,7 @@ const addLink = async () => {
     const stimulus = new Stimulus({
       type: 'url',
       name: linkName.value.trim() || linkUrl.value.trim(),
-      url: linkUrl.value.trim(),
+      url: normalizeUrl(linkUrl.value.trim()),
     })
     await persist([...stimuli.value, stimulus])
     linkName.value = ''

--- a/src/ux/FocusGroup/components/StimulusLibraryEditor.vue
+++ b/src/ux/FocusGroup/components/StimulusLibraryEditor.vue
@@ -1,0 +1,268 @@
+<template>
+  <div>
+    <div
+      v-if="stimuli.length === 0"
+      class="text-center py-8 text-medium-emphasis"
+    >
+      <v-icon icon="mdi-image-multiple-outline" size="48" class="mb-2" />
+      <p class="text-body-2 mb-0">{{ $t('focusGroup.stimulus.empty') }}</p>
+    </div>
+
+    <v-card
+      v-for="stimulus in stimuli"
+      :key="stimulus.id"
+      variant="outlined"
+      rounded="lg"
+      class="mb-3"
+    >
+      <v-card-text class="d-flex align-center ga-3 pa-4">
+        <v-avatar v-if="stimulus.type === 'image'" size="48" rounded="lg">
+          <v-img :src="stimulus.url" cover />
+        </v-avatar>
+        <v-avatar v-else size="48" rounded="lg" color="grey-lighten-3">
+          <v-icon :icon="typeIcon(stimulus.type)" />
+        </v-avatar>
+
+        <div class="flex-grow-1 min-width-0">
+          <div class="d-flex align-center ga-2">
+            <span class="font-weight-medium">{{ stimulus.name }}</span>
+            <v-chip size="x-small" variant="tonal">
+              {{ $t(`focusGroup.stimulus.types.${stimulus.type}`) }}
+            </v-chip>
+          </div>
+          <a
+            v-if="stimulus.type === 'url'"
+            :href="stimulus.url"
+            target="_blank"
+            rel="noopener"
+            class="text-caption text-truncate d-block"
+          >
+            {{ stimulus.url }}
+          </a>
+        </div>
+
+        <v-select
+          :model-value="stimulus.topicId"
+          :items="topics"
+          item-title="title"
+          item-value="id"
+          :label="$t('focusGroup.stimulus.topic')"
+          variant="outlined"
+          density="compact"
+          clearable
+          hide-details
+          style="max-width: 220px"
+          @update:model-value="(value) => onTopicChange(stimulus, value)"
+        />
+
+        <v-btn
+          icon="mdi-delete-outline"
+          size="small"
+          variant="text"
+          color="error"
+          :loading="deletingId === stimulus.id"
+          :aria-label="$t('focusGroup.stimulus.remove')"
+          @click="removeStimulus(stimulus)"
+        />
+      </v-card-text>
+    </v-card>
+
+    <v-row class="mt-2" dense>
+      <v-col cols="12" md="6">
+        <label
+          class="stimulus-drop-zone"
+          :class="{ disabled: uploading }"
+          @dragover.prevent
+          @drop.prevent="onDrop"
+        >
+          <v-icon size="32" class="mb-2">mdi-tray-arrow-up</v-icon>
+          <span class="text-body-2">
+            {{ $t('focusGroup.stimulus.dropHint') }}
+          </span>
+          <v-progress-linear v-if="uploading" indeterminate class="mt-2" />
+          <input
+            type="file"
+            accept="image/*,video/*"
+            class="stimulus-native-input"
+            :disabled="uploading"
+            @change="onFilePicked"
+          />
+        </label>
+      </v-col>
+
+      <v-col cols="12" md="6">
+        <v-card variant="outlined" rounded="lg" class="pa-4 h-100">
+          <p class="text-body-2 font-weight-medium mb-2">
+            {{ $t('focusGroup.stimulus.addLinkTitle') }}
+          </p>
+          <v-text-field
+            v-model="linkName"
+            :label="$t('focusGroup.stimulus.linkName')"
+            variant="outlined"
+            density="compact"
+            hide-details
+            class="mb-2"
+          />
+          <v-text-field
+            v-model="linkUrl"
+            :label="$t('focusGroup.stimulus.linkUrl')"
+            variant="outlined"
+            density="compact"
+            hide-details
+            class="mb-3"
+          />
+          <v-btn
+            variant="tonal"
+            color="primary"
+            prepend-icon="mdi-plus"
+            class="text-none"
+            :disabled="!linkUrl.trim()"
+            :loading="addingLink"
+            @click="addLink"
+          >
+            {{ $t('focusGroup.stimulus.addLink') }}
+          </v-btn>
+        </v-card>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { useStore } from 'vuex'
+import { ref as storageRef, uploadBytes, getDownloadURL } from 'firebase/storage'
+import { storage } from '@/app/plugins/firebase'
+import Stimulus from '@/ux/FocusGroup/models/Stimulus'
+
+const props = defineProps({
+  studyId: {
+    type: String,
+    required: true,
+  },
+  topics: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+const store = useStore()
+
+const stimuli = computed(() => store.getters.test?.stimuli ?? [])
+
+const uploading = ref(false)
+const addingLink = ref(false)
+const deletingId = ref(null)
+const linkName = ref('')
+const linkUrl = ref('')
+
+const typeIcon = (type) =>
+  type === 'video' ? 'mdi-video-outline' : 'mdi-link-variant'
+
+const persist = (nextStimuli) =>
+  store.dispatch('updateStimuli', {
+    studyId: props.studyId,
+    stimuli: nextStimuli,
+  })
+
+const uploadFile = async (file) => {
+  uploading.value = true
+  try {
+    const stimulus = new Stimulus({
+      type: file.type.startsWith('video/') ? 'video' : 'image',
+      name: file.name,
+    })
+    const path = `tests/${props.studyId}/stimulus_${stimulus.id}/${file.name}`
+    const reference = storageRef(storage, path)
+    await uploadBytes(reference, file)
+    stimulus.url = await getDownloadURL(reference)
+    stimulus.storagePath = path
+    await persist([...stimuli.value, stimulus])
+  } finally {
+    uploading.value = false
+  }
+}
+
+const onFilePicked = (event) => {
+  const [file] = event.target.files
+  event.target.value = ''
+  if (file) uploadFile(file)
+}
+
+const onDrop = (event) => {
+  if (uploading.value) return
+  const [file] = event.dataTransfer.files
+  if (file) uploadFile(file)
+}
+
+const addLink = async () => {
+  if (!linkUrl.value.trim()) return
+  addingLink.value = true
+  try {
+    const stimulus = new Stimulus({
+      type: 'url',
+      name: linkName.value.trim() || linkUrl.value.trim(),
+      url: linkUrl.value.trim(),
+    })
+    await persist([...stimuli.value, stimulus])
+    linkName.value = ''
+    linkUrl.value = ''
+  } finally {
+    addingLink.value = false
+  }
+}
+
+const onTopicChange = (stimulus, topicId) => {
+  const next = stimuli.value.map((item) =>
+    item.id === stimulus.id
+      ? new Stimulus({ ...item, topicId: topicId ?? null })
+      : item,
+  )
+  persist(next)
+}
+
+const removeStimulus = async (stimulus) => {
+  deletingId.value = stimulus.id
+  try {
+    const next = stimuli.value.filter((item) => item.id !== stimulus.id)
+    await store.dispatch('deleteStimulus', {
+      studyId: props.studyId,
+      stimulus,
+      stimuli: next,
+    })
+  } finally {
+    deletingId.value = null
+  }
+}
+</script>
+
+<style scoped>
+.stimulus-drop-zone {
+  display: flex;
+  height: 100%;
+  min-height: 140px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  border: 2px dashed #b8c6dc;
+  border-radius: 8px;
+  color: #405166;
+  cursor: pointer;
+  text-align: center;
+  transition: border-color 0.2s ease;
+}
+
+.stimulus-drop-zone:hover {
+  border-color: #00213f;
+}
+
+.stimulus-drop-zone.disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.stimulus-native-input {
+  display: none;
+}
+</style>

--- a/src/ux/FocusGroup/components/session/StimulusPanel.vue
+++ b/src/ux/FocusGroup/components/session/StimulusPanel.vue
@@ -1,0 +1,126 @@
+<template>
+  <v-card class="stimulus-panel" variant="flat" rounded="lg">
+    <p v-if="orderedStimuli.length === 0" class="stimulus-panel__empty">
+      {{ t('focusGroup.session.noStimuli') }}
+    </p>
+
+    <div v-else class="stimulus-panel__list">
+      <div
+        v-for="stimulus in orderedStimuli"
+        :key="stimulus.id"
+        class="stimulus-row"
+        :class="{ 'stimulus-row--active': stimulus.id === presentedStimulusId }"
+      >
+        <v-icon size="18" class="stimulus-row__icon">
+          {{ typeIcon(stimulus.type) }}
+        </v-icon>
+        <span class="stimulus-row__text">{{ stimulus.name }}</span>
+
+        <v-chip
+          v-if="stimulus.id === presentedStimulusId"
+          size="small"
+          color="success"
+          variant="flat"
+          prepend-icon="mdi-check"
+        >
+          {{ t('focusGroup.session.presenting') }}
+        </v-chip>
+        <v-btn
+          v-if="stimulus.id === presentedStimulusId"
+          size="small"
+          variant="text"
+          @click="emit('clear')"
+        >
+          {{ t('focusGroup.session.stopPresenting') }}
+        </v-btn>
+        <v-btn
+          v-else
+          size="small"
+          color="accent"
+          variant="flat"
+          prepend-icon="mdi-monitor-share"
+          @click="emit('present', stimulus.id)"
+        >
+          {{ t('focusGroup.session.present') }}
+        </v-btn>
+      </div>
+    </div>
+  </v-card>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const props = defineProps({
+  stimuli: { type: Array, default: () => [] },
+  // Stimuli tagged to the current topic are surfaced first.
+  currentTopicId: { type: String, default: null },
+  presentedStimulusId: { type: String, default: null },
+})
+
+const emit = defineEmits(['present', 'clear'])
+
+const orderedStimuli = computed(() => {
+  const list = Array.isArray(props.stimuli) ? props.stimuli : []
+  const forTopic = list.filter((item) => item.topicId === props.currentTopicId)
+  const rest = list.filter((item) => item.topicId !== props.currentTopicId)
+  return [...forTopic, ...rest]
+})
+
+const typeIcon = (type) => {
+  if (type === 'video') return 'mdi-video-outline'
+  if (type === 'url') return 'mdi-link-variant'
+  return 'mdi-image-outline'
+}
+</script>
+
+<style scoped>
+.stimulus-panel {
+  padding: 4px;
+}
+
+.stimulus-panel__empty {
+  margin: 0;
+  padding: 8px 4px;
+  font-size: 0.85rem;
+  color: rgba(var(--v-theme-on-surface), 0.5);
+}
+
+.stimulus-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.stimulus-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(var(--v-theme-on-surface), 0.03);
+  border: 1px solid transparent;
+}
+
+.stimulus-row--active {
+  background: rgba(var(--v-theme-success), 0.08);
+  border-color: rgba(var(--v-theme-success), 0.3);
+}
+
+.stimulus-row__icon {
+  flex: 0 0 auto;
+  color: rgb(var(--v-theme-accent));
+}
+
+.stimulus-row__text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.9rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/src/ux/FocusGroup/components/session/StimulusStage.vue
+++ b/src/ux/FocusGroup/components/session/StimulusStage.vue
@@ -1,0 +1,126 @@
+<template>
+  <!-- The stimulus the facilitator is currently presenting. Fills the stage,
+       taking priority over the video call / discussion so everyone looks at
+       the same thing. Renders nothing until one is presented. -->
+  <div v-if="stimulus" class="stimulus-stage">
+    <div class="stimulus-stage__bar">
+      <span class="stimulus-stage__label">
+        <v-icon size="15" color="accent">mdi-monitor-share</v-icon>
+        {{ t('focusGroup.session.presentingStimulus') }}
+        <strong>{{ stimulus.name }}</strong>
+      </span>
+      <v-btn
+        v-if="canClear"
+        size="small"
+        variant="tonal"
+        prepend-icon="mdi-close"
+        class="text-none"
+        @click="emit('clear')"
+      >
+        {{ t('focusGroup.session.stopPresenting') }}
+      </v-btn>
+    </div>
+
+    <div class="stimulus-stage__body">
+      <v-img
+        v-if="stimulus.type === 'image'"
+        :src="stimulus.url"
+        class="stimulus-stage__media"
+      />
+      <video
+        v-else-if="stimulus.type === 'video'"
+        :src="stimulus.url"
+        class="stimulus-stage__media"
+        controls
+      />
+      <a
+        v-else
+        :href="stimulus.url"
+        target="_blank"
+        rel="noopener"
+        class="stimulus-stage__link"
+      >
+        <v-icon size="32" class="mb-2">mdi-open-in-new</v-icon>
+        <span>{{ t('focusGroup.session.openStimulusLink') }}</span>
+        <span class="stimulus-stage__url">{{ stimulus.url }}</span>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+defineProps({
+  // The resolved stimulus being presented; null renders nothing.
+  stimulus: { type: Object, default: null },
+  // Facilitator gets a control to stop presenting.
+  canClear: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['clear'])
+</script>
+
+<style scoped>
+.stimulus-stage {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: 0;
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgb(var(--v-theme-surface));
+  border: 1px solid rgba(var(--v-border-color), 0.12);
+}
+
+.stimulus-stage__bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  background: rgba(var(--v-theme-accent), 0.08);
+  border-bottom: 1px solid rgba(var(--v-theme-accent), 0.22);
+}
+
+.stimulus-stage__label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82rem;
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.stimulus-stage__body {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  background: rgba(var(--v-theme-on-surface), 0.02);
+}
+
+.stimulus-stage__media {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.stimulus-stage__link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px;
+  color: rgb(var(--v-theme-primary));
+  text-align: center;
+}
+
+.stimulus-stage__url {
+  margin-top: 4px;
+  font-size: 0.82rem;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+  word-break: break-all;
+}
+</style>

--- a/src/ux/FocusGroup/components/session/StimulusStage.vue
+++ b/src/ux/FocusGroup/components/session/StimulusStage.vue
@@ -32,7 +32,12 @@
         :src="stimulus.url"
         class="stimulus-stage__media"
         controls
-      />
+      >
+        <!-- Stimulus video is an arbitrary facilitator upload with no
+             caption track available; kept present so assistive tech still
+             gets a captions hook if one is added later. -->
+        <track kind="captions" />
+      </video>
       <a
         v-else
         :href="stimulus.url"

--- a/src/ux/FocusGroup/composables/useFocusGroupSession.js
+++ b/src/ux/FocusGroup/composables/useFocusGroupSession.js
@@ -54,6 +54,9 @@ export function useFocusGroupSession(studyId) {
   const currentPrompt = computed(() => snapshot.value?.currentPrompt ?? null)
   // Observer/note-taker notes, kept per observer: { [userId]: [{ text, timestamp, taskName }] }
   const notes = computed(() => snapshot.value?.notes ?? {})
+  // The stimulus the facilitator is currently presenting, scoped to a topic so
+  // advancing the guide can retire it. { stimulusId, topicId, presentedAt } | null
+  const currentStimulus = computed(() => snapshot.value?.currentStimulus ?? null)
   // Per-topic countdown timer. Clients tick locally from `endsAt`; only the
   // facilitator's play/pause/reset write here, so there are no per-second writes.
   // { topicId, running, endsAt, remainingMs } | null
@@ -161,6 +164,31 @@ export function useFocusGroupSession(studyId) {
   }
 
   /**
+   * Present a stimulus to every attendee. Scoped to the topic so moving on
+   * naturally retires it; a new presentation overwrites the previous one.
+   */
+  async function presentStimulus({ stimulusId, topicId }) {
+    await update(rootRef, {
+      currentStimulus: {
+        stimulusId: stimulusId ?? null,
+        topicId: topicId ?? null,
+        presentedAt: serverTimestamp(),
+      },
+      lastUpdate: serverTimestamp(),
+    })
+  }
+
+  /**
+   * Stop presenting so no stimulus is shown to participants.
+   */
+  async function clearStimulus() {
+    await update(rootRef, {
+      currentStimulus: null,
+      lastUpdate: serverTimestamp(),
+    })
+  }
+
+  /**
    * Persist an observer's notes. Kept under their own user id so each observer
    * keeps a private, timestamped, topic-tagged record that survives a refresh.
    */
@@ -250,6 +278,7 @@ export function useFocusGroupSession(studyId) {
     currentPrompt,
     notes,
     timer,
+    currentStimulus,
     loaded,
     isLive,
     isEnded,
@@ -265,6 +294,8 @@ export function useFocusGroupSession(studyId) {
     recordConsent,
     askPrompt,
     clearPrompt,
+    presentStimulus,
+    clearStimulus,
     saveNotes,
     playTimer,
     pauseTimer,

--- a/src/ux/FocusGroup/controllers/FocusGroupController.js
+++ b/src/ux/FocusGroup/controllers/FocusGroupController.js
@@ -39,6 +39,17 @@ export default class FocusGroupController extends Controller {
     })
   }
 
+  async updateStimuli(id, stimuli) {
+    return this.update(COLLECTION, id, {
+      stimuli: stimuli.map((stimulus) =>
+        typeof stimulus.toFirestore === 'function'
+          ? stimulus.toFirestore()
+          : stimulus,
+      ),
+      updateDate: Date.now(),
+    })
+  }
+
   /**
    * Persist a finished live session into the study's answer document, keyed by
    * session id under the `sessions` map.

--- a/src/ux/FocusGroup/models/FocusGroupStudy.js
+++ b/src/ux/FocusGroup/models/FocusGroupStudy.js
@@ -2,6 +2,7 @@ import { STUDY_TYPES } from '@/shared/constants/methodDefinitions'
 import Study from '@/shared/models/Study'
 import DiscussionTopic from './DiscussionTopic'
 import FocusGroupConfig from './FocusGroupConfig'
+import Stimulus from './Stimulus'
 
 /**
  * Represents a Focus Group study.
@@ -21,12 +22,16 @@ export default class FocusGroupStudy extends Study {
       params.config instanceof FocusGroupConfig
         ? params.config
         : new FocusGroupConfig(params.config ?? {})
+    this.stimuli = (params.stimuli ?? []).map((stimulus) =>
+      stimulus instanceof Stimulus ? stimulus : new Stimulus(stimulus),
+    )
   }
 
   toFirestore() {
     return Object.assign(super.toFirestore(), {
       discussionGuide: this.discussionGuide.map((topic) => topic.toFirestore()),
       config: this.config.toFirestore(),
+      stimuli: this.stimuli.map((stimulus) => stimulus.toFirestore()),
     })
   }
 }

--- a/src/ux/FocusGroup/models/Stimulus.js
+++ b/src/ux/FocusGroup/models/Stimulus.js
@@ -1,0 +1,44 @@
+/**
+ * A stimulus (image, video, or link) a facilitator can present during a
+ * Focus Group session.
+ *
+ * @param {string} type - 'image' | 'video' | 'url'.
+ * @param {string} name - Display name shown in the library and stage.
+ * @param {string} url - Download URL (Storage) or the raw link (type 'url').
+ * @param {string|null} storagePath - Firebase Storage path, null for 'url' stimuli.
+ * @param {string|null} topicId - Optional discussion topic this stimulus is tagged to.
+ */
+export default class Stimulus {
+  constructor({ id, type, name, url, storagePath, topicId, createdAt } = {}) {
+    this.id = id ?? Stimulus.generateId()
+    this.type = type ?? 'image'
+    this.name = name ?? ''
+    this.url = url ?? ''
+    this.storagePath = storagePath ?? null
+    this.topicId = topicId ?? null
+    this.createdAt = createdAt ?? Date.now()
+  }
+
+  static generateId() {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+      return `stimulus-${crypto.randomUUID()}`
+    }
+    return `stimulus-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  }
+
+  toFirestore() {
+    return {
+      id: this.id,
+      type: this.type,
+      name: this.name,
+      url: this.url,
+      storagePath: this.storagePath,
+      topicId: this.topicId,
+      createdAt: this.createdAt,
+    }
+  }
+
+  static fromFirestore(data = {}) {
+    return new Stimulus(data)
+  }
+}

--- a/src/ux/FocusGroup/models/Stimulus.js
+++ b/src/ux/FocusGroup/models/Stimulus.js
@@ -23,7 +23,16 @@ export default class Stimulus {
     if (typeof crypto !== 'undefined' && crypto.randomUUID) {
       return `stimulus-${crypto.randomUUID()}`
     }
-    return `stimulus-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+      const array = new Uint32Array(2)
+      crypto.getRandomValues(array)
+      return `stimulus-${Date.now()}-${array[0].toString(36)}${array[1].toString(36)}`
+    }
+    // No Web Crypto available (e.g. the Jest test environment). This id is
+    // never security-sensitive, only unique-per-session, so a counter is a
+    // fine last resort and avoids reaching for a non-cryptographic PRNG.
+    Stimulus.fallbackIdCounter = (Stimulus.fallbackIdCounter ?? 0) + 1
+    return `stimulus-${Date.now()}-${Stimulus.fallbackIdCounter.toString(36)}`
   }
 
   toFirestore() {

--- a/src/ux/FocusGroup/store/FocusGroup.js
+++ b/src/ux/FocusGroup/store/FocusGroup.js
@@ -1,4 +1,5 @@
 import FocusGroupController from '@/ux/FocusGroup/controllers/FocusGroupController'
+import { deleteStudyStorageFile } from '@/shared/services/studyStorageService'
 import i18n from '@/app/plugins/i18n'
 
 const focusGroupController = new FocusGroupController()
@@ -57,6 +58,44 @@ export default {
         throw err
       } finally {
         commit('setLoading', false)
+      }
+    },
+
+    /**
+     * Persist the stimulus library immediately (not batched behind Save) so an
+     * uploaded file is never left orphaned in Storage without a saved reference.
+     */
+    async updateStimuli({ commit, dispatch }, { studyId, stimuli }) {
+      try {
+        await focusGroupController.updateStimuli(studyId, stimuli)
+        await dispatch('getStudy', { id: studyId })
+      } catch (err) {
+        commit('SET_TOAST', {
+          message: i18n.global.t('errors.globalError'),
+          type: 'error',
+        })
+        throw err
+      }
+    },
+
+    /**
+     * Remove a stimulus from the library. Link-only stimuli have no Storage
+     * file to clean up; uploaded stimuli are deleted via the Cloud Function
+     * proxy, matching the rest of the app's storage-delete flow.
+     */
+    async deleteStimulus({ commit, dispatch }, { studyId, stimulus, stimuli }) {
+      try {
+        if (stimulus.storagePath) {
+          await deleteStudyStorageFile(studyId, stimulus.storagePath)
+        }
+        await focusGroupController.updateStimuli(studyId, stimuli)
+        await dispatch('getStudy', { id: studyId })
+      } catch (err) {
+        commit('SET_TOAST', {
+          message: i18n.global.t('errors.globalError'),
+          type: 'error',
+        })
+        throw err
       }
     },
   },

--- a/src/ux/FocusGroup/views/EditFocusGroupView.vue
+++ b/src/ux/FocusGroup/views/EditFocusGroupView.vue
@@ -20,6 +20,9 @@
           <v-tab @click="index = 2">
             {{ $t('focusGroup.edit.tabs.guide') }}
           </v-tab>
+          <v-tab @click="index = 3">
+            {{ $t('focusGroup.edit.tabs.stimuli') }}
+          </v-tab>
         </v-tabs>
 
         <v-col cols="12">
@@ -59,6 +62,16 @@
               <DiscussionGuideEditor v-model="topics" />
             </v-card>
           </div>
+
+          <!-- STIMULI -->
+          <div v-if="index === 3">
+            <v-card elevation="2" rounded="lg" class="pa-6">
+              <StimulusLibraryEditor
+                :study-id="route.params.id"
+                :topics="topics"
+              />
+            </v-card>
+          </div>
         </v-col>
       </div>
     </v-container>
@@ -68,6 +81,7 @@
 <script setup>
 import DiscussionGuideEditor from '@/ux/FocusGroup/components/DiscussionGuideEditor.vue'
 import SessionConfigEditor from '@/ux/FocusGroup/components/SessionConfigEditor.vue'
+import StimulusLibraryEditor from '@/ux/FocusGroup/components/StimulusLibraryEditor.vue'
 import DiscussionTopic from '@/ux/FocusGroup/models/DiscussionTopic'
 import FocusGroupConfig from '@/ux/FocusGroup/models/FocusGroupConfig'
 import PageWrapper from '@/shared/views/template/PageWrapper.vue'

--- a/src/ux/FocusGroup/views/FocusGroupSessionView.vue
+++ b/src/ux/FocusGroup/views/FocusGroupSessionView.vue
@@ -107,8 +107,15 @@
           />
 
           <div class="fg-stage-body">
+            <StimulusStage
+              v-if="stageMode === 'stimulus'"
+              class="fg-fill"
+              :stimulus="resolvedStimulus"
+              :can-clear="isFacilitator"
+              @clear="onClearStimulus"
+            />
             <SessionVideoStage
-              v-if="videoEnabled"
+              v-else-if="stageMode === 'video'"
               class="fg-fill"
               :remote-participants="remoteParticipants"
               :screen-share-feeds="screenShareFeeds"
@@ -373,6 +380,16 @@
             </p>
           </div>
 
+          <div v-else-if="panelTab === 'stimuli'" class="fg-panel-scroll">
+            <StimulusPanel
+              :stimuli="stimuli"
+              :current-topic-id="currentTopicId"
+              :presented-stimulus-id="currentStimulus?.stimulusId ?? null"
+              @present="onPresentStimulus"
+              @clear="onClearStimulus"
+            />
+          </div>
+
           <div v-else-if="panelTab === 'notes'" class="fg-fill fg-notes">
             <ObservatorNotes
               v-model="observerNotes"
@@ -401,6 +418,8 @@ import SessionVideoStage from '@/ux/FocusGroup/components/session/SessionVideoSt
 import TopicPanel from '@/ux/FocusGroup/components/session/TopicPanel.vue'
 import SessionTimer from '@/ux/FocusGroup/components/session/SessionTimer.vue'
 import CurrentQuestion from '@/ux/FocusGroup/components/session/CurrentQuestion.vue'
+import StimulusPanel from '@/ux/FocusGroup/components/session/StimulusPanel.vue'
+import StimulusStage from '@/ux/FocusGroup/components/session/StimulusStage.vue'
 import TopicDiscussion from '@/ux/FocusGroup/components/session/TopicDiscussion.vue'
 import ParticipantList from '@/ux/FocusGroup/components/session/ParticipantList.vue'
 import ObservatorNotes from '@/ux/UserTest/components/ObservatorNotes.vue'
@@ -427,6 +446,7 @@ const {
   currentPrompt,
   notes,
   timer,
+  currentStimulus,
   loaded,
   isLive,
   isEnded,
@@ -438,6 +458,8 @@ const {
   recordConsent,
   askPrompt,
   clearPrompt,
+  presentStimulus,
+  clearStimulus,
   saveNotes,
   playTimer,
   pauseTimer,
@@ -482,6 +504,17 @@ const currentTopic = computed(
   () => discussionGuide.value[currentTopicIndex.value] ?? null,
 )
 const currentTopicId = computed(() => currentTopic.value?.id ?? null)
+
+// --- Stimuli ---
+const stimuli = computed(() =>
+  Array.isArray(test.value?.stimuli) ? test.value.stimuli : [],
+)
+// The client resolves the presented stimulus locally: RTDB only syncs the id.
+const resolvedStimulus = computed(() => {
+  const stimulusId = currentStimulus.value?.stimulusId
+  if (!stimulusId) return null
+  return stimuli.value.find((item) => item.id === stimulusId) ?? null
+})
 
 // The active question shown to everyone, scoped to the current topic so a stale
 // prompt from a previous topic never leaks onto the next one.
@@ -582,6 +615,15 @@ const videoEnabled = computed(
   () => sessionConfig.value.enableVideoCall === true,
 )
 
+// A presented stimulus takes over the stage from the video call or discussion,
+// the same way a screen share would — everyone should be looking at the same
+// thing. Camera tiles simply hide while a stimulus is up (no PiP yet).
+const stageMode = computed(() => {
+  if (resolvedStimulus.value) return 'stimulus'
+  if (videoEnabled.value) return 'video'
+  return 'discussion'
+})
+
 // Side-panel tabs, in reading order: the facilitator's guide, the discussion
 // (a tab only when video owns the stage, otherwise the discussion IS the
 // stage), then the people roster.
@@ -592,6 +634,12 @@ const panelTabs = computed(() => {
       key: 'guide',
       icon: 'mdi-script-text-outline',
       label: 'focusGroup.session.guide',
+    })
+  if (isFacilitator.value && stimuli.value.length > 0)
+    tabs.push({
+      key: 'stimuli',
+      icon: 'mdi-image-multiple-outline',
+      label: 'focusGroup.session.stimuli',
     })
   if (videoEnabled.value)
     tabs.push({
@@ -794,6 +842,11 @@ const onAsk = (prompt) => {
   askPrompt({ text: prompt.trim(), topicId: currentTopicId.value })
 }
 const onClearPrompt = () => clearPrompt()
+
+// Facilitator presents a stimulus to everyone (or stops presenting).
+const onPresentStimulus = (stimulusId) =>
+  presentStimulus({ stimulusId, topicId: currentTopicId.value })
+const onClearStimulus = () => clearStimulus()
 
 // --- Observer notes (reuses the moderated ObservatorNotes tool) ---
 const observerNotes = ref([])

--- a/src/ux/FocusGroup/views/FocusGroupSessionView.vue
+++ b/src/ux/FocusGroup/views/FocusGroupSessionView.vue
@@ -516,6 +516,20 @@ const resolvedStimulus = computed(() => {
   return stimuli.value.find((item) => item.id === stimulusId) ?? null
 })
 
+// `test.stimuli` is fetched once on mount, not live-synced. A stimulus added
+// to the library after a participant/observer already joined the session is
+// invisible to them until something refreshes the study — so a presented id
+// that isn't resolvable locally means the library is stale, not that nothing
+// was presented. Re-fetch once to pick it up.
+watch(
+  () => currentStimulus.value?.stimulusId,
+  (stimulusId) => {
+    if (!stimulusId) return
+    const known = stimuli.value.some((item) => item.id === stimulusId)
+    if (!known) store.dispatch('getStudy', { id: studyId })
+  },
+)
+
 // The active question shown to everyone, scoped to the current topic so a stale
 // prompt from a previous topic never leaks onto the next one.
 const activePromptText = computed(() =>

--- a/storage.rules
+++ b/storage.rules
@@ -64,13 +64,26 @@ service firebase.storage {
       );
     }
 
+    function isFocusGroupStudy(studyId) {
+      return study(studyId).testType == 'FOCUS_GROUP';
+    }
+
+    // Focus Group roles (studyRoleMap scale): 0 facilitator, 1 participant,
+    // 3 observer, 4 co-facilitator. All of them may view a presented stimulus.
+    function canViewFocusGroupStimulus(studyId) {
+      return signedIn() && isFocusGroupStudy(studyId) &&
+        roleFor(studyId) in [0, 1, 3, 4];
+    }
+
     match /tests/{studyId}/{userId}/{allPaths=**} {
       allow read: if canAccessStorage(studyId) ||
         (userId.matches('heuristic_.*') && canEditStudy(studyId)) ||
+        (userId.matches('stimulus_.*') && canViewFocusGroupStimulus(studyId)) ||
         (request.auth.uid == userId && canAnswerStudy(studyId));
       allow create, update: if
         canAccessStorage(studyId) ||
         (userId.matches('heuristic_.*') && canEditStudy(studyId)) ||
+        (userId.matches('stimulus_.*') && canEditStudy(studyId)) ||
         (request.auth.uid == userId && canAnswerStudy(studyId));
       allow delete: if false;
     }

--- a/tests/rules/studyAccess.rules.spec.js
+++ b/tests/rules/studyAccess.rules.spec.js
@@ -450,4 +450,43 @@ describe('Storage study RBAC', () => {
     )
     await assertFails(uploadBytes(unsupportedUserRecording, new Uint8Array([1])))
   })
+
+  it('lets a Focus Group facilitator upload a stimulus and every session role read it, but denies writes from non-facilitators', async () => {
+    await testEnv.withSecurityRulesDisabled((adminContext) =>
+      updateDoc(doc(adminContext.firestore(), 'tests/study-1'), {
+        testType: 'FOCUS_GROUP',
+        studyRoleMap: { admin: 0, manager: 4, user: 1, observator: 3 },
+      }),
+    )
+
+    const facilitatorUpload = ref(
+      context('admin').storage(),
+      'tests/study-1/stimulus_1/homepage.png',
+    )
+    await assertSucceeds(uploadBytes(facilitatorUpload, new Uint8Array([1])))
+
+    const participantRead = ref(
+      context('user').storage(),
+      'tests/study-1/stimulus_1/homepage.png',
+    )
+    await assertSucceeds(getBytes(participantRead))
+
+    const observerRead = ref(
+      context('observator').storage(),
+      'tests/study-1/stimulus_1/homepage.png',
+    )
+    await assertSucceeds(getBytes(observerRead))
+
+    const strangerRead = ref(
+      context('stranger').storage(),
+      'tests/study-1/stimulus_1/homepage.png',
+    )
+    await assertFails(getBytes(strangerRead))
+
+    const participantUpload = ref(
+      context('user').storage(),
+      'tests/study-1/stimulus_2/blocked.png',
+    )
+    await assertFails(uploadBytes(participantUpload, new Uint8Array([1])))
+  })
 })

--- a/tests/rules/studyAccess.rules.spec.js
+++ b/tests/rules/studyAccess.rules.spec.js
@@ -469,7 +469,8 @@ describe('Storage study RBAC', () => {
       context('user').storage(),
       'tests/study-1/stimulus_1/homepage.png',
     )
-    await assertSucceeds(getBytes(participantRead))
+    const downloaded = await getBytes(participantRead)
+    expect(new Uint8Array(downloaded)).toEqual(new Uint8Array([1]))
 
     const observerRead = ref(
       context('observator').storage(),

--- a/tests/unit/Stimulus.spec.js
+++ b/tests/unit/Stimulus.spec.js
@@ -1,0 +1,52 @@
+import Stimulus from '@/ux/FocusGroup/models/Stimulus'
+
+describe('Stimulus', () => {
+  it('fills in defaults and generates an id when constructed empty', () => {
+    const stimulus = new Stimulus()
+
+    expect(stimulus.id).toMatch(/^stimulus-/)
+    expect(stimulus.type).toBe('image')
+    expect(stimulus.name).toBe('')
+    expect(stimulus.url).toBe('')
+    expect(stimulus.storagePath).toBeNull()
+    expect(stimulus.topicId).toBeNull()
+    expect(typeof stimulus.createdAt).toBe('number')
+  })
+
+  it('generates unique ids', () => {
+    const a = Stimulus.generateId()
+    const b = Stimulus.generateId()
+
+    expect(a).not.toBe(b)
+  })
+
+  it('round-trips an image stimulus through Firestore', () => {
+    const original = new Stimulus({
+      id: 'stimulus-1',
+      type: 'image',
+      name: 'Homepage mock',
+      url: 'https://storage.example.com/homepage.png',
+      storagePath: 'tests/study-1/stimulus_stimulus-1/homepage.png',
+      topicId: 'topic-1',
+      createdAt: 1700000000000,
+    })
+
+    const restored = Stimulus.fromFirestore(original.toFirestore())
+
+    expect(restored).toEqual(original)
+  })
+
+  it('round-trips a url stimulus with no storagePath', () => {
+    const original = new Stimulus({
+      type: 'url',
+      name: 'Live prototype',
+      url: 'https://figma.com/proto/abc',
+      topicId: null,
+    })
+
+    const restored = Stimulus.fromFirestore(original.toFirestore())
+
+    expect(restored.storagePath).toBeNull()
+    expect(restored.url).toBe('https://figma.com/proto/abc')
+  })
+})


### PR DESCRIPTION
## Summary

Focus groups are usually run around something concrete , a design, a prototype, a screen, an ad .. so this adds a stimulus library to the Focus Group module and lets the facilitator present one live during a
session.

- **Study config**: a new "Stimuli" tab on the edit view lets the facilitator upload an image/video or add a link, and optionally tag it to a discussion topic. Persists immediately (not batched behind Save) so an uploaded file is never orphaned in Storage.
- **Live session**: a facilitator-only Stimuli panel lists the library (topic-tagged items surfaced first) with a Present/Stop control per item. Presenting takes over the main stage for every attendee in real time - facilitator, participants, and observers - the same way a screen share would.

## Bugs caught and fixed during manual QA

- **Storage RBAC gap**: `storage.rules`'s `canAccessStorage()` only granted read access to the facilitator. As originally drafted this would have permission-denied participants/observers trying to view a presented stimulus , defeating the point of the feature. Fixed with a Focus-Group-aware `canViewFocusGroupStimulus` carve-out (mirrors the pattern `firestore.rules` already uses) plus a `stimulus_.*` Storage path convention alongside the existing `heuristic_.*` one. Covered by a new case in `tests/rules/studyAccess.rules.spec.js`.
- **Protocol-less links**: a link stimulus added without `https://` (e.g. `example.com`) resolved as relative to the current page instead of an external site, silently routing inside the app instead of opening the link. Fixed by normalizing to `https://` when no protocol is given.
- **Stale library mid-session**: `test.stimuli` is fetched once on mount, not live-synced. A stimulus added to the library after a participant or observer had already joined the session was invisible to them — the stage would silently fall back to video/discussion instead of showing what was presented. Fixed by re-fetching the study when a presented stimulus id isn't resolvable locally.


## Video



https://github.com/user-attachments/assets/0f59ab16-fac5-4340-88ce-429114e728c2



---
Closes #2228 