### PR TITLE
feat(focus-group): live participation tracker

### DIFF
--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -2620,6 +2620,8 @@
       "sessionInfo": "Session",
       "showParticipants": "Show participants",
       "hideParticipants": "Hide participants",
+      "participationPercent": "{percent}%",
+      "participationHint": "Share of session messages from this participant",
       "muteMicrophone": "Mute microphone",
       "unmuteMicrophone": "Unmute microphone",
       "turnCameraOff": "Turn off camera",

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -2621,7 +2621,7 @@
       "showParticipants": "Show participants",
       "hideParticipants": "Hide participants",
       "participationPercent": "{percent}%",
-      "participationHint": "Share of session messages from this participant",
+      "participationHint": "Share of session activity from this participant (messages and speaking time)",
       "muteMicrophone": "Mute microphone",
       "unmuteMicrophone": "Unmute microphone",
       "turnCameraOff": "Turn off camera",

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -2521,7 +2521,7 @@
       "showParticipants": "Mostrar participantes",
       "hideParticipants": "Ocultar participantes",
       "participationPercent": "{percent}%",
-      "participationHint": "Proporción de mensajes de la sesión de este participante",
+      "participationHint": "Proporción de la actividad de la sesión de este participante (mensajes y tiempo hablando)",
       "muteMicrophone": "Silenciar micrófono",
       "unmuteMicrophone": "Activar micrófono",
       "turnCameraOff": "Apagar cámara",

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -2520,6 +2520,8 @@
       "sessionInfo": "Sesión",
       "showParticipants": "Mostrar participantes",
       "hideParticipants": "Ocultar participantes",
+      "participationPercent": "{percent}%",
+      "participationHint": "Proporción de mensajes de la sesión de este participante",
       "muteMicrophone": "Silenciar micrófono",
       "unmuteMicrophone": "Activar micrófono",
       "turnCameraOff": "Apagar cámara",

--- a/src/ux/FocusGroup/components/session/ParticipantList.vue
+++ b/src/ux/FocusGroup/components/session/ParticipantList.vue
@@ -43,6 +43,15 @@
           >
             mdi-message-text
           </v-icon>
+          <v-chip
+            v-if="isFacilitator && entry.isParticipant"
+            size="x-small"
+            variant="tonal"
+            :color="participationColor(entry.participation)"
+            :title="t('focusGroup.session.participationHint')"
+          >
+            {{ t('focusGroup.session.participationPercent', { percent: entry.participation }) }}
+          </v-chip>
         </div>
       </div>
     </div>
@@ -61,6 +70,10 @@ const props = defineProps({
   // ids that have submitted a response for the current topic
   respondedIds: { type: Array, default: () => [] },
   currentUserId: { type: String, default: '' },
+  // { userId: percent } — each participant's share of session messages.
+  // Facilitator-only signal, so it's only rendered when isFacilitator is set.
+  participation: { type: Object, default: () => ({}) },
+  isFacilitator: { type: Boolean, default: false },
 })
 
 // The role is stored as a localized label, so colour by matching the known
@@ -71,6 +84,16 @@ const roleStyle = (role) => {
   if (role === t('focusGroup.session.roleObserver'))
     return { color: 'orange', icon: 'mdi-eye' }
   return { color: 'green', icon: 'mdi-account' }
+}
+
+// Below this share of the session's messages, a participant is flagged as
+// low-engagement so the facilitator can draw them into the discussion.
+const LOW_PARTICIPATION_THRESHOLD = 15
+
+const participationColor = (percent) => {
+  if (percent === 0) return 'error'
+  if (percent < LOW_PARTICIPATION_THRESHOLD) return 'warning'
+  return 'grey'
 }
 
 const entries = computed(() =>
@@ -84,6 +107,8 @@ const entries = computed(() =>
       connected: value?.connected === true,
       color: style.color,
       icon: style.icon,
+      isParticipant: role === t('focusGroup.session.roleParticipant'),
+      participation: props.participation[id] ?? 0,
     }
   }),
 )

--- a/src/ux/FocusGroup/composables/useSpeakingTime.js
+++ b/src/ux/FocusGroup/composables/useSpeakingTime.js
@@ -1,0 +1,53 @@
+import { ref, watch, onBeforeUnmount } from 'vue'
+import { RoomEvent } from 'livekit-client'
+import { applyActiveSpeakersChange } from '@/ux/FocusGroup/utils/speakingTime'
+
+/**
+ * Tracks accumulated LiveKit speaking time per participant identity, for as
+ * long as this client stays connected to the room. Ephemeral/client-side
+ * only (like message counts are already read live, nothing new is written
+ * to RTDB) — every connected client, including the facilitator, receives
+ * `ActiveSpeakersChanged` for the whole room, so this needs no new backend.
+ *
+ * @param {import('vue').Ref} roomRef - the LiveKit Room ref from useLiveKitRoom.
+ * @returns {{ speakingMs: import('vue').Ref<Object> }} { [identity]: ms }
+ */
+export function useSpeakingTime(roomRef) {
+  const speakingMs = ref({})
+  let activeSince = {}
+  let attachedRoom = null
+
+  function handleActiveSpeakersChanged(speakers) {
+    const result = applyActiveSpeakersChange({
+      accumulatedMs: speakingMs.value,
+      activeSince,
+      speakingIdentities: speakers.map((participant) => participant.identity),
+      now: Date.now(),
+    })
+    speakingMs.value = result.accumulatedMs
+    activeSince = result.activeSince
+  }
+
+  function detach() {
+    if (attachedRoom) {
+      attachedRoom.off(RoomEvent.ActiveSpeakersChanged, handleActiveSpeakersChanged)
+      attachedRoom = null
+    }
+  }
+
+  watch(
+    roomRef,
+    (room) => {
+      detach()
+      if (room) {
+        room.on(RoomEvent.ActiveSpeakersChanged, handleActiveSpeakersChanged)
+        attachedRoom = room
+      }
+    },
+    { immediate: true },
+  )
+
+  onBeforeUnmount(detach)
+
+  return { speakingMs }
+}

--- a/src/ux/FocusGroup/utils/participation.js
+++ b/src/ux/FocusGroup/utils/participation.js
@@ -1,32 +1,77 @@
 /**
- * Each participant's share of the session's discussion messages, as a
- * percentage of the total. Purely derived from data already tracked by
- * `useFocusGroupSession` (RTDB `messages/{topicId}/{messageId}`) — no new
- * writes needed. Facilitator-only signal: "identify the percentage
- * participation of each user".
+ * Each participant's share of the session's overall activity, as a
+ * percentage. Blends two independent signals so a participant who mostly
+ * talks isn't invisible next to one who mostly types:
+ *
+ * - message share: text messages posted, from RTDB `messages/{topicId}/{messageId}`
+ * - speaking share: LiveKit active-speaker time, from useSpeakingTime()
+ *
+ * Facilitator-only signal: "identify the percentage participation of each
+ * user". When only one signal has any data, that signal alone decides the
+ * split — averaging against an all-zero signal would otherwise flatten
+ * everyone toward 50%.
+ *
+ * @param {Object} params
+ * @param {Object} params.messages - { [topicId]: { [messageId]: { userId, ... } } }
+ * @param {Object} [params.speakingMs] - { [userId]: accumulated milliseconds speaking }
+ * @returns {Object} { [userId]: percent } — percent is 0-100, rounded to the
+ *   nearest whole number. Empty when neither signal has any data yet.
+ */
+export function computeParticipation({ messages, speakingMs } = {}) {
+  const messageShares = sharesFromCounts(countMessagesByUser(messages))
+  const speakingShares = sharesFromCounts(speakingMs ?? {})
+
+  const hasMessages = Object.keys(messageShares).length > 0
+  const hasSpeaking = Object.keys(speakingShares).length > 0
+  if (!hasMessages && !hasSpeaking) return {}
+
+  const userIds = new Set([
+    ...Object.keys(messageShares),
+    ...Object.keys(speakingShares),
+  ])
+
+  const percentages = {}
+  userIds.forEach((userId) => {
+    const blended =
+      hasMessages && hasSpeaking
+        ? ((messageShares[userId] ?? 0) + (speakingShares[userId] ?? 0)) / 2
+        : (messageShares[userId] ?? speakingShares[userId] ?? 0)
+    percentages[userId] = Math.round(blended)
+  })
+  return percentages
+}
+
+/**
+ * Raw message count per author, across every topic in the session.
  *
  * @param {Object} messages - { [topicId]: { [messageId]: { userId, ... } } }
- * @returns {Object} { [userId]: percent } — percent is 0-100, rounded to the
- *   nearest whole number. Empty when no messages have been sent yet.
+ * @returns {Object} { [userId]: count }
  */
-export function computeParticipation(messages) {
+export function countMessagesByUser(messages) {
   const counts = {}
-  let total = 0
-
   Object.values(messages ?? {}).forEach((topicMessages) => {
     Object.values(topicMessages ?? {}).forEach((message) => {
       const userId = message?.userId
       if (!userId) return
       counts[userId] = (counts[userId] ?? 0) + 1
-      total += 1
     })
   })
+  return counts
+}
 
+/**
+ * Normalizes a { [userId]: quantity } map (message counts, milliseconds
+ * spoken, anything additive) into each key's percentage share of the total.
+ *
+ * @param {Object} counts - { [userId]: number }
+ * @returns {Object} { [userId]: percent } — unrounded; empty when the total is 0.
+ */
+function sharesFromCounts(counts) {
+  const total = Object.values(counts).reduce((sum, count) => sum + count, 0)
   if (total === 0) return {}
-
-  const percentages = {}
+  const shares = {}
   Object.entries(counts).forEach(([userId, count]) => {
-    percentages[userId] = Math.round((count / total) * 100)
+    shares[userId] = (count / total) * 100
   })
-  return percentages
+  return shares
 }

--- a/src/ux/FocusGroup/utils/participation.js
+++ b/src/ux/FocusGroup/utils/participation.js
@@ -1,0 +1,32 @@
+/**
+ * Each participant's share of the session's discussion messages, as a
+ * percentage of the total. Purely derived from data already tracked by
+ * `useFocusGroupSession` (RTDB `messages/{topicId}/{messageId}`) — no new
+ * writes needed. Facilitator-only signal: "identify the percentage
+ * participation of each user".
+ *
+ * @param {Object} messages - { [topicId]: { [messageId]: { userId, ... } } }
+ * @returns {Object} { [userId]: percent } — percent is 0-100, rounded to the
+ *   nearest whole number. Empty when no messages have been sent yet.
+ */
+export function computeParticipation(messages) {
+  const counts = {}
+  let total = 0
+
+  Object.values(messages ?? {}).forEach((topicMessages) => {
+    Object.values(topicMessages ?? {}).forEach((message) => {
+      const userId = message?.userId
+      if (!userId) return
+      counts[userId] = (counts[userId] ?? 0) + 1
+      total += 1
+    })
+  })
+
+  if (total === 0) return {}
+
+  const percentages = {}
+  Object.entries(counts).forEach(([userId, count]) => {
+    percentages[userId] = Math.round((count / total) * 100)
+  })
+  return percentages
+}

--- a/src/ux/FocusGroup/utils/speakingTime.js
+++ b/src/ux/FocusGroup/utils/speakingTime.js
@@ -1,0 +1,47 @@
+/**
+ * Pure accumulator for LiveKit's `ActiveSpeakersChanged` event: turns a
+ * sequence of "who's speaking right now" snapshots into accumulated
+ * speaking duration per identity. Kept LiveKit/Vue-free so it's trivially
+ * unit-testable — the composable that calls this owns the room listener.
+ *
+ * Time is only added to `accumulatedMs` when a speaker *stops* (transitions
+ * out of the active-speakers set), not continuously — simpler than a
+ * ticking clock, and in real conversation people pause often enough that
+ * this still updates the UI at a natural cadence.
+ *
+ * @param {Object} params
+ * @param {Object} params.accumulatedMs - { [identity]: ms } so far.
+ * @param {Object} params.activeSince - { [identity]: timestamp } for
+ *   identities currently mid-speech (started but not yet stopped).
+ * @param {string[]} params.speakingIdentities - who LiveKit reports as
+ *   actively speaking right now.
+ * @param {number} params.now - current time in ms (injectable for tests).
+ * @returns {{ accumulatedMs: Object, activeSince: Object }} new state;
+ *   inputs are not mutated.
+ */
+export function applyActiveSpeakersChange({
+  accumulatedMs,
+  activeSince,
+  speakingIdentities,
+  now,
+}) {
+  const nextAccumulated = { ...accumulatedMs }
+  const nextActiveSince = { ...activeSince }
+  const speakingSet = new Set(speakingIdentities ?? [])
+
+  Object.keys(nextActiveSince).forEach((identity) => {
+    if (speakingSet.has(identity)) return
+    const startedAt = nextActiveSince[identity]
+    delete nextActiveSince[identity]
+    nextAccumulated[identity] =
+      (nextAccumulated[identity] ?? 0) + Math.max(0, now - startedAt)
+  })
+
+  speakingSet.forEach((identity) => {
+    if (!(identity in nextActiveSince)) {
+      nextActiveSince[identity] = now
+    }
+  })
+
+  return { accumulatedMs: nextAccumulated, activeSince: nextActiveSince }
+}

--- a/src/ux/FocusGroup/views/FocusGroupSessionView.vue
+++ b/src/ux/FocusGroup/views/FocusGroupSessionView.vue
@@ -355,6 +355,8 @@
               :participants="participants"
               :responded-ids="respondedIds"
               :current-user-id="user?.id"
+              :participation="participationByUser"
+              :is-facilitator="isFacilitator"
             />
           </div>
 
@@ -396,6 +398,7 @@ import { Track } from 'livekit-client'
 import { ACCESS_LEVEL } from '@/shared/utils/accessLevel'
 import { useLiveKitRoom } from '@/shared/components/videoCall/composables/useLiveKitRoom'
 import { useFocusGroupSession } from '@/ux/FocusGroup/composables/useFocusGroupSession'
+import { computeParticipation } from '@/ux/FocusGroup/utils/participation'
 import SessionLobby from '@/ux/FocusGroup/components/session/SessionLobby.vue'
 import SessionVideoStage from '@/ux/FocusGroup/components/session/SessionVideoStage.vue'
 import TopicPanel from '@/ux/FocusGroup/components/session/TopicPanel.vue'
@@ -735,6 +738,10 @@ const currentMessages = computed(() => {
 const respondedIds = computed(() => [
   ...new Set(currentMessages.value.map((m) => m.userId)),
 ])
+
+// Facilitator-only signal: each participant's share of the session's
+// messages so far (across all topics, not just the current one).
+const participationByUser = computed(() => computeParticipation(messages.value))
 
 // --- Facilitator actions ---
 const onStart = async () => {

--- a/src/ux/FocusGroup/views/FocusGroupSessionView.vue
+++ b/src/ux/FocusGroup/views/FocusGroupSessionView.vue
@@ -398,6 +398,7 @@ import { Track } from 'livekit-client'
 import { ACCESS_LEVEL } from '@/shared/utils/accessLevel'
 import { useLiveKitRoom } from '@/shared/components/videoCall/composables/useLiveKitRoom'
 import { useFocusGroupSession } from '@/ux/FocusGroup/composables/useFocusGroupSession'
+import { useSpeakingTime } from '@/ux/FocusGroup/composables/useSpeakingTime'
 import { computeParticipation } from '@/ux/FocusGroup/utils/participation'
 import SessionLobby from '@/ux/FocusGroup/components/session/SessionLobby.vue'
 import SessionVideoStage from '@/ux/FocusGroup/components/session/SessionVideoStage.vue'
@@ -662,6 +663,11 @@ const {
   cooperators: computed(() => test.value?.cooperators || []),
 })
 
+// Accumulated LiveKit active-speaker time per identity, feeding the
+// facilitator-only participation indicator alongside message counts — see
+// participationByUser below.
+const { speakingMs } = useSpeakingTime(callRoom)
+
 const localVideoState = computed(() => ({
   name: user.value?.name || user.value?.email?.split('@')[0] || '',
   isObservator: isCallObservator.value,
@@ -740,8 +746,12 @@ const respondedIds = computed(() => [
 ])
 
 // Facilitator-only signal: each participant's share of the session's
-// messages so far (across all topics, not just the current one).
-const participationByUser = computed(() => computeParticipation(messages.value))
+// overall activity — messages sent (all topics) blended with LiveKit
+// speaking time, so a participant who mostly talks isn't invisible next to
+// one who mostly types.
+const participationByUser = computed(() =>
+  computeParticipation({ messages: messages.value, speakingMs: speakingMs.value }),
+)
 
 // --- Facilitator actions ---
 const onStart = async () => {

--- a/tests/unit/participation.spec.js
+++ b/tests/unit/participation.spec.js
@@ -1,0 +1,50 @@
+import { computeParticipation } from '@/ux/FocusGroup/utils/participation'
+
+describe('computeParticipation', () => {
+  it('returns an empty object when there are no messages', () => {
+    expect(computeParticipation({})).toEqual({})
+    expect(computeParticipation(undefined)).toEqual({})
+  })
+
+  it('splits participation evenly across two equally active participants', () => {
+    const messages = {
+      'topic-1': {
+        m1: { userId: 'alice' },
+        m2: { userId: 'bob' },
+      },
+      'topic-2': {
+        m3: { userId: 'alice' },
+        m4: { userId: 'bob' },
+      },
+    }
+
+    expect(computeParticipation(messages)).toEqual({ alice: 50, bob: 50 })
+  })
+
+  it('weights participation by message share across all topics', () => {
+    const messages = {
+      'topic-1': {
+        m1: { userId: 'alice' },
+        m2: { userId: 'alice' },
+        m3: { userId: 'bob' },
+      },
+      'topic-2': {
+        m4: { userId: 'alice' },
+      },
+    }
+
+    // alice: 3/4 = 75%, bob: 1/4 = 25%
+    expect(computeParticipation(messages)).toEqual({ alice: 75, bob: 25 })
+  })
+
+  it('ignores messages with no userId', () => {
+    const messages = {
+      'topic-1': {
+        m1: { userId: 'alice' },
+        m2: { text: 'orphaned, no userId' },
+      },
+    }
+
+    expect(computeParticipation(messages)).toEqual({ alice: 100 })
+  })
+})

--- a/tests/unit/participation.spec.js
+++ b/tests/unit/participation.spec.js
@@ -1,50 +1,101 @@
-import { computeParticipation } from '@/ux/FocusGroup/utils/participation'
+import {
+  computeParticipation,
+  countMessagesByUser,
+} from '@/ux/FocusGroup/utils/participation'
 
-describe('computeParticipation', () => {
+describe('countMessagesByUser', () => {
   it('returns an empty object when there are no messages', () => {
-    expect(computeParticipation({})).toEqual({})
-    expect(computeParticipation(undefined)).toEqual({})
+    expect(countMessagesByUser({})).toEqual({})
+    expect(countMessagesByUser(undefined)).toEqual({})
   })
 
-  it('splits participation evenly across two equally active participants', () => {
+  it('counts messages per author across all topics', () => {
     const messages = {
-      'topic-1': {
-        m1: { userId: 'alice' },
-        m2: { userId: 'bob' },
-      },
-      'topic-2': {
-        m3: { userId: 'alice' },
-        m4: { userId: 'bob' },
-      },
+      'topic-1': { m1: { userId: 'alice' }, m2: { userId: 'bob' } },
+      'topic-2': { m3: { userId: 'alice' } },
     }
-
-    expect(computeParticipation(messages)).toEqual({ alice: 50, bob: 50 })
-  })
-
-  it('weights participation by message share across all topics', () => {
-    const messages = {
-      'topic-1': {
-        m1: { userId: 'alice' },
-        m2: { userId: 'alice' },
-        m3: { userId: 'bob' },
-      },
-      'topic-2': {
-        m4: { userId: 'alice' },
-      },
-    }
-
-    // alice: 3/4 = 75%, bob: 1/4 = 25%
-    expect(computeParticipation(messages)).toEqual({ alice: 75, bob: 25 })
+    expect(countMessagesByUser(messages)).toEqual({ alice: 2, bob: 1 })
   })
 
   it('ignores messages with no userId', () => {
     const messages = {
-      'topic-1': {
-        m1: { userId: 'alice' },
-        m2: { text: 'orphaned, no userId' },
-      },
+      'topic-1': { m1: { userId: 'alice' }, m2: { text: 'orphaned' } },
     }
+    expect(countMessagesByUser(messages)).toEqual({ alice: 1 })
+  })
+})
 
-    expect(computeParticipation(messages)).toEqual({ alice: 100 })
+describe('computeParticipation', () => {
+  it('returns an empty object when there are no messages and no speaking time', () => {
+    expect(computeParticipation({})).toEqual({})
+    expect(computeParticipation({ messages: {}, speakingMs: {} })).toEqual({})
+    expect(computeParticipation()).toEqual({})
+  })
+
+  describe('message-only (no one has spoken yet)', () => {
+    it('splits participation evenly across two equally active participants', () => {
+      const messages = {
+        'topic-1': { m1: { userId: 'alice' }, m2: { userId: 'bob' } },
+        'topic-2': { m3: { userId: 'alice' }, m4: { userId: 'bob' } },
+      }
+      expect(computeParticipation({ messages })).toEqual({ alice: 50, bob: 50 })
+    })
+
+    it('weights participation by message share across all topics', () => {
+      const messages = {
+        'topic-1': {
+          m1: { userId: 'alice' },
+          m2: { userId: 'alice' },
+          m3: { userId: 'bob' },
+        },
+        'topic-2': { m4: { userId: 'alice' } },
+      }
+      // alice: 3/4 = 75%, bob: 1/4 = 25%
+      expect(computeParticipation({ messages })).toEqual({ alice: 75, bob: 25 })
+    })
+  })
+
+  describe('speaking-only (no one has typed yet)', () => {
+    it('uses speaking share alone when there are no messages', () => {
+      const speakingMs = { alice: 3000, bob: 1000 }
+      expect(computeParticipation({ messages: {}, speakingMs })).toEqual({
+        alice: 75,
+        bob: 25,
+      })
+    })
+  })
+
+  describe('blended (both signals present)', () => {
+    it('averages message share and speaking share per participant', () => {
+      // alice: 100% of messages, 0% of speaking -> (100 + 0) / 2 = 50
+      // bob:     0% of messages, 100% of speaking -> (0 + 100) / 2 = 50
+      const messages = { 'topic-1': { m1: { userId: 'alice' } } }
+      const speakingMs = { bob: 5000 }
+      expect(computeParticipation({ messages, speakingMs })).toEqual({
+        alice: 50,
+        bob: 50,
+      })
+    })
+
+    it('does not let a silent typist erase a heavy talker', () => {
+      // Without blending, bob (1 short message) would read as "more active"
+      // than alice, who spoke the whole time but never typed.
+      const messages = {
+        'topic-1': { m1: { userId: 'bob' } },
+      }
+      const speakingMs = { alice: 60000 }
+      const result = computeParticipation({ messages, speakingMs })
+      expect(result.alice).toBeGreaterThan(0)
+      expect(result.alice).toBe(50)
+    })
+
+    it('includes a participant who only appears in one of the two signals', () => {
+      const messages = {
+        'topic-1': { m1: { userId: 'alice' }, m2: { userId: 'carol' } },
+      }
+      const speakingMs = { bob: 2000 }
+      const result = computeParticipation({ messages, speakingMs })
+      expect(Object.keys(result).sort()).toEqual(['alice', 'bob', 'carol'])
+    })
   })
 })

--- a/tests/unit/speakingTime.spec.js
+++ b/tests/unit/speakingTime.spec.js
@@ -1,0 +1,88 @@
+import { applyActiveSpeakersChange } from '@/ux/FocusGroup/utils/speakingTime'
+
+describe('applyActiveSpeakersChange', () => {
+  it('starts timing a newly-speaking identity without accumulating anything yet', () => {
+    const result = applyActiveSpeakersChange({
+      accumulatedMs: {},
+      activeSince: {},
+      speakingIdentities: ['alice'],
+      now: 1000,
+    })
+    expect(result.accumulatedMs).toEqual({})
+    expect(result.activeSince).toEqual({ alice: 1000 })
+  })
+
+  it('accumulates elapsed time when a speaker stops', () => {
+    const result = applyActiveSpeakersChange({
+      accumulatedMs: {},
+      activeSince: { alice: 1000 },
+      speakingIdentities: [],
+      now: 4000,
+    })
+    expect(result.accumulatedMs).toEqual({ alice: 3000 })
+    expect(result.activeSince).toEqual({})
+  })
+
+  it('adds to existing accumulated time rather than overwriting it', () => {
+    const result = applyActiveSpeakersChange({
+      accumulatedMs: { alice: 2000 },
+      activeSince: { alice: 5000 },
+      speakingIdentities: [],
+      now: 7500,
+    })
+    expect(result.accumulatedMs).toEqual({ alice: 4500 })
+  })
+
+  it('does not double-count a speaker who is still speaking across two updates', () => {
+    const first = applyActiveSpeakersChange({
+      accumulatedMs: {},
+      activeSince: {},
+      speakingIdentities: ['alice'],
+      now: 1000,
+    })
+    // A second "still speaking" update should not reset the start time.
+    const second = applyActiveSpeakersChange({
+      accumulatedMs: first.accumulatedMs,
+      activeSince: first.activeSince,
+      speakingIdentities: ['alice'],
+      now: 2000,
+    })
+    expect(second.activeSince).toEqual({ alice: 1000 })
+    expect(second.accumulatedMs).toEqual({})
+  })
+
+  it('tracks multiple simultaneous speakers independently', () => {
+    const started = applyActiveSpeakersChange({
+      accumulatedMs: {},
+      activeSince: {},
+      speakingIdentities: ['alice', 'bob'],
+      now: 0,
+    })
+    const aliceStops = applyActiveSpeakersChange({
+      accumulatedMs: started.accumulatedMs,
+      activeSince: started.activeSince,
+      speakingIdentities: ['bob'],
+      now: 1000,
+    })
+    const bobStops = applyActiveSpeakersChange({
+      accumulatedMs: aliceStops.accumulatedMs,
+      activeSince: aliceStops.activeSince,
+      speakingIdentities: [],
+      now: 3000,
+    })
+    expect(bobStops.accumulatedMs).toEqual({ alice: 1000, bob: 3000 })
+  })
+
+  it('does not mutate the input accumulatedMs/activeSince objects', () => {
+    const accumulatedMs = { alice: 100 }
+    const activeSince = { bob: 500 }
+    applyActiveSpeakersChange({
+      accumulatedMs,
+      activeSince,
+      speakingIdentities: [],
+      now: 1500,
+    })
+    expect(accumulatedMs).toEqual({ alice: 100 })
+    expect(activeSince).toEqual({ bob: 500 })
+  })
+})


### PR DESCRIPTION

## Summary

Facilitators running a focus group have no way to tell who's actually engaged during the session .. this adds a live, facilitator-only percentage next to each participant showing their share of the session's activity.

- **Signal**: blends two sources - text messages posted and LiveKit speaking time , so a participant who mostly talks isn't invisible next to one who mostly types. When only one signal has data yet (e.g. no one has spoken), that signal alone decides the split.
- **Zero new writes**: message counts are already tracked in RTDB; speaking time comes from LiveKit's `ActiveSpeakersChanged` event, which every connected client (including the facilitator's) already receives live for
  the whole room. Nothing new is persisted.
- **Visibility**: the % chip only renders for participant-role rows, and only on the facilitator's own Participants panel , participants and observers never see it, including their own.
- Chip colors flag low engagement: neutral above 15%, orange below 15%, red at 0%.

## Bug caught and fixed during manual QA

Shipped the message-only version first and demoed it m a participant who spoke for a long stretch without ever typing showed **0%**, while someone who sent one short chat message outranked them. Fixed by adding the speaking-time signal described above.


## Video

https://github.com/user-attachments/assets/fcf2e3df-7935-434f-9105-1582ad4be626


https://github.com/user-attachments/assets/a0f61005-4c7c-46ab-8eb4-789d193c5a0b

---
Closes #2226 