### PR TITLE
fix(study_moderated): improve moderated study completion and media cleanup

### DIFF
--- a/src/shared/components/videoCall/composables/useLiveKitRoom.js
+++ b/src/shared/components/videoCall/composables/useLiveKitRoom.js
@@ -392,6 +392,17 @@ export function useLiveKitRoom({
 
   async function disconnect() {
     if (room.value) {
+      if (room.value.localParticipant) {
+        try {
+          await room.value.localParticipant.setCameraEnabled(false)
+        } catch (e) {}
+        try {
+          await room.value.localParticipant.setMicrophoneEnabled(false)
+        } catch (e) {}
+        try {
+          await room.value.localParticipant.setScreenShareEnabled(false)
+        } catch (e) {}
+      }
       await room.value.disconnect()
       room.value = null
     }

--- a/src/ux/UserTest/components/AudioRecorder.vue
+++ b/src/ux/UserTest/components/AudioRecorder.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onBeforeUnmount } from 'vue'
 import { useStore } from 'vuex'
 import {
   getStorage,
@@ -254,6 +254,18 @@ const stopAudioRecording = () => {
     mediaRecorder.value.remote.stop()
   }
 }
+
+onBeforeUnmount(() => {
+  if (audioStream.value) {
+    audioStream.value.getTracks().forEach((track) => track.stop())
+  }
+  if (mediaRecorder.value?.local && mediaRecorder.value.local.state !== 'inactive') {
+    mediaRecorder.value.local.stop()
+  }
+  if (mediaRecorder.value?.remote && mediaRecorder.value.remote.state !== 'inactive') {
+    mediaRecorder.value.remote.stop()
+  }
+})
 
 defineExpose({ startAudioRecording, stopAudioRecording })
 </script>

--- a/src/ux/UserTest/components/VideoRecorder.vue
+++ b/src/ux/UserTest/components/VideoRecorder.vue
@@ -41,7 +41,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onBeforeUnmount } from 'vue'
 import { useStore } from 'vuex'
 import { useI18n } from 'vue-i18n'
 import {
@@ -210,10 +210,19 @@ const startRecording = async () => {
 }
 
 const stopRecording = () => {
-  if (mediaRecorder.value) {
+  if (mediaRecorder.value && mediaRecorder.value.state !== 'inactive') {
     mediaRecorder.value.stop()
   }
 }
+
+onBeforeUnmount(() => {
+  if (videoStream.value) {
+    videoStream.value.getTracks().forEach((track) => track.stop())
+  }
+  if (mediaRecorder.value && mediaRecorder.value.state !== 'inactive') {
+    mediaRecorder.value.stop()
+  }
+})
 
 defineExpose({ startRecording, stopRecording })
 </script>

--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -922,11 +922,14 @@ const handleSubmit = async () => {
   try {
     localTestAnswer.submitted = true
     await saveAnswer()
-    if (hasTestDashboardAccess.value) {
-      await router.push(`/userTest/moderated/dashboard/${test.value.id}`)
-    } else {
-      await router.push({ name: 'Admin' })
-    }
+    
+    // Return to the call/session screen instead of navigating away
+    displayVideoCallComponent.value = true
+    
+    store.commit('SET_TOAST', {
+      type: 'success',
+      message: t('finishTest.submitMessage') || 'Submitted',
+    })
   } catch {
     store.commit('SET_TOAST', {
       type: 'error',


### PR DESCRIPTION
## Description
This PR resolves issue #2287 by improving the participant experience at the end of a moderated study and ensuring all media tracks (camera and microphone) are properly cleaned up to prevent resource leakage.

## Changes Made
- **ModeratedTestView.vue:** Modified `handleSubmit` so that participants are no longer abruptly removed (navigated away) after submitting the test. They will remain in the call session screen and see a success toast instead.
- **useLiveKitRoom.js:** Updated the `disconnect` method to explicitly set the `localParticipant`'s camera, microphone, and screen share to `false` before terminating the LiveKit room connection.
- **VideoRecorder.vue & AudioRecorder.vue:** Introduced `onBeforeUnmount` lifecycle hooks. If a participant exits the view abruptly, these components will explicitly stop any lingering browser `MediaStream` hardware tracks and halt the recording process.

## Related Issue
Fixes #2287

## Checklist
- [x] Tested locally to verify media tracks are fully released upon disconnecting or submitting.
- [x] Passed local linting checks (`npm run lint:fix`).
- [x] Participant successfully stays in the session after submitting.
