### PR TITLE
fix(firestore): add missing rules for settings, sessions, and participants collections

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -221,5 +221,11 @@ service cloud.firestore {
     match /calibrations/{document=**} {
       allow read, write: if signedIn();
     }
+    match /settings/{settingId} {
+      allow read: if signedIn();
+    }
+    match /{path=**}/sessions/{sessionId} {
+      allow read: if signedIn();
+    }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -140,6 +140,10 @@ service cloud.firestore {
         );
         allow write: if false;
       }
+
+      match /participants/{participantId} {
+        allow read: if signedIn();
+      }
     }
 
     match /answers/{answerId} {


### PR DESCRIPTION
Fixes #2298

## Problem
Several pages fail to load with "No matching allow statements" because
`firestore.rules` was missing rules for three separate reads:

1. `settings/upcomingWebinar` — blocks `/admin` dashboard load
2. `sessions` (collection-group query) — blocks `/admin` dashboard load
3. `tests/{studyId}/participants` (nested subcollection) — blocks
   `/heuristic/participants/:id`

All three were confirmed via the Firestore Emulator's Requests log
(Firestore tab → Requests), which shows the exact denied paths:
- `GET /databases/(default)/documents/settings/upcomingWebinar`
- `LIST /databases/(default)/documents/**/sessions/*`
- `LIST /databases/(default)/documents/tests/{studyId}/participants/*`

## Fix
Added three `match` blocks to `firestore.rules`:
- `settings/{settingId}` — signed-in read access
- `{path=**}/sessions/{sessionId}` — signed-in read access, using the
  `{path=**}` collection-group wildcard since sessions are queried as a
  collection-group, not a fixed nested path
- `participants/{participantId}` nested inside `tests/{studyId}` —
  signed-in read access, alongside the existing `auditTrail`, `logs`,
  and `logBatches` subcollection matches

10 lines added total, nothing else changed.

## Testing
- Fresh `firebase emulators:start`, fresh sign-up
- `/admin` and `/heuristic/participants/:id` both load cleanly
- Confirmed all three previously-denied requests now show green/allowed
  in the emulator's Requests log

## Note on overlapping work
`2286-fix-improve-firestore-and-storage-rules-for-anonymous-users-and-legacy-data`
also touches `settings`/`sessions`/`participants` as part of a broader WIP
rules rewrite. That branch nests `sessions` under `tests/{studyId}/sessions`,
but the app queries sessions via a collection-group (confirmed via the log
above), so a nested-only match won't satisfy that query — the `{path=**}`
wildcard is required. This PR is a minimal, narrowly-scoped fix for the
immediate blockers, not a replacement for that larger effort.

## Follow-up
Noticed a separate, unrelated issue: a brief error-boundary flash on first
page load, likely due to an auth-state race condition rather than a rules
gap. Filed separately for visibility, not blocking this PR.


Video demonstration:
https://github.com/user-attachments/assets/8377a4f6-f9ad-489e-ade1-bad10e27388c


