### PR TITLE
fix(moderator): hid preview option for moderated user study

### DIFF
--- a/src/shared/utils/studyNavigation.js
+++ b/src/shared/utils/studyNavigation.js
@@ -150,6 +150,11 @@ const NAVIGATION_ITEMS = Object.freeze([
     icon: ICONS.PREVIEW,
     capability: C.STUDY_ANSWER,
     path: ({ id, previewPath }) => previewPath ?? `/testview/${id}`,
+    visible: (study) =>
+      !(
+        normalizeStudyType(study?.testType) == STUDY_TYPES.USER &&
+        study?.subType === USER_STUDY_SUBTYPES.MODERATED
+      ),
   },
   {
     title: 'Progress',

--- a/tests/unit/studyNavigation.spec.js
+++ b/tests/unit/studyNavigation.spec.js
@@ -206,7 +206,6 @@ describe('study navigation', () => {
 
     expect(titlesFor(study, user, 'userTest/moderated')).toEqual([
       'Dashboard',
-      'Preview',
       'Results',
       'Cooperators',
       'Participants',


### PR DESCRIPTION
Hid preview option for moderated user study

<img width="637" height="199" alt="image" src="https://github.com/user-attachments/assets/fbd7a7f6-a441-4510-a4d1-6025f3c1cc61" />

Fixes #2267 