### PR TITLE
2306 featnotifications improvement on notifications

### DIFF
--- a/src/app/plugins/firebase/FirebaseFirestoreRepository.js
+++ b/src/app/plugins/firebase/FirebaseFirestoreRepository.js
@@ -14,6 +14,7 @@ import {
   setDoc,
   deleteField,
   collectionGroup,
+  writeBatch,
 } from 'firebase/firestore'
 
 /**
@@ -199,6 +200,17 @@ export default class Controller {
       parentId: document.ref.parent.parent?.id,
       ...document.data(),
     }))
+  }
+
+  async batchUpdate(updates) {
+    const batch = writeBatch(db)
+
+    updates.forEach(({ col, docId, payload }) => {
+      const ref = doc(db, `${col}/${docId}`)
+      batch.update(ref, payload)
+    })
+
+    return batch.commit()
   }
 
   // Utility method to get deleteField for field removal

--- a/src/controllers/StudyController.js
+++ b/src/controllers/StudyController.js
@@ -87,9 +87,6 @@ export default class StudyController extends Controller {
             userController.removeTestFromUser(cooperator.userDocId, payload.id),
           )
         }
-        promises.push(
-          userController.removeNotificationsForTest(payload.id, cooperators),
-        )
         await Promise.all(promises)
       }
       // Remove only the deleted test from the admin's myTests/myAnswers via a

--- a/src/features/auth/controllers/UserController.js
+++ b/src/features/auth/controllers/UserController.js
@@ -21,7 +21,6 @@ export default class UserController extends Controller {
       accessLevel: 1,
       myTests: {},
       myAnswers: {},
-      notifications: [],
       storageUsageMB: 0,
     }).toFirestore()
     return super.set(COLLECTION, payload.id, user)
@@ -155,96 +154,6 @@ export default class UserController extends Controller {
   async reauthenticateUser(user, email, password) {
     const credential = EmailAuthProvider.credential(email, password)
     await reauthenticateWithCredential(user, credential)
-  }
-
-  async addNotification(payload) {
-    const userToUpdate = await this.getById(payload.userId)
-    userToUpdate.notifications.push(payload.notification.toFirestore())
-    // Only write the notifications field to avoid overwriting other fields
-    // (e.g. myTests) with a stale in-memory copy.
-    return this.update(payload.userId, {
-      notifications: userToUpdate.notifications,
-    })
-  }
-
-  async markNotificationAsRead(payload) {
-    const userToUpdate = new User(payload.user)
-
-    // Find the notification in the notifications array
-    const notificationIndex = userToUpdate.notifications.findIndex(
-      (n) => n.createdDate === payload.notification.createdDate,
-    )
-
-    if (notificationIndex !== -1) {
-      // Mark notification as read
-      userToUpdate.notifications[notificationIndex].read = true
-      userToUpdate.notifications[notificationIndex].readAt = Date.now()
-
-      // Only write the notifications field. Writing the full document with
-      // toFirestore() would overwrite myTests with the stale in-memory copy.
-      await this.update(userToUpdate.id, {
-        notifications: userToUpdate.notifications,
-      })
-      return userToUpdate
-    } else {
-      // Notification was not found in the array
-      throw new Error('Notification not found.')
-    }
-  }
-
-  async markAllNotificationsAsRead(user) {
-    const userToUpdate = new User(user)
-
-    let hasUnread = false
-    userToUpdate.notifications.forEach((n) => {
-      if (!n.read) {
-        n.read = true
-        n.readAt = Date.now()
-        hasUnread = true
-      }
-    })
-
-    if (!hasUnread) return userToUpdate
-
-    // Only write the notifications field. Writing the full document with
-    // toFirestore() would overwrite myTests with the stale in-memory copy.
-    await this.update(userToUpdate.id, {
-      notifications: userToUpdate.notifications,
-    })
-    // Return the updated user object (in memory) so the store can commit it immediately
-    return userToUpdate
-  }
-
-  async removeNotificationsForTest(testId, cooperators) {
-    try {
-      for (let cooperator = 0; cooperator < cooperators.length; cooperator++) {
-        const userDocID = cooperators[cooperator].userDocId
-
-        // Lê o documento do usuário diretamente
-        const userDoc = await super.readOne('users', userDocID)
-
-        // Verifica se o documento do usuário existe
-        if (userDoc.exists()) {
-          const userData = userDoc.data()
-          const userId = userDoc.id
-
-          // Verificar se o usuário tem notificações
-          if (userData.notifications && userData.notifications.length > 0) {
-            // Filtrar notificações que têm o testId correspondente
-            userData.notifications = userData.notifications.filter(
-              (notification) => notification.testId !== testId,
-            )
-            // Atualizar o documento do usuário com as notificações filtradas
-            await super.update('users', userId, {
-              notifications: userData.notifications,
-            })
-          }
-        } else {
-        }
-      }
-    } catch (error) {
-      throw error
-    }
   }
 
   async removeTestFromUser(userId, testIdToRemove) {

--- a/src/features/auth/models/UserModel.js
+++ b/src/features/auth/models/UserModel.js
@@ -15,7 +15,6 @@ export default class User {
     id,
     accessLevel,
     email,
-    notifications = [],
     myAnswers = [],
     myTests = [],
     username = null,
@@ -28,7 +27,6 @@ export default class User {
     this.id = id
     this.accessLevel = accessLevel
     this.email = email
-    this.notifications = notifications
     this.myAnswers = myAnswers
     this.myTests = myTests
     this.username = username
@@ -49,7 +47,6 @@ export default class User {
     return {
       accessLevel: this.accessLevel,
       email: this.email,
-      notifications: this.notifications,
       myAnswers: this.myAnswers,
       myTests: this.myTests,
       username: this.username, // Include username in Firestore representation
@@ -59,13 +56,5 @@ export default class User {
       lastCalibrationId: this.lastCalibrationId,
       storageUsageMB: this.storageUsageMB,
     }
-  }
-
-  /**
-   * Move all current notifications to the inbox.
-   */
-  archiveNotifications() {
-    this.inbox = [...this.inbox, ...this.notifications] // Add notifications to inbox
-    this.notifications = [] // Clear current notifications
   }
 }

--- a/src/features/auth/store/Auth.js
+++ b/src/features/auth/store/Auth.js
@@ -76,7 +76,7 @@ export default {
         // Send verification email
         try {
           await authController.sendVerificationEmail(user.email, user.email)
-        } catch { }
+        } catch {}
 
         commit('SET_TOAST', {
           message: i18n.global.t('auth.signupSuccess'),
@@ -93,7 +93,7 @@ export default {
       }
     },
 
-    async signin({ commit }, payload) {
+    async signin({ commit, dispatch }, payload) {
       commit('setLoading', true)
 
       try {
@@ -114,13 +114,14 @@ export default {
         }
 
         const dbUser = await userController.getById(user.uid)
-
         commit('SET_USER', dbUser)
 
         commit('SET_TOAST', {
           message: i18n.global.t('auth.loginSuccess'),
           type: 'success',
         })
+
+        dispatch('subscribeToNotifications', user.uid)
       } catch (err) {
         if (err.message === 'EMAIL_NOT_VERIFIED') {
           throw err
@@ -137,7 +138,7 @@ export default {
      * @action signInWithGoogle
      * @returns {void}
      */
-    async signInWithGoogle({ commit }, payload) {
+    async signInWithGoogle({ commit, dispatch }, payload) {
       try {
         const { user } = await authController.signInWithGoogle(
           payload.rememberMe,
@@ -169,6 +170,7 @@ export default {
           message: i18n.global.t('auth.loginSuccess'),
           type: 'success',
         })
+        dispatch('subscribeToNotifications', user.uid)
       } catch (err) {
         const silentErrors = [
           'auth/popup-closed-by-user',
@@ -210,7 +212,7 @@ export default {
       }
     },
 
-    async autoSignIn({ commit }) {
+    async autoSignIn({ commit, dispatch }) {
       try {
         const user = await authController.autoSignIn()
         if (!user) return
@@ -224,6 +226,7 @@ export default {
 
         const dbUser = await userController.getById(user.uid)
         commit('SET_USER', dbUser)
+        dispatch('subscribeToNotifications', user.uid)
       } catch (e) {
         commit('SET_TOAST', {
           message: i18n.global.t('errors.globalError'),

--- a/src/features/navigation/components/NotificationButton.vue
+++ b/src/features/navigation/components/NotificationButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="Array.isArray(user.notifications)">
+  <div v-if="Array.isArray(notifications)">
     <v-menu
       v-model="menuOpen"
       location="bottom end"
@@ -80,7 +80,7 @@
               :class="{ active: index === activeIndex }"
               style="margin-bottom: 10px"
               @go-to-redirect="goToNotificationRedirect"
-              @mark-as-read="markNotificationAsRead"
+              @toggle-read="toggleRead"
             />
           </template>
 
@@ -132,18 +132,15 @@ let resolveDialog
 
 const user = computed(() => store.getters.user)
 
+const notifications = computed(() => store.getters.notifications ?? [])
+
 const unreadNotifications = computed(() =>
-  [...(user.value.notifications || [])]
-    .filter((notification) => !notification.read)
-    .sort((a, b) => new Date(b.createdDate) - new Date(a.createdDate))
-    .slice(0, 6),
+  notifications.value?.filter((notification) => !notification.read),
 )
 
 const unreadCount = computed(
   () =>
-    (user.value.notifications || []).filter(
-      (notification) => !notification.read,
-    ).length,
+    notifications.value?.filter((notification) => !notification.read).length,
 )
 
 /**
@@ -192,8 +189,17 @@ const markNotificationAsRead = async (notification) => {
   if (!notification) return
 
   await store.dispatch('markNotificationAsRead', {
-    notification,
-    user: user.value,
+    notificationId: notification.id,
+    userId: user.value?.id,
+  })
+}
+
+const markNotificationAsUnread = async (notification) => {
+  if (!notification) return
+
+  await store.dispatch('markNotificationAsUnread', {
+    notificationId: notification.id,
+    userId: user.value?.id,
   })
 }
 
@@ -273,14 +279,22 @@ const goToNotificationRedirect = async (notification) => {
   menuOpen.value = false
 }
 
+const toggleRead = async (notification) => {
+  if (notification.read) {
+    await markNotificationAsUnread(notification)
+  } else {
+    await markNotificationAsRead(notification)
+  }
+}
+
 const markAllAsRead = async () => {
-  const unread = (user.value.notifications || []).filter(
-    (notification) => !notification.read,
-  )
+  const unread = notifications.value?.filter((n) => !n.read)
+  if (!unread?.length) return
 
-  if (!unread.length) return
-
-  await store.dispatch('markAllNotificationsAsRead', user.value)
+  await store.dispatch('markAllNotificationsAsRead', {
+    userId: user.value.id,
+    notifications: notifications.value,
+  })
 }
 
 const goToNotificationPage = () => {

--- a/src/features/notifications/controllers/NotificationController.js
+++ b/src/features/notifications/controllers/NotificationController.js
@@ -1,0 +1,102 @@
+import Controller from '@/app/plugins/firebase/FirebaseFirestoreRepository'
+import { db } from '@/app/plugins/firebase'
+import {
+  onSnapshot,
+  collection,
+  query,
+  orderBy,
+  writeBatch,
+  doc,
+} from 'firebase/firestore'
+
+const PARENT_COLLECTION = 'users'
+const NOTIFICATIONS_SUBCOLLECTION = 'notifications'
+
+export default class NotificationController extends Controller {
+  constructor() {
+    super()
+  }
+
+  _getCollection(userId) {
+    return `${PARENT_COLLECTION}/${userId}/${NOTIFICATIONS_SUBCOLLECTION}`
+  }
+
+  async addNotification(payload) {
+    const notification = payload.notification.toFirestore()
+
+    const docRef = await super.create(
+      this._getCollection(payload.userId),
+      notification,
+    )
+
+    return {
+      ...notification,
+      id: docRef.id,
+    }
+  }
+
+  async subscribeToNotifications(userId, callback) {
+    const notificationsCollection = collection(db, this._getCollection(userId))
+
+    const q = query(notificationsCollection, orderBy('createdDate', 'desc'))
+
+    return onSnapshot(q, (snapshot) => {
+      const notifications = snapshot.docs.map((document) => ({
+        ...document.data(),
+        id: document.id,
+      }))
+
+      callback(notifications)
+    })
+  }
+
+  async markNotificationAsRead(payload) {
+    return super.update(
+      this._getCollection(payload.userId),
+      payload.notificationId,
+      {
+        read: true,
+        readAt: Date.now(),
+      },
+    )
+  }
+
+  async markNotificationAsUnread(payload) {
+    return super.update(
+      this._getCollection(payload.userId),
+      payload.notificationId,
+      {
+        read: false,
+        readAt: Date.now(),
+      },
+    )
+  }
+
+  async markAllNotificationsAsRead(payload) {
+    const unreadNotifications = payload.notifications.filter(
+      (notification) => !notification.read,
+    )
+
+    if (unreadNotifications.length === 0) {
+      return
+    }
+
+    const batch = writeBatch(db)
+    const readAt = Date.now()
+
+    unreadNotifications.forEach((notification) => {
+      const notificationRef = doc(
+        db,
+        this._getCollection(payload.userId),
+        notification.id,
+      )
+
+      batch.update(notificationRef, {
+        read: true,
+        readAt,
+      })
+    })
+
+    return batch.commit()
+  }
+}

--- a/src/features/notifications/store/notification.js
+++ b/src/features/notifications/store/notification.js
@@ -1,23 +1,45 @@
-import UserController from '@/features/auth/controllers/UserController'
-const userController = new UserController()
+import NotificationController from '@/features/notifications/controllers/NotificationController'
+const notificationController = new NotificationController()
 
 export default {
+  state: {
+    notifications: [],
+  },
+  getters: {
+    notifications(state) {
+      return state.notifications
+    },
+  },
+  mutations: {
+    setNotifications(state, notifications) {
+      state.notifications = notifications
+    },
+  },
   actions: {
     async addNotification({ commit }, payload) {
       commit('setLoading', true)
       try {
-        await userController.addNotification(payload)
+        await notificationController.addNotification(payload)
       } catch (e) {
         commit('setError', e)
       } finally {
         commit('setLoading', false)
       }
+    },
+
+    subscribeToNotifications({ commit }, userId) {
+      return notificationController.subscribeToNotifications(
+        userId,
+        (notifications) => {
+          commit('setNotifications', notifications)
+        },
+      )
     },
 
     async markNotificationAsRead({ commit }, payload) {
       commit('setLoading', true)
       try {
-        await userController.markNotificationAsRead(payload)
+        await notificationController.markNotificationAsRead(payload)
       } catch (e) {
         commit('setError', e)
       } finally {
@@ -25,12 +47,22 @@ export default {
       }
     },
 
-    async markAllNotificationsAsRead({ commit }, user) {
+    async markNotificationAsUnread({ commit }, payload) {
       commit('setLoading', true)
       try {
-        const updatedUser = await userController.markAllNotificationsAsRead(user)
-        // Update the root Auth store state with the new user object
-        commit('SET_USER', updatedUser, { root: true })
+        await notificationController.markNotificationAsUnread(payload)
+      } catch (e) {
+        commit('setError', e)
+      } finally {
+        commit('setLoading', false)
+      }
+    },
+
+    async markAllNotificationsAsRead({ commit }, payload) {
+      commit('setLoading', true)
+
+      try {
+        await notificationController.markAllNotificationsAsRead(payload)
       } catch (e) {
         commit('setError', e)
       } finally {

--- a/src/features/notifications/views/NotificationPage.vue
+++ b/src/features/notifications/views/NotificationPage.vue
@@ -145,27 +145,10 @@
               }"
               class="mb-3"
               @go-to-redirect="handleNotificationClick"
-              @mark-as-read="toggleRead"
+              @toggle-read="toggleRead"
             />
           </div>
         </template>
-
-        <!-- REFRESH -->
-        <v-btn
-          color="primary"
-          variant="tonal"
-          size="small"
-          prepend-icon="mdi-refresh"
-          :loading="refreshing"
-          class="refresh-btn"
-          @click="refreshNotifications"
-        >
-          {{ $t('notificationsPage.refresh') }}
-
-          <template #loader>
-            <v-progress-circular indeterminate size="16" width="2" />
-          </template>
-        </v-btn>
 
         <!-- PAGINATION -->
         <v-pagination
@@ -209,7 +192,6 @@ const search = ref('')
 const activeIndex = ref(-1)
 const loading = ref(true)
 const markingAllAsRead = ref(false)
-const refreshing = ref(false)
 const invite = ref(null)
 
 // Pagination
@@ -225,10 +207,10 @@ let resolveDialog
 // Computed
 const user = computed(() => store.getters.user)
 
-const totalCount = computed(() => user.value?.notifications?.length || 0)
+const totalCount = computed(() => notifications.value?.length || 0)
 
 const unreadCount = computed(
-  () => user.value?.notifications?.filter((n) => !n.read).length || 0,
+  () => notifications.value?.filter((n) => !n.read).length || 0,
 )
 
 // Mobile tabs
@@ -250,21 +232,11 @@ const mobileTabItems = computed(() => [
   },
 ])
 
-// Sorted notifications
-const sortedNotifications = computed(() => {
-  if (!user.value?.notifications) return []
-
-  return [...user.value.notifications].sort((a, b) => {
-    const aDate = new Date(a.createdDate)
-    const bDate = new Date(b.createdDate)
-
-    return bDate - aDate
-  })
-})
+const notifications = computed(() => store.getters.notifications ?? [])
 
 // Filtered notifications
 const filteredNotifications = computed(() => {
-  let list = sortedNotifications.value
+  let list = notifications.value
 
   if (activeTab.value === 'unread') {
     list = list.filter((n) => !n.read)
@@ -294,7 +266,7 @@ const paginatedNotifications = computed(() => {
     list = filteredNotifications.value
   } else if (activeTab.value === 'inbox') {
     page = inboxPage.value
-    list = sortedNotifications.value
+    list = notifications.value
   } else {
     page = allPage.value
     list = filteredNotifications.value
@@ -338,7 +310,7 @@ const currentPages = computed(() => {
   }
 
   if (activeTab.value === 'inbox') {
-    return Math.ceil(sortedNotifications.value.length / pageSize.value)
+    return Math.ceil(notifications.value.length / pageSize.value)
   }
 
   return Math.ceil(filteredNotifications.value.length / pageSize.value)
@@ -479,56 +451,42 @@ const goToNotificationRedirect = async (notification) => {
 const markAsRead = async (notification) => {
   if (!notification || notification.read) return
 
-  try {
-    await store.dispatch('markNotificationAsRead', {
-      notification,
-      user: user.value,
-    })
-  } catch {
-    // Error handling without console.error for SonarCloud
-  }
+  await store.dispatch('markNotificationAsRead', {
+    notificationId: notification.id,
+    userId: user.value?.id,
+  })
+}
+// Mar as unread
+const markAsUnread = async (notification) => {
+  if (!notification) return
+
+  await store.dispatch('markNotificationAsUnread', {
+    notificationId: notification.id,
+    userId: user.value?.id,
+  })
 }
 
 // NotificationItem action
 const toggleRead = async (notification) => {
-  await markAsRead(notification)
+  if (notification.read) {
+    await markAsUnread(notification)
+  } else {
+    await markAsRead(notification)
+  }
 }
 
 // Mark all as read
 const markAllAsRead = async () => {
-  const unread = user.value.notifications.filter((n) => !n.read)
-
-  if (unread.length === 0) return
+  const unread = notifications.value?.filter((n) => !n.read)
+  if (!unread?.length) return
 
   markingAllAsRead.value = true
 
-  try {
-    await Promise.all(
-      unread.map((notification) =>
-        store.dispatch('markNotificationAsRead', {
-          notification,
-          user: user.value,
-        }),
-      ),
-    )
-  } catch {
-    // Error handling without console.error for SonarCloud
-  } finally {
-    markingAllAsRead.value = false
-  }
-}
-
-// Refresh
-const refreshNotifications = async () => {
-  refreshing.value = true
-
-  try {
-    globalThis.location.reload()
-  } catch {
-    // Error handling without console.error for SonarCloud
-  } finally {
-    refreshing.value = false
-  }
+  await store.dispatch('markAllNotificationsAsRead', {
+    userId: user.value.id,
+    notifications: notifications.value,
+  })
+  markingAllAsRead.value = false
 }
 
 // Keyboard navigation
@@ -567,15 +525,6 @@ const handleKeyDown = (e) => {
       ) {
         handleNotificationClick(filteredNotifications.value[activeIndex.value])
       }
-
-      break
-
-    case 'r':
-      if (e.ctrlKey || e.metaKey) {
-        e.preventDefault()
-        refreshNotifications()
-      }
-
       break
 
     case 'Escape':
@@ -623,15 +572,6 @@ onUnmounted(() => {
   overflow: hidden;
 }
 
-.refresh-btn {
-  min-width: 140px;
-  height: 40px;
-  font-weight: bold;
-  letter-spacing: 0.3px;
-  background-color: #768898 !important;
-  color: white !important;
-}
-
 /* Keyboard active state */
 
 .notification-item.active {
@@ -659,11 +599,6 @@ onUnmounted(() => {
   .v-btn--size-small {
     font-size: 0.75rem;
     padding: 0 8px;
-  }
-
-  .refresh-btn {
-    min-width: 80px;
-    font-size: 0.8rem;
   }
 }
 

--- a/tests/unit/StudyController.spec.js
+++ b/tests/unit/StudyController.spec.js
@@ -37,7 +37,6 @@ jest.mock('@/shared/controllers/AnswerController', () => {
 jest.mock('@/features/auth/controllers/UserController', () => {
   return jest.fn().mockImplementation(() => ({
     removeTestFromUser: jest.fn(),
-    removeNotificationsForTest: jest.fn(),
     update: jest.fn(),
     getById: jest.fn(),
   }))
@@ -86,7 +85,6 @@ describe('StudyController', () => {
 
     mockUserController = {
       removeTestFromUser: jest.fn().mockResolvedValue(),
-      removeNotificationsForTest: jest.fn().mockResolvedValue(),
       update: jest.fn().mockResolvedValue(),
       getById: jest.fn().mockResolvedValue(),
     }

--- a/tests/unit/UserController.spec.js
+++ b/tests/unit/UserController.spec.js
@@ -1,140 +1,152 @@
 import UserController from '@/features/auth/controllers/UserController'
 
 jest.mock('firebase/firestore', () => ({
-    doc: jest.fn(),
-    updateDoc: jest.fn(),
-    collection: jest.fn(),
-    getDocs: jest.fn(),
-    getDoc: jest.fn(),
-    setDoc: jest.fn(),
-    deleteDoc: jest.fn(),
-    query: jest.fn(),
-    where: jest.fn(),
-    documentId: jest.fn(() => '__name__')
+  doc: jest.fn(),
+  updateDoc: jest.fn(),
+  collection: jest.fn(),
+  getDocs: jest.fn(),
+  getDoc: jest.fn(),
+  setDoc: jest.fn(),
+  deleteDoc: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  documentId: jest.fn(() => '__name__'),
 }))
 
 jest.mock('firebase/auth', () => ({
-    EmailAuthProvider: {
-        credential: jest.fn()
-    },
-    reauthenticateWithCredential: jest.fn(),
-    updatePassword: jest.fn()
+  EmailAuthProvider: {
+    credential: jest.fn(),
+  },
+  reauthenticateWithCredential: jest.fn(),
+  updatePassword: jest.fn(),
 }))
 
 jest.mock('@/app/plugins/firebase', () => ({
-    db: {}
+  db: {},
 }))
 
 describe('UserController', () => {
-    let userController
+  let userController
 
-    beforeEach(() => {
-        jest.clearAllMocks()
-        userController = new UserController()
+  beforeEach(() => {
+    jest.clearAllMocks()
+    userController = new UserController()
+  })
+
+  describe('Structure', () => {
+    it('should have create method', () => {
+      expect(typeof userController.create).toBe('function')
     })
 
-    describe('Structure', () => {
-        it('should have create method', () => {
-            expect(typeof userController.create).toBe('function')
-        })
-
-        it('should have update method', () => {
-            expect(typeof userController.update).toBe('function')
-        })
-
-        it('should have readAll method', () => {
-            expect(typeof userController.readAll).toBe('function')
-        })
-
-        it('should have getById method', () => {
-            expect(typeof userController.getById).toBe('function')
-        })
-
-        it('should have updateProfile method', () => {
-            expect(typeof userController.updateProfile).toBe('function')
-        })
-
-        it('should have deleteUser method', () => {
-            expect(typeof userController.deleteUser).toBe('function')
-        })
-
-        it('should have changePassword method', () => {
-            expect(typeof userController.changePassword).toBe('function')
-        })
-
-        it('should have addNotification method', () => {
-            expect(typeof userController.addNotification).toBe('function')
-        })
-
-        it('should have markNotificationAsRead method', () => {
-            expect(typeof userController.markNotificationAsRead).toBe('function')
-        })
-
-        it('should have removeTestFromUser method', () => {
-            expect(typeof userController.removeTestFromUser).toBe('function')
-        })
-
-        it('should have updateLevel method', () => {
-            expect(typeof userController.updateLevel).toBe('function')
-        })
+    it('should have update method', () => {
+      expect(typeof userController.update).toBe('function')
     })
 
-    describe('updateProfile', () => {
-        it('should call update with profile data', async () => {
-            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(userController)), 'update')
-                .mockResolvedValue()
-
-            const payload = {
-                username: 'newusername',
-                contactNo: '1234567890',
-                country: 'US'
-            }
-
-            await userController.updateProfile('user-123', payload)
-
-            expect(updateSpy).toHaveBeenCalledWith('users', 'user-123', {
-                username: 'newusername',
-                contactNo: '1234567890',
-                country: 'US'
-            })
-
-            updateSpy.mockRestore()
-        })
+    it('should have readAll method', () => {
+      expect(typeof userController.readAll).toBe('function')
     })
 
-    describe('deleteUser', () => {
-        it('should call delete with user id', async () => {
-            const deleteSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(userController)), 'delete')
-                .mockResolvedValue()
-
-            await userController.deleteUser('user-123')
-
-            expect(deleteSpy).toHaveBeenCalledWith('users', 'user-123')
-
-            deleteSpy.mockRestore()
-        })
+    it('should have getById method', () => {
+      expect(typeof userController.getById).toBe('function')
     })
 
-    describe('updateLevel', () => {
-        it('should call update with access level', async () => {
-            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(userController)), 'update')
-                .mockResolvedValue()
-
-            await userController.updateLevel('user-123', 2)
-
-            expect(updateSpy).toHaveBeenCalledWith('users', 'user-123', { accessLevel: 2 })
-
-            updateSpy.mockRestore()
-        })
-
-        it('should throw error when update fails', async () => {
-            const mockError = new Error('Update failed')
-            const updateSpy = jest.spyOn(Object.getPrototypeOf(Object.getPrototypeOf(userController)), 'update')
-                .mockRejectedValue(mockError)
-
-            await expect(userController.updateLevel('user-123', 2)).rejects.toThrow(mockError)
-
-            updateSpy.mockRestore()
-        })
+    it('should have updateProfile method', () => {
+      expect(typeof userController.updateProfile).toBe('function')
     })
+
+    it('should have deleteUser method', () => {
+      expect(typeof userController.deleteUser).toBe('function')
+    })
+
+    it('should have changePassword method', () => {
+      expect(typeof userController.changePassword).toBe('function')
+    })
+
+    it('should have markNotificationAsRead method', () => {
+      expect(typeof userController.markNotificationAsRead).toBe('function')
+    })
+
+    it('should have updateLevel method', () => {
+      expect(typeof userController.updateLevel).toBe('function')
+    })
+  })
+
+  describe('updateProfile', () => {
+    it('should call update with profile data', async () => {
+      const updateSpy = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(userController)),
+          'update',
+        )
+        .mockResolvedValue()
+
+      const payload = {
+        username: 'newusername',
+        contactNo: '1234567890',
+        country: 'US',
+      }
+
+      await userController.updateProfile('user-123', payload)
+
+      expect(updateSpy).toHaveBeenCalledWith('users', 'user-123', {
+        username: 'newusername',
+        contactNo: '1234567890',
+        country: 'US',
+      })
+
+      updateSpy.mockRestore()
+    })
+  })
+
+  describe('deleteUser', () => {
+    it('should call delete with user id', async () => {
+      const deleteSpy = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(userController)),
+          'delete',
+        )
+        .mockResolvedValue()
+
+      await userController.deleteUser('user-123')
+
+      expect(deleteSpy).toHaveBeenCalledWith('users', 'user-123')
+
+      deleteSpy.mockRestore()
+    })
+  })
+
+  describe('updateLevel', () => {
+    it('should call update with access level', async () => {
+      const updateSpy = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(userController)),
+          'update',
+        )
+        .mockResolvedValue()
+
+      await userController.updateLevel('user-123', 2)
+
+      expect(updateSpy).toHaveBeenCalledWith('users', 'user-123', {
+        accessLevel: 2,
+      })
+
+      updateSpy.mockRestore()
+    })
+
+    it('should throw error when update fails', async () => {
+      const mockError = new Error('Update failed')
+      const updateSpy = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(userController)),
+          'update',
+        )
+        .mockRejectedValue(mockError)
+
+      await expect(userController.updateLevel('user-123', 2)).rejects.toThrow(
+        mockError,
+      )
+
+      updateSpy.mockRestore()
+    })
+  })
 })

--- a/tests/unit/UserController.spec.js
+++ b/tests/unit/UserController.spec.js
@@ -62,10 +62,6 @@ describe('UserController', () => {
       expect(typeof userController.changePassword).toBe('function')
     })
 
-    it('should have markNotificationAsRead method', () => {
-      expect(typeof userController.markNotificationAsRead).toBe('function')
-    })
-
     it('should have updateLevel method', () => {
       expect(typeof userController.updateLevel).toBe('function')
     })


### PR DESCRIPTION
## Summary

Improve the notifications architecture and experience by:

- Moving notifications from the user document to the `users/{userId}/notifications` subcollection.
- Adding real-time Firestore snapshots to keep notifications synchronized across the application.
- Creating a dedicated `NotificationController` to handle notification-related operations.
- Restoring the unread notifications functionality across the navbar and notifications page.
- Updating read and mark-all-as-read flows to work with the new notification structure.
- Using notification document IDs to reliably identify and update individual notifications.

This also decouples notifications from the `User` model and provides a cleaner foundation for future notification-related features.

Fixes #2306

<img width="725" height="958" alt="image" src="https://github.com/user-attachments/assets/0716ae85-7071-4dc4-ad8e-ff501862d064" />
