### PR TITLE
chore: commented study and storage limits

### DIFF
--- a/src/features/dashboard/components/StatsCards.vue
+++ b/src/features/dashboard/components/StatsCards.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row class="mb-6">
     <!-- Total Studies Card -->
-    <v-col cols="6" sm="6" md="3">
+    <v-col cols="4" sm="4" md="4">
       <v-card elevation="2" rounded="lg" class="stats-card">
         <v-card-text>
           <v-row>
@@ -12,7 +12,8 @@
             </v-col>
             <v-col cols="12" sm class="text-left text-sm-right pt-0 pt-sm-3">
               <!--STUDIES WHERE USER IS TESTADMIN -->
-              <div class="stats-value">{{ totalStudies }}/50</div>
+              <!-- <div class="stats-value">{{ totalStudies }}/50</div> -->
+              <div class="stats-value">{{ totalStudies }}</div>
               <div class="stats-label">{{ $t('Dashboard.studies') }}</div>
             </v-col>
           </v-row>
@@ -21,7 +22,7 @@
     </v-col>
 
     <!-- Storage Quota Card -->
-    <v-col cols="6" sm="6" md="3">
+    <v-col cols="4" sm="4" md="4">
       <v-card elevation="2" rounded="lg" class="stats-card">
         <v-card-text class="pa-4">
           <v-row>
@@ -43,7 +44,7 @@
     </v-col>
 
     <!-- Current Plan Card -->
-    <v-col cols="6" sm="6" md="3">
+    <!-- <v-col cols="6" sm="6" md="3">
       <v-card elevation="2" rounded="lg" class="stats-card">
         <v-card-text class="pa-4">
           <v-row>
@@ -59,10 +60,10 @@
           </v-row>
         </v-card-text>
       </v-card>
-    </v-col>
+    </v-col> -->
 
     <!-- Total Participants Card -->
-    <v-col cols="6" sm="6" md="3">
+    <v-col cols="4" sm="4" md="4">
       <v-card elevation="2" rounded="lg" class="stats-card">
         <v-card-text class="pa-4">
           <v-row>
@@ -73,7 +74,8 @@
             </v-col>
             <!-- COOPERATORS FROM STUDIES WHERE USER IS TESTADMIN -->
             <v-col cols="12" sm class="text-left text-sm-right pt-0 pt-sm-3">
-              <div class="stats-value">{{ totalParticipants }}/5</div>
+              <!-- <div class="stats-value">{{ totalParticipants }}/5</div> -->
+              <div class="stats-value">{{ totalParticipants }}</div>
               <div class="stats-label">
                 {{ $t('Dashboard.participantsLabel') }}
               </div>
@@ -106,9 +108,11 @@ const props = defineProps({
 const formattedStorage = computed(() => {
   if (props.usedStorage >= 1000) {
     const gb = (props.usedStorage / 1000).toFixed(2)
-    return `${gb}GB/0.5GB`
+    // return `${gb}GB/0.5GB`
+    return `${gb}GB`
   }
-  return `${props.usedStorage.toFixed(2)}MB/500MB`
+  // return `${props.usedStorage.toFixed(2)}MB/500MB`
+  return `${props.usedStorage.toFixed(2)}MB`
 })
 </script>
 

--- a/src/shared/composables/useStorageFiles.js
+++ b/src/shared/composables/useStorageFiles.js
@@ -425,9 +425,9 @@ export function useStorageFiles() {
   const accountUsedBytes = computed(
     () => Number(user.value?.storageUsageMB || 0) * 1024 * 1024,
   )
-  const accountFreeBytes = computed(() =>
-    Math.max(storageQuotaBytes - accountUsedBytes.value, 0),
-  )
+  // const accountFreeBytes = computed(() =>
+  //   Math.max(storageQuotaBytes - accountUsedBytes.value, 0),
+  // )
   const accountUsagePercentage = computed(() =>
     Math.min((accountUsedBytes.value / storageQuotaBytes) * 100, 100),
   )
@@ -453,7 +453,8 @@ export function useStorageFiles() {
 
   const largestType = computed(() =>
     typeBreakdown.value.reduce(
-      (largest, item) => (!largest || item.size > largest.size ? item : largest),
+      (largest, item) =>
+        !largest || item.size > largest.size ? item : largest,
       null,
     ),
   )
@@ -470,14 +471,14 @@ export function useStorageFiles() {
       icon: 'mdi-database',
       color: 'primary',
     },
-    {
-      key: 'free',
-      title: t('storage.freeSpace'),
-      value: formatBytes(accountFreeBytes.value),
-      subtitle: t('storage.accountQuota'),
-      icon: 'mdi-database-check',
-      color: 'success',
-    },
+    // {
+    //   key: 'free',
+    //   title: t('storage.freeSpace'),
+    //   value: formatBytes(accountFreeBytes.value),
+    //   subtitle: t('storage.accountQuota'),
+    //   icon: 'mdi-database-check',
+    //   color: 'success',
+    // },
     {
       key: 'files',
       title: t('storage.totalFiles'),

--- a/src/shared/views/StorageView.vue
+++ b/src/shared/views/StorageView.vue
@@ -6,11 +6,7 @@
   >
     <template #subtitle>
       <div class="d-flex align-center flex-wrap ga-2 mt-2 mb-4">
-        <v-icon
-          icon="mdi-database"
-          size="small"
-          class="text-medium-emphasis"
-        />
+        <v-icon icon="mdi-database" size="small" class="text-medium-emphasis" />
         <span class="text-body-1 text-grey-darken-1">
           {{ t('storage.studyDescription') }}
         </span>
@@ -44,7 +40,9 @@
                     </div>
                   </div>
                 </div>
-                <div class="text-caption text-medium-emphasis mt-2 summary-subtitle">
+                <div
+                  class="text-caption text-medium-emphasis mt-2 summary-subtitle"
+                >
                   {{ metric.subtitle }}
                 </div>
               </v-card-text>
@@ -70,9 +68,9 @@
                   <div class="text-subtitle-2 font-weight-bold">
                     {{ formatBytes(accountUsedBytes) }}
                   </div>
-                  <div class="text-caption text-medium-emphasis">
+                  <!-- <div class="text-caption text-medium-emphasis">
                     / {{ formatBytes(storageQuotaBytes) }}
-                  </div>
+                  </div> -->
                 </div>
                 <v-btn
                   :icon="
@@ -83,7 +81,9 @@
                   variant="text"
                   size="small"
                   :aria-label="t('storage.storageAnalysis')"
-                  @click="isStorageAnalysisExpanded = !isStorageAnalysisExpanded"
+                  @click="
+                    isStorageAnalysisExpanded = !isStorageAnalysisExpanded
+                  "
                 />
               </div>
             </div>
@@ -111,14 +111,18 @@
                           <v-icon :icon="item.icon" size="16" />
                         </v-avatar>
                         <div class="breakdown-copy">
-                          <div class="breakdown-title text-body-2 font-weight-medium">
+                          <div
+                            class="breakdown-title text-body-2 font-weight-medium"
+                          >
                             {{ fileTypeLabel(item.type) }}
                           </div>
                           <div class="text-caption text-medium-emphasis">
                             {{ t('storage.fileCount', { count: item.count }) }}
                           </div>
                         </div>
-                        <div class="breakdown-size text-body-2 font-weight-bold">
+                        <div
+                          class="breakdown-size text-body-2 font-weight-bold"
+                        >
                           {{ formatBytes(item.size) }}
                         </div>
                       </div>
@@ -151,10 +155,7 @@
       </v-col>
     </v-row>
 
-    <v-card
-      class="files-card rounded-lg d-none d-sm-block"
-      elevation="2"
-    >
+    <v-card class="files-card rounded-lg d-none d-sm-block" elevation="2">
       <v-card-title class="files-header px-6 py-4">
         <span class="text-h6 font-weight-bold">
           {{ t('storage.mediaFiles') }}
@@ -217,7 +218,9 @@
         </template>
 
         <template #[`item.size`]="{ item }">
-          {{ item.sizeKnown ? formatBytes(item.size) : t('storage.unknownSize') }}
+          {{
+            item.sizeKnown ? formatBytes(item.size) : t('storage.unknownSize')
+          }}
         </template>
 
         <template #[`item.actions`]="{ item }">
@@ -354,7 +357,9 @@
               <div class="text-caption font-weight-bold text-medium-emphasis">
                 {{ t('storage.headers.date') }}
               </div>
-              <div class="text-body-2 mt-1">{{ formatFileDate(item.date) }}</div>
+              <div class="text-body-2 mt-1">
+                {{ formatFileDate(item.date) }}
+              </div>
             </v-sheet>
           </v-col>
           <v-col cols="6">
@@ -516,7 +521,7 @@ const {
   previewFile,
   deleteDialog,
   fileToDelete,
-  storageQuotaBytes,
+  // storageQuotaBytes,
   isDeleting,
   studyTitle,
   headers,

--- a/src/ux/Heuristic/components/manager/StorageInfo.vue
+++ b/src/ux/Heuristic/components/manager/StorageInfo.vue
@@ -28,25 +28,21 @@
     </div>
 
     <!-- Información adicional -->
-    <div class="additional-info">
+    <!-- <div class="additional-info">
       <div class="info-subtitle text-caption text-grey-darken-1">
         {{ $t('Dashboard.cards.limitAvailable') }}
       </div>
       <div class="info-value text-body-2 font-weight-medium">
         {{ storageLimit }}
       </div>
-    </div>
+    </div> -->
   </v-card>
 </template>
 
 <script setup>
 import { computed, ref, watch } from 'vue'
-import {
-  getMetadata,
-  listAll,
-  ref as storageRef,
-} from 'firebase/storage'
-import { useI18n } from 'vue-i18n'
+import { getMetadata, listAll, ref as storageRef } from 'firebase/storage'
+// import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 import { storage } from '@/app/plugins/firebase'
 import { formatBytes } from '@/shared/utils/formatUtils'
@@ -58,7 +54,7 @@ const props = defineProps({
   },
 })
 
-const { t } = useI18n()
+// const { t } = useI18n()
 const store = useStore()
 const storageUsedBytes = ref(0)
 const loadingStorage = ref(false)
@@ -119,10 +115,10 @@ const storageUsed = computed(() =>
   storageLoadFailed.value ? '-' : formatBytes(storageUsedBytes.value),
 )
 
-const storageLimit = computed(() => {
-  // Límite estándar para estudios
-  return `2${t('common.units.gb')}`
-})
+// const storageLimit = computed(() => {
+//   // Límite estándar para estudios
+//   return `2${t('common.units.gb')}`
+// })
 </script>
 
 <style scoped>

--- a/src/ux/UserTest/components/manager/StorageInfo.vue
+++ b/src/ux/UserTest/components/manager/StorageInfo.vue
@@ -16,7 +16,7 @@
             </p>
           </div>
         </div>
-        <v-chip
+        <!-- <v-chip
           size="small"
           color="rgba(255,255,255,0.2)"
           variant="outlined"
@@ -24,7 +24,7 @@
         >
           <v-icon start size="16">mdi-flask</v-icon>
           {{ t('manager.storage.beta') }}
-        </v-chip>
+        </v-chip> -->
       </div>
     </div>
 
@@ -54,12 +54,13 @@
           :indeterminate="loading"
         />
         <div class="text-caption text-medium-emphasis mt-1">
-          {{
+          <!-- {{
             t('manager.storage.storageQuota', {
               used: storageUsedFormatted,
               quota: storageQuotaFormatted,
             })
-          }}
+          }} -->
+          {{ storageUsedFormatted }}
         </div>
       </div>
 
@@ -251,7 +252,7 @@ const storageColor = computed(() => {
 const storageUsedFormatted = computed(() =>
   formatBytes(estimatedStorageUsed.value),
 )
-const storageQuotaFormatted = computed(() => formatBytes(storageQuotaBytes))
+// const storageQuotaFormatted = computed(() => formatBytes(storageQuotaBytes))
 
 const canManageStorage = computed(() => {
   return hasStudyCapability(


### PR DESCRIPTION
Commented out the limit indicators for:

* **Storage**
* **Studies**
* **Participants**

The UI no longer displays fixed usage limit values for these resources.
<img width="1630" height="370" alt="image" src="https://github.com/user-attachments/assets/71f4bcb7-c208-4466-a401-6a3d828dac6a" />
<img width="717" height="545" alt="image" src="https://github.com/user-attachments/assets/4fa689cd-753f-46b5-bd98-b68ee8689c0e" />
<img width="1907" height="966" alt="image" src="https://github.com/user-attachments/assets/6f0d8cc4-4422-49dc-8c7f-d4a8b8b4fe43" />
