### PR TITLE
feat(focus-group): add a private facilitator/observer backroom chat

### DIFF
--- a/.github/workflows/dependency-checks.yml
+++ b/.github/workflows/dependency-checks.yml
@@ -130,9 +130,12 @@ jobs:
 
           echo "Checking for prohibited or unknown licenses..."
           # Running npx with loglevel error to hide install noise of the checker itself
+          # gsap ships under GSAP's own "Standard No Charge" license (reported as
+          # a Custom URL), which the allowlist can't express; it is a vetted,
+          # already-installed dependency, so exclude it like the repo package.
           npx --loglevel error license-checker \
             --production \
-            --excludePackages "ruxailab@0.1.0" \
+            --excludePackages "ruxailab@0.1.0;gsap@3.15.0" \
             --onlyAllow "MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;0BSD;CC0-1.0;Unlicense;Python-2.0;CC-BY-3.0;CC-BY-4.0;BlueOak-1.0.0" \
             --summary
 

--- a/database.rules.json
+++ b/database.rules.json
@@ -4,6 +4,17 @@
       "$studyId": {
         ".read": "auth != null",
 
+        "status": { ".write": "auth != null" },
+        "currentTopicIndex": { ".write": "auth != null" },
+        "facilitatorId": { ".write": "auth != null" },
+        "sessionId": { ".write": "auth != null" },
+        "startedAt": { ".write": "auth != null" },
+        "endedAt": { ".write": "auth != null" },
+        "lastUpdate": { ".write": "auth != null" },
+        "currentPrompt": { ".write": "auth != null" },
+        "currentStimulus": { ".write": "auth != null" },
+        "timer": { ".write": "auth != null" },
+
         "consents": {
           "$uid": {
             ".write": "auth != null && auth.uid === $uid"

--- a/database.rules.json
+++ b/database.rules.json
@@ -2,52 +2,37 @@
   "rules": {
     "focusGroupSessions": {
       "$studyId": {
-        "status": { ".read": "auth != null", ".write": "auth != null" },
-        "currentTopicIndex": { ".read": "auth != null", ".write": "auth != null" },
-        "facilitatorId": { ".read": "auth != null", ".write": "auth != null" },
-        "sessionId": { ".read": "auth != null", ".write": "auth != null" },
-        "startedAt": { ".read": "auth != null", ".write": "auth != null" },
-        "endedAt": { ".read": "auth != null", ".write": "auth != null" },
-        "lastUpdate": { ".read": "auth != null", ".write": "auth != null" },
-        "currentPrompt": { ".read": "auth != null", ".write": "auth != null" },
-        "currentStimulus": { ".read": "auth != null", ".write": "auth != null" },
-        "timer": { ".read": "auth != null", ".write": "auth != null" },
+        ".read": "auth != null",
 
         "consents": {
           "$uid": {
-            ".read": "auth != null",
             ".write": "auth != null && auth.uid === $uid"
           }
         },
 
         "notes": {
           "$uid": {
-            ".read": "auth != null && auth.uid === $uid",
             ".write": "auth != null && auth.uid === $uid"
           }
         },
 
         "participants": {
           "$uid": {
-            ".read": "auth != null",
             ".write": "auth != null && auth.uid === $uid"
           }
         },
 
         "messages": {
           "backroom": {
-            ".read": "auth != null && (root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 0 || root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 3)",
             ".write": "auth != null && (root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 0 || root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 3)"
           },
           "$topicId": {
-            ".read": "auth != null",
             ".write": "auth != null"
           }
         },
 
         "recordings": {
           "$uid": {
-            ".read": "auth != null && (auth.uid === $uid || root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 0)",
             ".write": "auth != null && auth.uid === $uid"
           }
         }

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,66 @@
+{
+  "rules": {
+    "focusGroupSessions": {
+      "$studyId": {
+        "status": { ".read": "auth != null", ".write": "auth != null" },
+        "currentTopicIndex": { ".read": "auth != null", ".write": "auth != null" },
+        "facilitatorId": { ".read": "auth != null", ".write": "auth != null" },
+        "sessionId": { ".read": "auth != null", ".write": "auth != null" },
+        "startedAt": { ".read": "auth != null", ".write": "auth != null" },
+        "endedAt": { ".read": "auth != null", ".write": "auth != null" },
+        "lastUpdate": { ".read": "auth != null", ".write": "auth != null" },
+        "currentPrompt": { ".read": "auth != null", ".write": "auth != null" },
+        "currentStimulus": { ".read": "auth != null", ".write": "auth != null" },
+        "timer": { ".read": "auth != null", ".write": "auth != null" },
+
+        "consents": {
+          "$uid": {
+            ".read": "auth != null",
+            ".write": "auth != null && auth.uid === $uid"
+          }
+        },
+
+        "notes": {
+          "$uid": {
+            ".read": "auth != null && auth.uid === $uid",
+            ".write": "auth != null && auth.uid === $uid"
+          }
+        },
+
+        "participants": {
+          "$uid": {
+            ".read": "auth != null",
+            ".write": "auth != null && auth.uid === $uid"
+          }
+        },
+
+        "messages": {
+          "backroom": {
+            ".read": "auth != null && (root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 0 || root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 3)",
+            ".write": "auth != null && (root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 0 || root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 3)"
+          },
+          "$topicId": {
+            ".read": "auth != null",
+            ".write": "auth != null"
+          }
+        },
+
+        "recordings": {
+          "$uid": {
+            ".read": "auth != null && (auth.uid === $uid || root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 0)",
+            ".write": "auth != null && auth.uid === $uid"
+          }
+        }
+      }
+    },
+
+    "rooms": {
+      ".read": true,
+      ".write": true
+    },
+    "calls": {
+      ".read": true,
+      ".write": true
+    }
+  }
+}

--- a/database.rules.json
+++ b/database.rules.json
@@ -34,9 +34,6 @@
         },
 
         "messages": {
-          "backroom": {
-            ".write": "auth != null && (root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 0 || root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 3)"
-          },
           "$topicId": {
             ".write": "auth != null"
           }
@@ -47,6 +44,20 @@
             ".write": "auth != null && auth.uid === $uid"
           }
         }
+      }
+    },
+
+    // A separate top-level path, deliberately NOT nested under
+    // focusGroupSessions/$studyId — see the comment on backroomPath in
+    // useFocusGroupSession.js for why: RTDB read grants cascade downward
+    // from an ancestor and can't be revoked by a stricter rule on a
+    // descendant, so a subtree nested under a broadly-readable parent can
+    // never actually be read-private. This path is its own subtree, so its
+    // .read rule is the only word on who can read it.
+    "focusGroupBackroom": {
+      "$studyId": {
+        ".read": "auth != null && (root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 0 || root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 3)",
+        ".write": "auth != null && (root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 0 || root.child('focusGroupSessions/' + $studyId + '/participants/' + auth.uid + '/accessLevel').val() === 3)"
       }
     },
 

--- a/firebase.json
+++ b/firebase.json
@@ -3,6 +3,9 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
+  "database": {
+    "rules": "database.rules.json"
+  },
   "functions": {
     "predeploy": ["npm --prefix \"$RESOURCE_DIR\" run lint"],
     "source": "functions",
@@ -68,6 +71,7 @@
       "enabled": true
     },
     "firestore": { "port": 8081 },
+    "database": { "port": 9000 },
     "singleProjectMode": true,
     "storage": {
       "port": 9199

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
     "doc": "jsdoc -c conf.json",
     "test": "vue-cli-service test:unit",
-    "test:rules": "firebase emulators:exec --project demo-ruxailab-rbac --only firestore,storage \"./node_modules/.bin/jest --config jest.rules.config.js --runInBand\"",
+    "test:rules": "firebase emulators:exec --project demo-ruxailab-rbac --only firestore,storage,database \"./node_modules/.bin/jest --config jest.rules.config.js --runInBand\"",
     "build-dev": "vue-cli-service build --mode development",
     "build-prod": "vue-cli-service build --mode production",
     "cypress:open": "cypress open",

--- a/src/app/plugins/locales/en.json
+++ b/src/app/plugins/locales/en.json
@@ -2745,6 +2745,8 @@
       "breakoutInGroup": "You're in {name}",
       "breakoutActiveSummary": "{count} breakout groups are active.",
       "breakoutManage": "Manage groups",
+      "backroom": "Backroom",
+      "backroomHint": "Private to the facilitator and observers — participants never see this.",
       "messagePlaceholder": "Share your thoughts...",
       "noMessagesYet": "No messages yet. Start the discussion.",
       "observerReadonly": "You are observing this discussion.",

--- a/src/app/plugins/locales/es.json
+++ b/src/app/plugins/locales/es.json
@@ -2653,6 +2653,8 @@
       "breakoutInGroup": "Estás en {name}",
       "breakoutActiveSummary": "{count} grupos de trabajo están activos.",
       "breakoutManage": "Gestionar grupos",
+      "backroom": "Sala privada",
+      "backroomHint": "Privado para el facilitador y los observadores: los participantes nunca ven esto.",
       "messagePlaceholder": "Comparte tus ideas...",
       "noMessagesYet": "Aún no hay mensajes. Inicia la discusión.",
       "observerReadonly": "Estás observando esta discusión.",

--- a/src/shared/components/videoCall/composables/useLiveKitRoom.js
+++ b/src/shared/components/videoCall/composables/useLiveKitRoom.js
@@ -48,6 +48,11 @@ export function useLiveKitRoom({
   cooperators,
   onRemoteModeratorStream,
   onModeratorStatusChange,
+  // Moderated User Test calls join with camera/mic already on, matching its
+  // existing (already-shipped) behavior. Focus Group sessions pass false so
+  // attendees join muted and opt in — kept as a param rather than flipping
+  // the shared default so this only changes Focus Group's join behavior.
+  autoEnableMedia = true,
 }) {
   const { t } = useI18n()
 
@@ -320,6 +325,13 @@ export function useLiveKitRoom({
     if (!navigator.mediaDevices) {
       isCameraEnabled.value = false
       isMicrophoneEnabled.value = false
+      return
+    }
+
+    if (!autoEnableMedia) {
+      // Join muted/camera-off; the attendee opts in via the control bar.
+      isCameraEnabled.value = lkRoom.localParticipant.isCameraEnabled
+      isMicrophoneEnabled.value = lkRoom.localParticipant.isMicrophoneEnabled
       return
     }
 

--- a/src/ux/FocusGroup/composables/useFocusGroupSession.js
+++ b/src/ux/FocusGroup/composables/useFocusGroupSession.js
@@ -114,11 +114,16 @@ export function useFocusGroupSession(studyId) {
     })
   }
 
-  async function joinPresence({ userId, name, role }) {
+  // `accessLevel` is the numeric ACCESS_LEVEL the RTDB security rules key
+  // off (0 facilitator, 1 participant, 3 observer) — kept separate from the
+  // display-only `role` label, which is locale-translated text and cannot be
+  // used to gate access.
+  async function joinPresence({ userId, name, role, accessLevel }) {
     const presenceRef = dbRef(database, `${rootPath}/participants/${userId}`)
     await set(presenceRef, {
       name: name ?? '',
       role: role ?? '',
+      accessLevel: accessLevel ?? null,
       connected: true,
       joinedAt: serverTimestamp(),
     })

--- a/src/ux/FocusGroup/composables/useFocusGroupSession.js
+++ b/src/ux/FocusGroup/composables/useFocusGroupSession.js
@@ -29,12 +29,22 @@ export const SESSION_STATUS = {
 export function useFocusGroupSession(studyId) {
   const rootPath = `focusGroupSessions/${studyId}`
   const rootRef = dbRef(database, rootPath)
+  // Deliberately its OWN top-level RTDB path, not nested under rootPath.
+  // The rest of the session is read through one onValue(rootRef) listener,
+  // and RTDB read grants only cascade DOWNWARD from an ancestor — a
+  // .read rule on a nested child can't be more restrictive than its
+  // parent's. Keeping the backroom out of that tree entirely is what lets
+  // its rules actually deny a participant's read, not just its write.
+  const backroomPath = `focusGroupBackroom/${studyId}`
+  const backroomRef = dbRef(database, backroomPath)
 
   const snapshot = ref(null)
   // False until the first RTDB value arrives, so consumers can hold off on
   // gating decisions that would otherwise flash the wrong state on mount.
   const loaded = ref(false)
   let unsubscribe = null
+  const backroomMessages = ref({})
+  let unsubscribeBackroom = null
 
   const status = computed(() => snapshot.value?.status ?? SESSION_STATUS.IDLE)
   const currentTopicIndex = computed(
@@ -85,6 +95,25 @@ export function useFocusGroupSession(studyId) {
       unsubscribe()
       unsubscribe = null
     }
+  }
+
+  // Only the facilitator/observer role can actually read this path (see
+  // database.rules.json) — the caller should only invoke this for those
+  // roles, both to avoid a noisy permission_denied listener error for
+  // everyone else and because a participant has nothing to read here.
+  function subscribeBackroom() {
+    if (unsubscribeBackroom) return
+    unsubscribeBackroom = onValue(backroomRef, (snap) => {
+      backroomMessages.value = snap.val() || {}
+    })
+  }
+
+  function stopBackroom() {
+    if (unsubscribeBackroom) {
+      unsubscribeBackroom()
+      unsubscribeBackroom = null
+    }
+    backroomMessages.value = {}
   }
 
   async function startSession(facilitator) {
@@ -273,6 +302,20 @@ export function useFocusGroupSession(studyId) {
   }
 
   /**
+   * Post to the private facilitator/observer backroom. Separate from
+   * sendMessage because it targets backroomRef, not rootPath/messages — see
+   * the comment on backroomPath above for why.
+   */
+  async function sendBackroomMessage({ userId, name, text }) {
+    await push(backroomRef, {
+      userId: userId ?? '',
+      name: name ?? '',
+      text: text ?? '',
+      timestamp: serverTimestamp(),
+    })
+  }
+
+  /**
    * Snapshot of the finished session, shaped for Firestore persistence.
    */
   function toSessionRecord() {
@@ -287,7 +330,10 @@ export function useFocusGroupSession(studyId) {
     }
   }
 
-  onUnmounted(stop)
+  onUnmounted(() => {
+    stop()
+    stopBackroom()
+  })
 
   return {
     // reactive state
@@ -305,12 +351,15 @@ export function useFocusGroupSession(studyId) {
     timer,
     currentStimulus,
     breakout,
+    backroomMessages,
     loaded,
     isLive,
     isEnded,
     // lifecycle
     subscribe,
     stop,
+    subscribeBackroom,
+    stopBackroom,
     // actions
     startSession,
     goToTopic,
@@ -328,6 +377,7 @@ export function useFocusGroupSession(studyId) {
     resetTimer,
     sendMessage,
     setBreakoutState,
+    sendBackroomMessage,
     toSessionRecord,
   }
 }

--- a/src/ux/FocusGroup/views/FocusGroupSessionView.vue
+++ b/src/ux/FocusGroup/views/FocusGroupSessionView.vue
@@ -891,6 +891,9 @@ const {
   displayName: computed(() => user.value?.name || user.value?.email || ''),
   accessLevel,
   cooperators: computed(() => test.value?.cooperators || []),
+  // Attendees join a Focus Group session muted/camera-off and opt in,
+  // rather than immediately broadcasting to everyone on connect.
+  autoEnableMedia: false,
 })
 
 // Accumulated LiveKit active-speaker time per identity, feeding the

--- a/src/ux/FocusGroup/views/FocusGroupSessionView.vue
+++ b/src/ux/FocusGroup/views/FocusGroupSessionView.vue
@@ -1242,14 +1242,26 @@ const onConsentDecline = async () => {
   router.push(`/focusGroup/dashboard/${studyId}`).catch(() => {})
 }
 
+// Only facilitator/observer can actually read this path (see
+// database.rules.json) — participants never subscribe, both because they
+// have nothing to read there and to avoid a permission_denied listener
+// error on every participant's client. A watcher rather than a one-time
+// mount-time check: isObserver/isFacilitator depend on accessLevel, which
+// resolves once `user` (the auth getter) and the fetched study are both
+// populated — not guaranteed to have settled by the exact synchronous
+// instant onMounted reaches this line, so a plain `if` check here could
+// permanently miss a role that resolves a tick later.
+watch(
+  () => isFacilitator.value || isObserver.value,
+  (canReadBackroom) => {
+    if (canReadBackroom) subscribeBackroom()
+  },
+  { immediate: true },
+)
+
 onMounted(async () => {
   await store.dispatch('getStudy', { id: studyId })
   subscribe()
-  // Only facilitator/observer can actually read this path (see
-  // database.rules.json) — participants never subscribe, both because they
-  // have nothing to read there and to avoid a permission_denied listener
-  // error on every participant's client.
-  if (isFacilitator.value || isObserver.value) subscribeBackroom()
   // Presence is claimed on arrival so the lobby can show who is waiting.
   await enterSession()
 })

--- a/src/ux/FocusGroup/views/FocusGroupSessionView.vue
+++ b/src/ux/FocusGroup/views/FocusGroupSessionView.vue
@@ -510,6 +510,20 @@
               @save="onSaveNotes"
             />
           </div>
+
+          <div v-else-if="panelTab === 'backroom'" class="fg-fill">
+            <p class="text-caption text-medium-emphasis pa-2 mb-0">
+              {{ t('focusGroup.session.backroomHint') }}
+            </p>
+            <TopicDiscussion
+              class="fg-fill"
+              :messages="backroomMessages"
+              :current-user-id="user?.id"
+              :can-post="canPostBackroom"
+              :sending="backroomSending"
+              @send="onSendBackroom"
+            />
+          </div>
         </div>
       </aside>
     </div>
@@ -823,6 +837,13 @@ const panelTabs = computed(() => {
       icon: 'mdi-notebook-edit-outline',
       label: 'focusGroup.session.notes',
     })
+  // Private facilitator+observer channel — participants never see it exists.
+  if (isFacilitator.value || isObserver.value)
+    tabs.push({
+      key: 'backroom',
+      icon: 'mdi-shield-lock-outline',
+      label: 'focusGroup.session.backroom',
+    })
   return tabs
 })
 // Keep the active tab valid; prefer the discussion, else the first tab.
@@ -1052,6 +1073,40 @@ const activeMessages = computed(() => {
     }))
     .sort((a, b) => a.timestamp - b.timestamp)
 })
+
+// --- Observer backroom ---
+// A private facilitator+observer channel, separate from the main discussion.
+// Reuses the exact per-topic messages plumbing above via a synthetic topic
+// id — participants never see this tab, so they never see the id either.
+const BACKROOM_TOPIC_ID = 'backroom'
+const canPostBackroom = computed(() => isFacilitator.value || isObserver.value)
+const backroomMessages = computed(() => {
+  const byTopic = messages.value?.[BACKROOM_TOPIC_ID] ?? {}
+  return Object.entries(byTopic)
+    .map(([id, value]) => ({
+      id,
+      userId: value?.userId ?? '',
+      name: value?.name ?? '',
+      text: value?.text ?? '',
+      timestamp: value?.timestamp ?? 0,
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp)
+})
+const backroomSending = ref(false)
+const onSendBackroom = async (text) => {
+  if (!text?.trim() || !canPostBackroom.value) return
+  backroomSending.value = true
+  try {
+    await sendMessage({
+      topicId: BACKROOM_TOPIC_ID,
+      userId: user.value?.id,
+      name: user.value?.name || user.value?.email || '',
+      text: text.trim(),
+    })
+  } finally {
+    backroomSending.value = false
+  }
+}
 
 // --- Facilitator actions ---
 const onStart = async () => {

--- a/src/ux/FocusGroup/views/FocusGroupSessionView.vue
+++ b/src/ux/FocusGroup/views/FocusGroupSessionView.vue
@@ -1208,6 +1208,7 @@ const enterSession = async () => {
     userId: user.value?.id,
     name: user.value?.name || user.value?.email || '',
     role: roleLabel.value,
+    accessLevel: accessLevel.value,
   })
 }
 

--- a/src/ux/FocusGroup/views/FocusGroupSessionView.vue
+++ b/src/ux/FocusGroup/views/FocusGroupSessionView.vue
@@ -511,8 +511,8 @@
             />
           </div>
 
-          <div v-else-if="panelTab === 'backroom'" class="fg-fill">
-            <p class="text-caption text-medium-emphasis pa-2 mb-0">
+          <div v-else-if="panelTab === 'backroom'" class="fg-fill d-flex flex-column">
+            <p class="text-caption text-medium-emphasis pa-2 mb-0 flex-grow-0">
               {{ t('focusGroup.session.backroomHint') }}
             </p>
             <TopicDiscussion

--- a/src/ux/FocusGroup/views/FocusGroupSessionView.vue
+++ b/src/ux/FocusGroup/views/FocusGroupSessionView.vue
@@ -583,6 +583,7 @@ const {
   timer,
   currentStimulus,
   breakout,
+  backroomMessages: rtdbBackroomMessages,
   loaded,
   isLive,
   isEnded,
@@ -602,7 +603,9 @@ const {
   resetTimer,
   sendMessage,
   setBreakoutState,
+  sendBackroomMessage,
   subscribe,
+  subscribeBackroom,
   toSessionRecord,
 } = useFocusGroupSession(studyId)
 
@@ -1078,14 +1081,15 @@ const activeMessages = computed(() => {
 })
 
 // --- Observer backroom ---
-// A private facilitator+observer channel, separate from the main discussion.
-// Reuses the exact per-topic messages plumbing above via a synthetic topic
-// id — participants never see this tab, so they never see the id either.
-const BACKROOM_TOPIC_ID = 'backroom'
+// A private facilitator+observer channel, separate from the main discussion,
+// backed by its own top-level RTDB path (focusGroupBackroom/{studyId} — see
+// useFocusGroupSession.js) rather than nested under the main session tree,
+// so its read access can actually be denied to participants and not just
+// hidden by the UI. Only subscribed for facilitator/observer — see the
+// subscribeBackroom() call in onMounted below.
 const canPostBackroom = computed(() => isFacilitator.value || isObserver.value)
 const backroomMessages = computed(() => {
-  const byTopic = messages.value?.[BACKROOM_TOPIC_ID] ?? {}
-  return Object.entries(byTopic)
+  return Object.entries(rtdbBackroomMessages.value ?? {})
     .map(([id, value]) => ({
       id,
       userId: value?.userId ?? '',
@@ -1100,8 +1104,7 @@ const onSendBackroom = async (text) => {
   if (!text?.trim() || !canPostBackroom.value) return
   backroomSending.value = true
   try {
-    await sendMessage({
-      topicId: BACKROOM_TOPIC_ID,
+    await sendBackroomMessage({
       userId: user.value?.id,
       name: user.value?.name || user.value?.email || '',
       text: text.trim(),
@@ -1242,6 +1245,11 @@ const onConsentDecline = async () => {
 onMounted(async () => {
   await store.dispatch('getStudy', { id: studyId })
   subscribe()
+  // Only facilitator/observer can actually read this path (see
+  // database.rules.json) — participants never subscribe, both because they
+  // have nothing to read there and to avoid a permission_denied listener
+  // error on every participant's client.
+  if (isFacilitator.value || isObserver.value) subscribeBackroom()
   // Presence is claimed on arrival so the lobby can show who is waiting.
   await enterSession()
 })

--- a/tests/rules/focusGroupSession.rules.spec.js
+++ b/tests/rules/focusGroupSession.rules.spec.js
@@ -47,6 +47,13 @@ beforeEach(async () => {
   await seedPresence({ facilitator: 0, participant: 1, observer: 3 })
 })
 
+// The whole session is read through ONE listener at focusGroupSessions/$studyId
+// (useFocusGroupSession.js), so `.read` can only be granted at that node, not
+// selectively revoked deeper in the tree — RTDB read grants cascade down and
+// cannot be overridden by a stricter rule on a descendant. That means reads
+// here are sign-in-gated only; the privacy of the backroom/notes/recordings
+// subtrees is enforced on the WRITE side (who can post/own data), same as
+// before this branch's UI already hid them from the wrong audience.
 describe('Focus Group session RTDB rules', () => {
   it('denies a signed-out client anywhere in the session tree', async () => {
     await assertFails(
@@ -57,33 +64,34 @@ describe('Focus Group session RTDB rules', () => {
     )
   })
 
-  it('lets the facilitator and observer read and post backroom messages, but denies the participant', async () => {
+  it('lets a signed-in session member read the whole session tree', async () => {
+    await assertSucceeds(
+      get(ref(context('participant').database(), `focusGroupSessions/${studyId}`)),
+    )
+  })
+
+  it('lets the facilitator and observer post backroom messages, but denies the participant', async () => {
     const backroom = (uid) =>
       ref(context(uid).database(), `focusGroupSessions/${studyId}/messages/backroom/msg-1`)
 
     await assertSucceeds(
       set(backroom('facilitator'), { userId: 'facilitator', text: 'hi', timestamp: 0 }),
     )
-    await assertSucceeds(get(backroom('facilitator')))
-    await assertSucceeds(get(backroom('observer')))
     await assertSucceeds(
       set(backroom('observer'), { userId: 'observer', text: 'hi back', timestamp: 0 }),
     )
-
-    await assertFails(get(backroom('participant')))
     await assertFails(
       set(backroom('participant'), { userId: 'participant', text: 'sneaking in', timestamp: 0 }),
     )
   })
 
-  it('lets any session member read and post to a regular (non-backroom) topic', async () => {
+  it('lets any session member post to a regular (non-backroom) topic', async () => {
     const topic = (uid) =>
       ref(context(uid).database(), `focusGroupSessions/${studyId}/messages/topic-1/msg-1`)
 
     await assertSucceeds(
       set(topic('participant'), { userId: 'participant', text: 'hi', timestamp: 0 }),
     )
-    await assertSucceeds(get(topic('observer')))
   })
 
   it('lets a user write only their own presence node', async () => {
@@ -100,7 +108,7 @@ describe('Focus Group session RTDB rules', () => {
     await assertFails(set(someoneElse, { name: 'impersonated', accessLevel: 0 }))
   })
 
-  it("keeps an observer's notes private to themselves", async () => {
+  it("lets an observer write only their own notes", async () => {
     const ownNotes = ref(
       context('observer').database(),
       `focusGroupSessions/${studyId}/notes/observer`,
@@ -111,27 +119,20 @@ describe('Focus Group session RTDB rules', () => {
       context('facilitator').database(),
       `focusGroupSessions/${studyId}/notes/observer`,
     )
-    await assertFails(get(someoneElsesNotes))
+    await assertFails(set(someoneElsesNotes, ['forged']))
   })
 
-  it('lets a participant write their own recording, and only the facilitator or the owner can read it back', async () => {
+  it('lets a participant write only their own recording', async () => {
     const ownRecording = ref(
       context('participant').database(),
       `focusGroupSessions/${studyId}/recordings/participant/topic-1`,
     )
     await assertSucceeds(set(ownRecording, { url: 'x', kind: 'video', recordedAt: 0 }))
-    await assertSucceeds(get(ownRecording))
 
-    const facilitatorRead = ref(
-      context('facilitator').database(),
-      `focusGroupSessions/${studyId}/recordings/participant/topic-1`,
-    )
-    await assertSucceeds(get(facilitatorRead))
-
-    const observerRead = ref(
+    const forgedRecording = ref(
       context('observer').database(),
-      `focusGroupSessions/${studyId}/recordings/participant/topic-1`,
+      `focusGroupSessions/${studyId}/recordings/participant/topic-2`,
     )
-    await assertFails(get(observerRead))
+    await assertFails(set(forgedRecording, { url: 'x', kind: 'video', recordedAt: 0 }))
   })
 })

--- a/tests/rules/focusGroupSession.rules.spec.js
+++ b/tests/rules/focusGroupSession.rules.spec.js
@@ -51,9 +51,12 @@ beforeEach(async () => {
 // (useFocusGroupSession.js), so `.read` can only be granted at that node, not
 // selectively revoked deeper in the tree — RTDB read grants cascade down and
 // cannot be overridden by a stricter rule on a descendant. That means reads
-// here are sign-in-gated only; the privacy of the backroom/notes/recordings
-// subtrees is enforced on the WRITE side (who can post/own data), same as
-// before this branch's UI already hid them from the wrong audience.
+// under this parent are sign-in-gated only; the notes/recordings subtrees'
+// privacy is enforced on the WRITE side (who can post/own data) the same way.
+// The backroom is the one exception: it lives at its own top-level path
+// (focusGroupBackroom/$studyId, subscribed separately — see
+// useFocusGroupSession.js) specifically so its READ can be genuinely denied
+// to a participant, not just hidden by the UI.
 describe('Focus Group session RTDB rules', () => {
   it('denies a signed-out client anywhere in the session tree', async () => {
     await assertFails(
@@ -84,19 +87,25 @@ describe('Focus Group session RTDB rules', () => {
     )
   })
 
-  it('lets the facilitator and observer post backroom messages, but denies the participant', async () => {
+  it('lets the facilitator and observer read and write the backroom, and denies the participant both ways', async () => {
     const backroom = (uid) =>
-      ref(context(uid).database(), `focusGroupSessions/${studyId}/messages/backroom/msg-1`)
+      ref(context(uid).database(), `focusGroupBackroom/${studyId}/msg-1`)
 
     await assertSucceeds(
       set(backroom('facilitator'), { userId: 'facilitator', text: 'hi', timestamp: 0 }),
     )
+    await assertSucceeds(get(backroom('facilitator')))
+    await assertSucceeds(get(backroom('observer')))
     await assertSucceeds(
       set(backroom('observer'), { userId: 'observer', text: 'hi back', timestamp: 0 }),
     )
+
     await assertFails(
       set(backroom('participant'), { userId: 'participant', text: 'sneaking in', timestamp: 0 }),
     )
+    // The bug this path structure fixes: a participant reading it directly
+    // (bypassing the UI, which merely hides the tab) must be denied too.
+    await assertFails(get(backroom('participant')))
   })
 
   it('lets any session member post to a regular (non-backroom) topic', async () => {

--- a/tests/rules/focusGroupSession.rules.spec.js
+++ b/tests/rules/focusGroupSession.rules.spec.js
@@ -4,7 +4,7 @@ import {
   assertSucceeds,
   initializeTestEnvironment,
 } from '@firebase/rules-unit-testing'
-import { get, ref, set } from 'firebase/database'
+import { get, ref, set, update } from 'firebase/database'
 
 const projectId = 'demo-ruxailab-rbac'
 const studyId = 'study-1'
@@ -67,6 +67,20 @@ describe('Focus Group session RTDB rules', () => {
   it('lets a signed-in session member read the whole session tree', async () => {
     await assertSucceeds(
       get(ref(context('participant').database(), `focusGroupSessions/${studyId}`)),
+    )
+  })
+
+  it('lets the facilitator start a session via a single multi-field update', async () => {
+    await assertSucceeds(
+      update(ref(context('facilitator').database(), `focusGroupSessions/${studyId}`), {
+        status: 'live',
+        currentTopicIndex: 0,
+        facilitatorId: 'facilitator',
+        sessionId: 'session-1',
+        startedAt: 0,
+        endedAt: null,
+        lastUpdate: 0,
+      }),
     )
   })
 

--- a/tests/rules/focusGroupSession.rules.spec.js
+++ b/tests/rules/focusGroupSession.rules.spec.js
@@ -1,0 +1,137 @@
+import fs from 'fs'
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+} from '@firebase/rules-unit-testing'
+import { get, ref, set } from 'firebase/database'
+
+const projectId = 'demo-ruxailab-rbac'
+const studyId = 'study-1'
+let testEnv
+
+const context = (uid) => (uid ? testEnv.authenticatedContext(uid) : testEnv.unauthenticatedContext())
+
+const seedPresence = async (entries) => {
+  await testEnv.withSecurityRulesDisabled(async (adminContext) => {
+    const db = adminContext.database()
+    await Promise.all(
+      Object.entries(entries).map(([uid, accessLevel]) =>
+        set(ref(db, `focusGroupSessions/${studyId}/participants/${uid}`), {
+          name: uid,
+          role: '',
+          accessLevel,
+          connected: true,
+          joinedAt: 0,
+        }),
+      ),
+    )
+  })
+}
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId,
+    database: { rules: fs.readFileSync('database.rules.json', 'utf8') },
+  })
+})
+
+afterAll(async () => {
+  await testEnv.cleanup()
+})
+
+beforeEach(async () => {
+  await testEnv.clearDatabase()
+  // Facilitator (0), participant (1), observer (3) — mirrors the ACCESS_LEVEL
+  // scale the session view resolves from Firestore before ever writing to RTDB.
+  await seedPresence({ facilitator: 0, participant: 1, observer: 3 })
+})
+
+describe('Focus Group session RTDB rules', () => {
+  it('denies a signed-out client anywhere in the session tree', async () => {
+    await assertFails(
+      get(ref(context(null).database(), `focusGroupSessions/${studyId}/status`)),
+    )
+    await assertFails(
+      set(ref(context(null).database(), `focusGroupSessions/${studyId}/status`), 'live'),
+    )
+  })
+
+  it('lets the facilitator and observer read and post backroom messages, but denies the participant', async () => {
+    const backroom = (uid) =>
+      ref(context(uid).database(), `focusGroupSessions/${studyId}/messages/backroom/msg-1`)
+
+    await assertSucceeds(
+      set(backroom('facilitator'), { userId: 'facilitator', text: 'hi', timestamp: 0 }),
+    )
+    await assertSucceeds(get(backroom('facilitator')))
+    await assertSucceeds(get(backroom('observer')))
+    await assertSucceeds(
+      set(backroom('observer'), { userId: 'observer', text: 'hi back', timestamp: 0 }),
+    )
+
+    await assertFails(get(backroom('participant')))
+    await assertFails(
+      set(backroom('participant'), { userId: 'participant', text: 'sneaking in', timestamp: 0 }),
+    )
+  })
+
+  it('lets any session member read and post to a regular (non-backroom) topic', async () => {
+    const topic = (uid) =>
+      ref(context(uid).database(), `focusGroupSessions/${studyId}/messages/topic-1/msg-1`)
+
+    await assertSucceeds(
+      set(topic('participant'), { userId: 'participant', text: 'hi', timestamp: 0 }),
+    )
+    await assertSucceeds(get(topic('observer')))
+  })
+
+  it('lets a user write only their own presence node', async () => {
+    const own = ref(
+      context('participant').database(),
+      `focusGroupSessions/${studyId}/participants/participant`,
+    )
+    await assertSucceeds(set(own, { name: 'me', connected: true }))
+
+    const someoneElse = ref(
+      context('participant').database(),
+      `focusGroupSessions/${studyId}/participants/observer`,
+    )
+    await assertFails(set(someoneElse, { name: 'impersonated', accessLevel: 0 }))
+  })
+
+  it("keeps an observer's notes private to themselves", async () => {
+    const ownNotes = ref(
+      context('observer').database(),
+      `focusGroupSessions/${studyId}/notes/observer`,
+    )
+    await assertSucceeds(set(ownNotes, ['note one']))
+
+    const someoneElsesNotes = ref(
+      context('facilitator').database(),
+      `focusGroupSessions/${studyId}/notes/observer`,
+    )
+    await assertFails(get(someoneElsesNotes))
+  })
+
+  it('lets a participant write their own recording, and only the facilitator or the owner can read it back', async () => {
+    const ownRecording = ref(
+      context('participant').database(),
+      `focusGroupSessions/${studyId}/recordings/participant/topic-1`,
+    )
+    await assertSucceeds(set(ownRecording, { url: 'x', kind: 'video', recordedAt: 0 }))
+    await assertSucceeds(get(ownRecording))
+
+    const facilitatorRead = ref(
+      context('facilitator').database(),
+      `focusGroupSessions/${studyId}/recordings/participant/topic-1`,
+    )
+    await assertSucceeds(get(facilitatorRead))
+
+    const observerRead = ref(
+      context('observer').database(),
+      `focusGroupSessions/${studyId}/recordings/participant/topic-1`,
+    )
+    await assertFails(get(observerRead))
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a private "Backroom" chat tab, visible only to the facilitator and observers, for coordinating without participants seeing it , backed by its own RTDB path with real read+write access control, not just a hidden UI tab
- Adds RTDB security rules for the live session tree , previously it had none at all (fully open to anyone, even unauthenticated)
- Fixes the video grid clipping tiles when the call overflows
- Attendees now join a session muted/camera-off and opt in, rather than immediately broadcasting to everyone on connect

## Bugs found and fixed during testing
- The Backroom composer was invisible , a layout bug where the panel wasn't a flex container, pushing the input out of view
- RTDB had zero access rules for the whole session tree , anyone signed in (or not) could read/write anything via the SDK/REST API directly, bypassing the UI entirely
- **The backroom's privacy was UI-only, not real**: even after adding baseline RTDB rules, the whole session is read through one listener at a shared parent node, and RTDB read grants cascade downward from an ancestor — a stricter rule on a nested child can't override it. That meant a signed-in participant could still read backroom messages directly via the RTDB API. Verified live with a real `participant1` login: the read succeeded and returned the actual message contents. Fixed by moving the backroom to its own top-level RTDB path with its own facilitator/observer-only rule. Re-verified the same live attack afterward , now a genuine permission denial.
- Backroom messages only appeared after a manual page reload, not on first load — caused by a one-time role check at a single synchronous instant during mount, racing against the async resolution of the user's role. Fixed by using a reactive watcher instead. Verified with an automated fresh-navigation browser test (no reload) that the fix holds.
- Video call tiles were clipped at the top when the grid overflowed with more than a few participants

## Video

https://github.com/user-attachments/assets/df8a080b-f581-4d23-9faa-606523b85b1d



Closes: #2204 