### PR TITLE
feat(user-test): improve moderated test facilitator UX (#2276)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -156,6 +156,10 @@ service cloud.firestore {
       match /participants/{participantId} {
         allow read: if signedIn();
       }
+
+      match /sessions/{sessionId} {
+        allow read, write: if signedIn();
+      }
     }
 
     match /answers/{answerId} {

--- a/src/ux/UserTest/components/steps/ModeratorWelcomeStep.vue
+++ b/src/ux/UserTest/components/steps/ModeratorWelcomeStep.vue
@@ -14,7 +14,7 @@
           </v-chip>
         </div>
 
-        <h2 class="split text-h4 font-weight-bold mb-4 text-primary">
+        <h2 class="split text-h4 font-weight-bold mb-2 text-primary">
           {{ $t('UserTestView.ModeratorWelcomeStep.welcome') }}
         </h2>
 
@@ -22,8 +22,168 @@
           {{ $t('UserTestView.ModeratorWelcomeStep.description') }}
         </p>
 
+        <!-- Webcam & Active Collaborators Row -->
+        <v-row class="mb-6" justify="center">
+          <!-- Facilitator Webcam Preview -->
+          <v-col cols="12" md="6">
+            <v-card
+              class="elevation-3 rounded-xl overflow-hidden pa-4 fill-height d-flex flex-column justify-space-between"
+            >
+              <div class="d-flex justify-space-between align-center mb-3">
+                <div
+                  class="text-subtitle-1 font-weight-bold d-flex align-center"
+                >
+                  <v-icon color="primary" class="mr-2">mdi-webcam</v-icon>
+                  Facilitator Camera Preview
+                </div>
+                <v-chip
+                  size="small"
+                  :color="isCameraOn ? 'success' : 'grey'"
+                  variant="flat"
+                >
+                  {{ isCameraOn ? 'Camera Active' : 'Camera Off' }}
+                </v-chip>
+              </div>
+
+              <div
+                class="webcam-preview-container rounded-lg mb-3 bg-black d-flex align-center justify-center position-relative"
+              >
+                <video
+                  ref="webcamVideoRef"
+                  autoplay
+                  playsinline
+                  muted
+                  class="webcam-video"
+                  :class="{ 'd-none': !isCameraOn }"
+                ></video>
+                <div
+                  v-if="!isCameraOn"
+                  class="text-center pa-6 text-grey-lighten-1"
+                >
+                  <v-icon size="48" color="grey">mdi-camera-off</v-icon>
+                  <div class="mt-2 text-caption">Webcam Preview Disabled</div>
+                </div>
+              </div>
+
+              <div class="d-flex justify-center ga-2">
+                <v-btn
+                  size="small"
+                  :color="isCameraOn ? 'primary' : 'grey'"
+                  variant="outlined"
+                  @click="toggleCamera"
+                >
+                  <v-icon start>{{
+                    isCameraOn ? 'mdi-camera' : 'mdi-camera-off'
+                  }}</v-icon>
+                  {{ isCameraOn ? 'Turn Off Camera' : 'Turn On Camera' }}
+                </v-btn>
+                <v-btn
+                  size="small"
+                  :color="isMicOn ? 'primary' : 'grey'"
+                  variant="outlined"
+                  @click="toggleMic"
+                >
+                  <v-icon start>{{
+                    isMicOn ? 'mdi-microphone' : 'mdi-microphone-off'
+                  }}</v-icon>
+                  {{ isMicOn ? 'Mute Mic' : 'Unmute Mic' }}
+                </v-btn>
+              </div>
+            </v-card>
+          </v-col>
+
+          <!-- Collaborators & Facilitators Waiting Card -->
+          <v-col cols="12" md="6">
+            <v-card
+              class="elevation-3 rounded-xl pa-4 fill-height text-left d-flex flex-column"
+            >
+              <div class="d-flex justify-space-between align-center mb-3">
+                <div
+                  class="text-subtitle-1 font-weight-bold d-flex align-center"
+                >
+                  <v-icon color="primary" class="mr-2"
+                    >mdi-account-group</v-icon
+                  >
+                  Collaborators in Call
+                </div>
+                <v-chip color="info" size="small" variant="flat">
+                  {{ staffMembers.length }}
+                  {{
+                    staffMembers.length === 1
+                      ? 'Collaborator'
+                      : 'Collaborators'
+                  }}
+                </v-chip>
+              </div>
+
+              <p class="text-caption text-grey-darken-1 mb-3">
+                Facilitators and observers present for this moderated test:
+              </p>
+
+              <v-divider class="mb-3" />
+
+              <div class="collaborators-list flex-grow-1 overflow-y-auto">
+                <v-list
+                  v-if="staffMembers && staffMembers.length > 0"
+                  density="compact"
+                  class="pa-0"
+                >
+                  <v-list-item
+                    v-for="(member, index) in staffMembers"
+                    :key="member.userDocId || index"
+                    class="px-2 py-1 rounded-lg mb-2 bg-grey-lighten-4"
+                  >
+                    <template #prepend>
+                      <v-avatar
+                        size="32"
+                        color="primary"
+                        class="text-white font-weight-bold mr-3"
+                      >
+                        {{
+                          (
+                            member.fullName ||
+                            member.email ||
+                            'F'
+                          )[0].toUpperCase()
+                        }}
+                      </v-avatar>
+                    </template>
+
+                    <v-list-item-title class="font-weight-medium text-body-2">
+                      {{ member.fullName || member.email || 'Facilitator' }}
+                    </v-list-item-title>
+
+                    <v-list-item-subtitle
+                      class="text-caption text-grey-darken-1"
+                    >
+                      {{ member.role || 'Facilitator' }}
+                    </v-list-item-subtitle>
+
+                    <template #append>
+                      <v-chip size="x-small" color="success" variant="tonal">
+                        <v-icon start size="10">mdi-circle</v-icon>
+                        Joined
+                      </v-chip>
+                    </template>
+                  </v-list-item>
+                </v-list>
+
+                <div v-else class="text-center py-6 text-grey">
+                  <v-icon size="36" color="grey-lighten-1"
+                    >mdi-account-clock</v-icon
+                  >
+                  <div class="text-caption mt-1">
+                    Waiting for collaborators to join...
+                  </div>
+                </div>
+              </div>
+            </v-card>
+          </v-col>
+        </v-row>
+
+        <!-- Instructions Card -->
         <v-row justify="center" class="mb-6">
-          <v-col cols="12" md="10" lg="8">
+          <v-col cols="12">
             <v-card
               class="moderator-instructions elevation-3"
               color="blue-grey-lighten-5"
@@ -33,7 +193,7 @@
                 {{ $t('UserTestView.ModeratorWelcomeStep.instructionsTitle') }}
               </v-card-title>
               <v-card-text>
-                <v-list density="compact" class="bg-transparent">
+                <v-list density="compact" class="bg-transparent text-left">
                   <v-list-item prepend-icon="mdi-video-plus" class="mb-2">
                     <v-list-item-title>{{
                       $t('UserTestView.ModeratorWelcomeStep.instruction1')
@@ -91,22 +251,67 @@
 import ShowInfo from '@/shared/components/ShowInfo.vue'
 import { onMounted, onBeforeUnmount, nextTick, ref } from 'vue'
 import { animateModeratorWelcomeText } from '@/shared/utils/animations'
+
 defineProps({
   stepperValue: { type: Number, required: true },
+  staffMembers: { type: Array, default: () => [] },
+  participantMembers: { type: Array, default: () => [] },
 })
 
 defineEmits(['start'])
+
 const welcomeContent = ref(null)
+const webcamVideoRef = ref(null)
+const isCameraOn = ref(true)
+const isMicOn = ref(true)
+let mediaStream = null
 let cleanupSplitAnimation = () => {}
+
+async function initWebcam() {
+  try {
+    mediaStream = await navigator.mediaDevices.getUserMedia({
+      video: true,
+      audio: true,
+    })
+    if (webcamVideoRef.value) {
+      webcamVideoRef.value.srcObject = mediaStream
+    }
+  } catch (err) {
+    console.warn('Webcam permission not granted or device unavailable:', err)
+    isCameraOn.value = false
+  }
+}
+
+function toggleCamera() {
+  isCameraOn.value = !isCameraOn.value
+  if (mediaStream) {
+    mediaStream.getVideoTracks().forEach((track) => {
+      track.enabled = isCameraOn.value
+    })
+  }
+}
+
+function toggleMic() {
+  isMicOn.value = !isMicOn.value
+  if (mediaStream) {
+    mediaStream.getAudioTracks().forEach((track) => {
+      track.enabled = isMicOn.value
+    })
+  }
+}
 
 onMounted(async () => {
   await nextTick()
+  initWebcam()
   cleanupSplitAnimation = await animateModeratorWelcomeText(
     welcomeContent.value?.querySelectorAll('.split'),
   )
 })
 
 onBeforeUnmount(() => {
+  if (mediaStream) {
+    mediaStream.getTracks().forEach((track) => track.stop())
+  }
   if (typeof cleanupSplitAnimation === 'function') {
     cleanupSplitAnimation()
     cleanupSplitAnimation = () => {}
@@ -138,10 +343,20 @@ onBeforeUnmount(() => {
   border-left: 4px solid rgb(var(--v-theme-primary));
 }
 
-.test-overview {
-  background: rgba(var(--v-theme-surface), 0.5);
-  border-radius: 12px;
-  padding: 24px;
+.webcam-preview-container {
+  height: 200px;
+  width: 100%;
+}
+
+.webcam-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.collaborators-list {
+  max-height: 200px;
 }
 
 .action-buttons {

--- a/src/ux/UserTest/views/ModeratedTestView.vue
+++ b/src/ux/UserTest/views/ModeratedTestView.vue
@@ -406,6 +406,8 @@
             <ModeratorWelcomeStep
               v-if="globalIndex === 0 && isModerator"
               :stepper-value="stepperValue"
+              :staff-members="sessionStaffMembers"
+              :participant-members="sessionParticipantsMembers"
               @start="handleWelcomeStart"
             />
             <WelcomeStep
@@ -1421,7 +1423,14 @@ const startTest = async () => {
   const callRef = dbRef(database, `calls/${roomId.value}`)
 
   if (staffUser) {
-    displayVideoCallComponent.value = true
+    if (isModerator.value) {
+      // Moderator sees the welcome step first (globalIndex = 0)
+      globalIndex.value = 0
+      displayVideoCallComponent.value = false
+    } else {
+      // Observers go directly to the video call
+      displayVideoCallComponent.value = true
+    }
     start.value = false
   }
 


### PR DESCRIPTION
## Summary
Closes #2276

When a facilitator opens a moderated user-test, the UX is now improved with a dedicated **Moderator Welcome Screen** shown before the video call starts.

## Changes

### ModeratorWelcomeStep.vue
- ✅ **Added webcam preview** with camera/mic toggle controls so the facilitator can check their setup before starting
- ✅ **Added collaborators-in-call counter** showing the number of active staff members
- ✅ **Added live collaborator list** — when another facilitator/observer enters the session, they appear in real-time with avatar, name, role, and status badge

### ModeratedTestView.vue
- ✅ **Removed steps toolbar** for the facilitator view (stepper is hidden when `isModerator` is true)
- ✅ **Show welcome step first** — moderators now see the ModeratorWelcomeStep before jumping to the video call. Clicking "Start Moderated Session" proceeds to the video call.
- Passed `staffMembers` and `participantMembers` props to ModeratorWelcomeStep

### firestore.rules
- Added `sessions` subcollection write rule inside `tests/{studyId}` to allow authenticated session creation

## Checklist from Issue
- [x] Remove steps toolbar
- [x] Add webcam
- [x] Add number of collaborators waiting to start the test
- [x] If another facilitators enter into the videocall they must appear there

## Demo

https://github.com/user-attachments/assets/c8342f29-08cf-409e-8e78-304e9476aab1


| Before | After |
|--------|-------|
| Facilitator went directly to video call | Facilitator sees Welcome Screen with webcam preview + collaborator list first |
