### PR TITLE
fix: resolve password label overlap on sign-in

### DIFF
--- a/src/features/auth/views/SignInView.vue
+++ b/src/features/auth/views/SignInView.vue
@@ -38,7 +38,6 @@
             :rules="[rules.required]"
             :label="$t('auth.SIGNIN.password')"
             :type="showPassword ? 'text' : 'password'"
-            placeholder="••••••••"
             prepend-inner-icon="mdi-lock-outline"
             :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
             variant="outlined"


### PR DESCRIPTION
Fixes #2321
<img width="1130" height="827" alt="image" src="https://github.com/user-attachments/assets/8b9140c5-5205-4bc3-9747-969dec2b86b2" />
