### PR TITLE
fix(utils): harden formatInitials against multi-space names and add formatUtils unit tests

### DIFF
--- a/src/shared/utils/formatUtils.js
+++ b/src/shared/utils/formatUtils.js
@@ -10,16 +10,17 @@
  * @returns {string} Formatted bytes string (e.g., "1.5 MB")
  */
 export const formatBytes = (bytes, decimals = 2) => {
-  if (bytes === 0) return '0 B'
-  if (!bytes || bytes < 0) return '0 B'
+  const numBytes = Number(bytes)
+  if (numBytes === 0) return '0 B'
+  if (!Number.isFinite(numBytes) || numBytes < 0) return '0 B'
 
   const k = 1024
   const dm = decimals < 0 ? 0 : decimals
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
 
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  const i = Math.floor(Math.log(numBytes) / Math.log(k))
 
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
+  return parseFloat((numBytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
 }
 
 /**
@@ -28,19 +29,22 @@ export const formatBytes = (bytes, decimals = 2) => {
  * @returns {string} Formatted initials (e.g., "JD")
  */
 export const formatInitials = (emailOrName) => {
-  if (!emailOrName) return '?'
+  if (!emailOrName || typeof emailOrName !== 'string') return '?'
+
+  const trimmed = emailOrName.trim()
+  if (!trimmed) return '?'
 
   // If it's an email, extract the part before @
-  if (emailOrName.includes('@')) {
-    const username = emailOrName.split('@')[0]
+  if (trimmed.includes('@')) {
+    const username = trimmed.split('@')[0]
     return username.slice(0, 2).toUpperCase()
   }
 
   // If it's a name, get first letter of each word
-  const words = emailOrName.trim().split(' ')
+  const words = trimmed.split(/\s+/).filter(Boolean)
   if (words.length >= 2) {
     return (words[0][0] + words[1][0]).toUpperCase()
   }
 
-  return emailOrName.slice(0, 2).toUpperCase()
+  return trimmed.slice(0, 2).toUpperCase()
 }

--- a/tests/unit/formatUtils.spec.js
+++ b/tests/unit/formatUtils.spec.js
@@ -1,0 +1,89 @@
+import { formatInitials, formatBytes } from '@/shared/utils/formatUtils'
+
+describe('formatInitials', () => {
+  it('extracts initials from a standard email', () => {
+    expect(formatInitials('john@example.com')).toBe('JO')
+  })
+
+  it('extracts initials from a two-word name', () => {
+    expect(formatInitials('John Doe')).toBe('JD')
+  })
+
+  it('handles names with multiple consecutive spaces', () => {
+    expect(formatInitials('John  Doe')).toBe('JD')
+  })
+
+  it('handles names with many consecutive spaces', () => {
+    expect(formatInitials('Jane   Smith')).toBe('JS')
+  })
+
+  it('returns fallback for whitespace-only input', () => {
+    expect(formatInitials('   ')).toBe('?')
+  })
+
+  it('returns fallback for null', () => {
+    expect(formatInitials(null)).toBe('?')
+  })
+
+  it('returns fallback for undefined', () => {
+    expect(formatInitials(undefined)).toBe('?')
+  })
+
+  it('returns fallback for empty string', () => {
+    expect(formatInitials('')).toBe('?')
+  })
+
+  it('returns first two characters for a single word', () => {
+    expect(formatInitials('John')).toBe('JO')
+  })
+
+  it('returns fallback for non-string input', () => {
+    expect(formatInitials(12345)).toBe('?')
+  })
+
+  it('handles a name with leading and trailing spaces', () => {
+    expect(formatInitials('  Alice Bob  ')).toBe('AB')
+  })
+})
+
+describe('formatBytes', () => {
+  it('returns "0 B" for zero bytes', () => {
+    expect(formatBytes(0)).toBe('0 B')
+  })
+
+  it('formats bytes correctly', () => {
+    expect(formatBytes(500)).toBe('500 B')
+  })
+
+  it('formats kilobytes correctly', () => {
+    expect(formatBytes(1024)).toBe('1 KB')
+  })
+
+  it('formats megabytes correctly', () => {
+    expect(formatBytes(1572864)).toBe('1.5 MB')
+  })
+
+  it('returns "0 B" for non-numeric string input', () => {
+    expect(formatBytes('abc')).toBe('0 B')
+  })
+
+  it('returns "0 B" for NaN', () => {
+    expect(formatBytes(NaN)).toBe('0 B')
+  })
+
+  it('returns "0 B" for negative values', () => {
+    expect(formatBytes(-100)).toBe('0 B')
+  })
+
+  it('returns "0 B" for null', () => {
+    expect(formatBytes(null)).toBe('0 B')
+  })
+
+  it('coerces numeric strings correctly', () => {
+    expect(formatBytes('1024')).toBe('1 KB')
+  })
+
+  it('respects custom decimal places', () => {
+    expect(formatBytes(1536, 1)).toBe('1.5 KB')
+  })
+})


### PR DESCRIPTION
## Description
This PR resolves edge-case handling bugs in `src/shared/utils/formatUtils.js` and adds a dedicated unit test suite for the utility module.

### Issues Resolved:
1. **Multi-Space Initials Corrupting to `JUNDEFINED`**:
   - `formatInitials` split names using a single space delimiter `.split(' ')`. When names contained consecutive spaces (e.g. `"John  Doe"`), the resulting array contained empty strings `['John', '', 'Doe']`, causing `words[1][0]` to resolve to `undefined` and producing `"JUNDEFINED"`.
   - **Fix**: Replaced `.split(' ')` with regex `.split(/\s+/).filter(Boolean)` to correctly handle arbitrary whitespace runs.
2. **Whitespace-Only Fallback**:
   - Whitespace-only strings (e.g. `"   "`) bypassed nullish checks and returned blank spaces `"  "` instead of the fallback `"?"`.
   - **Fix**: Added empty trimmed guard `if (!trimmed) return '?'` and non-string type checking.
3. **Invalid Bytes Outputting `NaN undefined`**:
   - Passing invalid or non-numeric strings into `formatBytes` computed `Math.log()` on `NaN`, resulting in `"NaN undefined"`.
   - **Fix**: Added `Number.isFinite()` guard returning `'0 B'` for non-finite values.
4. **Added Unit Test Coverage**:
   - Created `tests/unit/formatUtils.spec.js` covering  normal and edge-case scenarios .

---

## Related Issue
Closes #2332 

---

## Verification & Screenshots 📸

### Automated Tests Passing:
- **33/33 Unit Test Suites Passed (272/272 Tests)**
- **21/21 New Unit Tests in `formatUtils.spec.js` Passed**
- **ESLint & Prettier passed with 0 errors**
- **Production build compiled successfully**

<img width="732" height="695" alt="Screenshot 2026-08-29 122842" src="https://github.com/user-attachments/assets/09807fcc-07a1-4fb1-92df-7c2d4a6a81be" />


---

## Types of Changes
- [x] Bug fix 
- [x] New unit test coverage
