### PR TITLE
fix: robots.txt returning HTML instead of valid directives

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
Fixes #2026

## Problem
`/robots.txt` was returning the full `index.html` app shell instead of
plain-text robots directives. Firebase Hosting's catch-all SPA rewrite
(`"source": "**" -> "/index.html"` in firebase.json) was intercepting
the request because no static robots.txt file existed in the repo.

## Fix
Added `public/robots.txt`. Vue CLI copies everything in `public/`
verbatim into `dist/` on build, and Firebase Hosting always serves a
matching static file before falling back to the rewrite rule — so this
resolves the issue on all four hosting sites (dev, stage, develop,
prod) with no config changes needed.

## Testing
- Ran `npm run build` and confirmed `dist/robots.txt` is present with
  the expected content.
- No changes to routing, config, or app code — isolated, low-risk fix.