### PR TITLE
fix(auth): scope "Remember me" opt-out to the browser session

### DIFF
--- a/src/features/auth/controllers/AuthController.js
+++ b/src/features/auth/controllers/AuthController.js
@@ -12,6 +12,13 @@ import {
 import { auth } from '@/app/plugins/firebase'
 import axios from 'axios'
 import EmailController from '@/shared/controllers/EmailController'
+import {
+  canTrackBrowserSession,
+  endBrowserSession,
+  isBrowserSessionAlive,
+  isSessionScoped,
+  startBrowserSession,
+} from '@/shared/utils/authSessionPersistence'
 
 /**
  * Controller for authentication operations
@@ -28,30 +35,78 @@ export default class AuthController {
   }
 
   /**
+   * Stores the auth state where the lifetime the user asked for can be honoured.
+   *
+   * "Remember me" keeps the sign-in until it is revoked. Without it the sign-in
+   * is still shared across the tabs of the browser, and a session cookie is
+   * what ends it once the browser closes. Browsers that refuse that cookie
+   * leave us unable to tell a second tab apart from a restarted browser, so
+   * there we keep the tab-scoped persistence rather than signing the user in
+   * for longer than they asked for.
+   * @param {boolean} rememberMe - Whether to keep the user signed in
+   * @returns {Promise<boolean>} - Whether the sign-in is scoped to the session
+   */
+  async applyPersistence(rememberMe) {
+    const sessionScoped = !rememberMe && canTrackBrowserSession()
+
+    await setPersistence(
+      auth,
+      rememberMe || sessionScoped
+        ? browserLocalPersistence
+        : browserSessionPersistence,
+    )
+
+    return sessionScoped
+  }
+
+  /**
+   * Records how long a completed sign-in should last.
+   *
+   * Only a successful sign-in may move these markers, so that a failed attempt
+   * cannot shorten or extend the session the user already has.
+   * @param {boolean} sessionScoped - Whether the sign-in ends with the browser
+   * @returns {Promise}
+   */
+  async scopeSignIn(sessionScoped) {
+    if (!sessionScoped) return endBrowserSession()
+
+    // Cookies answered the probe before sign-in, so this only fails if access
+    // was withdrawn in between. Leaving the sign-in with nothing to expire it
+    // would outlast what the user asked for, so drop back to the tab.
+    if (!startBrowserSession()) {
+      await setPersistence(auth, browserSessionPersistence)
+    }
+  }
+
+  /**
    * Signs in a user with email and password
    * @param {string} email - User email
    * @param {string} password - User password
+   * @param {boolean} rememberMe - Whether to keep the user signed in
    * @returns {Promise} - Firebase auth user credential
    */
   async signIn(email, password, rememberMe) {
-    await setPersistence(
-      auth,
-      rememberMe ? browserLocalPersistence : browserSessionPersistence,
-    )
-    return signInWithEmailAndPassword(auth, email, password)
+    const sessionScoped = await this.applyPersistence(rememberMe)
+    const credential = await signInWithEmailAndPassword(auth, email, password)
+
+    await this.scopeSignIn(sessionScoped)
+
+    return credential
   }
 
   /**
    * Signs in a user with Google
+   * @param {boolean} rememberMe - Whether to keep the user signed in
    * @returns {Promise} - Firebase auth user credential
    */
   async signInWithGoogle(rememberMe) {
-    await setPersistence(
-      auth,
-      rememberMe ? browserLocalPersistence : browserSessionPersistence,
-    )
+    const sessionScoped = await this.applyPersistence(rememberMe)
     const provider = new GoogleAuthProvider()
-    return signInWithPopup(auth, provider)
+    const credential = await signInWithPopup(auth, provider)
+
+    await this.scopeSignIn(sessionScoped)
+
+    return credential
   }
 
   /**
@@ -67,7 +122,26 @@ export default class AuthController {
    * @returns {Promise} - Firebase auth signOut promise
    */
   async signOut() {
+    endBrowserSession()
     return signOut(auth)
+  }
+
+  /**
+   * Drops a sign-in made without "Remember me" once its browser session is over.
+   *
+   * The stored auth state outlives the browser, so the session cookie written
+   * at sign-in is what marks the session as still running. Once the browser
+   * deletes it, the sign-in has to go with it.
+   * @param {Object|null} user - User reported by the Firebase observer
+   * @returns {Promise<Object|null>} - The user, or null once signed out
+   */
+  async enforceBrowserSession(user) {
+    if (!user || !isSessionScoped() || isBrowserSessionAlive()) return user
+
+    await signOut(auth)
+    endBrowserSession()
+
+    return null
   }
 
   /**
@@ -78,9 +152,13 @@ export default class AuthController {
     return new Promise((resolve, reject) => {
       const unsubscribe = onAuthStateChanged(
         auth,
-        (user) => {
+        async (user) => {
           unsubscribe()
-          resolve(user)
+          try {
+            resolve(await this.enforceBrowserSession(user))
+          } catch (error) {
+            reject(error)
+          }
         },
         (error) => {
           unsubscribe()

--- a/src/shared/utils/authSessionPersistence.js
+++ b/src/shared/utils/authSessionPersistence.js
@@ -1,0 +1,137 @@
+/**
+ * Browser-session helpers backing the "Remember me" option.
+ *
+ * Firebase Auth ships two web persistences that survive a reload:
+ * `browserLocalPersistence` (localStorage — shared by every tab, and kept when
+ * the browser restarts) and `browserSessionPersistence` (sessionStorage —
+ * private to the tab that signed in). Neither one matches what an unchecked
+ * "Remember me" is expected to do: stay signed in across the tabs of the same
+ * browser, then sign out once that browser is closed.
+ *
+ * These helpers rebuild that behaviour on the primitive the convention is built
+ * on — a cookie with no expiry date. A session-scoped sign-in keeps its auth
+ * state in localStorage so every tab shares it, and drops a session cookie
+ * alongside it. Browsers delete that cookie when they shut down, so its absence
+ * on the next start is what tells us the browser session ended and the sign-in
+ * has to be dropped.
+ */
+
+const SESSION_COOKIE = 'ruxailab_browser_session'
+const PROBE_COOKIE = 'ruxailab_browser_session_probe'
+const SESSION_SCOPED_KEY = 'ruxailab.auth.session-scoped'
+const PROBE_KEY = 'ruxailab.auth.session-probe'
+
+const cookieAttributes = () => {
+  const attributes = ['path=/', 'SameSite=Lax']
+
+  if (window.location?.protocol === 'https:') attributes.push('Secure')
+
+  return attributes.join('; ')
+}
+
+const hasCookie = (name) =>
+  document.cookie.split('; ').some((cookie) => cookie.startsWith(`${name}=`))
+
+const setCookie = (name) => {
+  document.cookie = `${name}=1; ${cookieAttributes()}`
+}
+
+const deleteCookie = (name) => {
+  document.cookie = `${name}=; ${cookieAttributes()}; max-age=0`
+}
+
+/**
+ * Whether the browser still holds the session cookie written at sign-in.
+ * @returns {boolean}
+ */
+export const isBrowserSessionAlive = () => {
+  try {
+    return hasCookie(SESSION_COOKIE)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Whether the stored sign-in was made without "Remember me" and therefore
+ * lasts only as long as the browser session.
+ * @returns {boolean}
+ */
+export const isSessionScoped = () => {
+  try {
+    return localStorage.getItem(SESSION_SCOPED_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Whether this browser lets us tell a second tab apart from a restarted
+ * browser, which takes both a cookie the browser drops on exit and storage to
+ * remember that the sign-in depends on it.
+ * @returns {boolean}
+ */
+export const canTrackBrowserSession = () => {
+  try {
+    setCookie(PROBE_COOKIE)
+
+    if (!hasCookie(PROBE_COOKIE)) return false
+
+    deleteCookie(PROBE_COOKIE)
+  } catch {
+    return false
+  }
+
+  try {
+    localStorage.setItem(PROBE_KEY, 'true')
+    localStorage.removeItem(PROBE_KEY)
+  } catch {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Clears both markers, leaving the sign-in unscoped.
+ * @returns {void}
+ */
+export const endBrowserSession = () => {
+  try {
+    deleteCookie(SESSION_COOKIE)
+  } catch {
+    // Cookies are unavailable, so there is nothing to clear.
+  }
+
+  try {
+    localStorage.removeItem(SESSION_SCOPED_KEY)
+  } catch {
+    // Storage is unavailable, so there is nothing to clear.
+  }
+}
+
+/**
+ * Marks the sign-in as lasting only for the current browser session.
+ *
+ * Both markers are needed to expire the sign-in later, so the session only
+ * counts as started once the cookie is actually accepted by the browser.
+ * @returns {boolean} - Whether the browser session could be tracked
+ */
+export const startBrowserSession = () => {
+  try {
+    setCookie(SESSION_COOKIE)
+  } catch {
+    return false
+  }
+
+  if (!isBrowserSessionAlive()) return false
+
+  try {
+    localStorage.setItem(SESSION_SCOPED_KEY, 'true')
+  } catch {
+    endBrowserSession()
+    return false
+  }
+
+  return true
+}

--- a/tests/unit/AuthController.spec.js
+++ b/tests/unit/AuthController.spec.js
@@ -41,12 +41,24 @@ jest.mock('axios', () => ({
   post: jest.fn(),
 }))
 
+const SESSION_COOKIE = 'ruxailab_browser_session'
+
+const endBrowserSession = () => {
+  document.cookie = `${SESSION_COOKIE}=; path=/; max-age=0`
+  localStorage.clear()
+}
+
 describe('AuthController', () => {
   let authController
 
   beforeEach(() => {
     jest.clearAllMocks()
+    endBrowserSession()
     authController = new AuthController()
+  })
+
+  afterEach(() => {
+    endBrowserSession()
   })
 
   describe('signUp', () => {
@@ -96,13 +108,71 @@ describe('AuthController', () => {
       )
     })
 
-    it('should set session persistence when rememberMe is false', async () => {
+    it('should not scope the sign-in to a browser session when rememberMe is true', async () => {
+      setPersistence.mockResolvedValue()
+      signInWithEmailAndPassword.mockResolvedValue({ user: {} })
+
+      await authController.signIn('test@example.com', 'password123', true)
+
+      expect(document.cookie).not.toContain(SESSION_COOKIE)
+    })
+
+    it('should share the sign-in across tabs when rememberMe is false', async () => {
+      setPersistence.mockResolvedValue()
+      signInWithEmailAndPassword.mockResolvedValue({ user: {} })
+
+      await authController.signIn('test@example.com', 'password123', false)
+
+      // Local persistence is what every tab of the browser can read; the
+      // session cookie is what expires it once the browser is closed.
+      expect(setPersistence).toHaveBeenCalledWith(expect.anything(), 'local')
+      expect(document.cookie).toContain(`${SESSION_COOKIE}=1`)
+    })
+
+    it('should fall back to session persistence when cookies are blocked', async () => {
+      const cookie = jest
+        .spyOn(document, 'cookie', 'set')
+        .mockImplementation(() => {})
+
       setPersistence.mockResolvedValue()
       signInWithEmailAndPassword.mockResolvedValue({ user: {} })
 
       await authController.signIn('test@example.com', 'password123', false)
 
       expect(setPersistence).toHaveBeenCalledWith(expect.anything(), 'session')
+
+      cookie.mockRestore()
+    })
+
+    it('should fall back to session persistence when the marker cannot be stored', async () => {
+      // Cookies answer the probe, but writing the marker afterwards fails, so
+      // the sign-in would have nothing left to expire it.
+      const realSetItem = Storage.prototype.setItem
+      const setItem = jest
+        .spyOn(Storage.prototype, 'setItem')
+        .mockImplementation(function (key, value) {
+          if (key === 'ruxailab.auth.session-scoped') {
+            throw new Error('storage disabled')
+          }
+          return realSetItem.call(this, key, value)
+        })
+
+      setPersistence.mockResolvedValue()
+      signInWithEmailAndPassword.mockResolvedValue({ user: {} })
+
+      await authController.signIn('test@example.com', 'password123', false)
+
+      expect(setPersistence).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        'local',
+      )
+      expect(setPersistence).toHaveBeenLastCalledWith(
+        expect.anything(),
+        'session',
+      )
+
+      setItem.mockRestore()
     })
 
     it('should throw error when signIn fails', async () => {
@@ -114,6 +184,23 @@ describe('AuthController', () => {
       await expect(
         authController.signIn('test@example.com', 'wrong', false),
       ).rejects.toThrow(mockError)
+    })
+
+    it('should not scope an existing sign-in when the attempt fails', async () => {
+      setPersistence.mockResolvedValue()
+      signInWithEmailAndPassword.mockResolvedValue({ user: {} })
+
+      await authController.signIn('test@example.com', 'password123', true)
+
+      signInWithEmailAndPassword.mockRejectedValue(new Error('Invalid'))
+
+      await expect(
+        authController.signIn('test@example.com', 'wrong', false),
+      ).rejects.toThrow('Invalid')
+
+      // The remembered sign-in must not start expiring with the browser just
+      // because somebody mistyped a password on the sign-in page.
+      expect(document.cookie).not.toContain(SESSION_COOKIE)
     })
   })
 
@@ -132,13 +219,14 @@ describe('AuthController', () => {
       expect(result).toEqual(mockCredential)
     })
 
-    it('should set session persistence when rememberMe is false', async () => {
+    it('should share the sign-in across tabs when rememberMe is false', async () => {
       setPersistence.mockResolvedValue()
       signInWithPopup.mockResolvedValue({ user: {} })
 
       await authController.signInWithGoogle(false)
 
-      expect(setPersistence).toHaveBeenCalledWith(expect.anything(), 'session')
+      expect(setPersistence).toHaveBeenCalledWith(expect.anything(), 'local')
+      expect(document.cookie).toContain(`${SESSION_COOKIE}=1`)
     })
 
     it('should throw error when Google sign-in fails', async () => {
@@ -169,6 +257,17 @@ describe('AuthController', () => {
 
       await expect(authController.signOut()).rejects.toThrow(mockError)
     })
+
+    it('should clear the browser session markers', async () => {
+      setPersistence.mockResolvedValue()
+      signInWithEmailAndPassword.mockResolvedValue({ user: {} })
+      signOut.mockResolvedValue()
+
+      await authController.signIn('test@example.com', 'password123', false)
+      await authController.signOut()
+
+      expect(document.cookie).not.toContain(SESSION_COOKIE)
+    })
   })
 
   describe('getCurrentUser', () => {
@@ -193,23 +292,76 @@ describe('AuthController', () => {
   })
 
   describe('autoSignIn', () => {
-    it('should call onAuthStateChanged', async () => {
-      const mockUser = {
-        uid: 'auto-user',
-        email: 'auto@example.com',
-      }
+    const mockUser = {
+      uid: 'auto-user',
+      email: 'auto@example.com',
+    }
 
+    const observeUser = (user) => {
       onAuthStateChanged.mockImplementation((auth, callback) => {
         const unsubscribe = jest.fn()
 
-        setTimeout(() => callback(mockUser), 0)
+        setTimeout(() => callback(user), 0)
 
         return unsubscribe
       })
+    }
+
+    const signInWithoutRememberMe = async () => {
+      setPersistence.mockResolvedValue()
+      signInWithEmailAndPassword.mockResolvedValue({ user: mockUser })
+
+      await authController.signIn('test@example.com', 'password123', false)
+    }
+
+    it('should call onAuthStateChanged', async () => {
+      observeUser(mockUser)
 
       await authController.autoSignIn()
 
       expect(onAuthStateChanged).toHaveBeenCalled()
+    })
+
+    it('should restore a session-scoped sign-in while the browser session lasts', async () => {
+      await signInWithoutRememberMe()
+      observeUser(mockUser)
+
+      // A second tab of the same browser still has the session cookie.
+      await expect(authController.autoSignIn()).resolves.toEqual(mockUser)
+      expect(signOut).not.toHaveBeenCalled()
+    })
+
+    it('should sign out a session-scoped user once the browser session ended', async () => {
+      await signInWithoutRememberMe()
+
+      // Closing the browser is what deletes a cookie with no expiry date,
+      // while the stored auth state survives it.
+      document.cookie = `${SESSION_COOKIE}=; path=/; max-age=0`
+
+      observeUser(mockUser)
+      signOut.mockResolvedValue()
+
+      await expect(authController.autoSignIn()).resolves.toBeNull()
+      expect(signOut).toHaveBeenCalled()
+    })
+
+    it('should keep a remembered user signed in without a session cookie', async () => {
+      setPersistence.mockResolvedValue()
+      signInWithEmailAndPassword.mockResolvedValue({ user: mockUser })
+
+      await authController.signIn('test@example.com', 'password123', true)
+
+      observeUser(mockUser)
+
+      await expect(authController.autoSignIn()).resolves.toEqual(mockUser)
+      expect(signOut).not.toHaveBeenCalled()
+    })
+
+    it('should resolve null when nobody is signed in', async () => {
+      observeUser(null)
+
+      await expect(authController.autoSignIn()).resolves.toBeNull()
+      expect(signOut).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/unit/authSessionPersistence.spec.js
+++ b/tests/unit/authSessionPersistence.spec.js
@@ -1,0 +1,131 @@
+import {
+  canTrackBrowserSession,
+  endBrowserSession,
+  isBrowserSessionAlive,
+  isSessionScoped,
+  startBrowserSession,
+} from '@/shared/utils/authSessionPersistence'
+
+describe('authSessionPersistence', () => {
+  beforeEach(() => {
+    endBrowserSession()
+    localStorage.clear()
+  })
+
+  it('reports no browser session before one is started', () => {
+    expect(isBrowserSessionAlive()).toBe(false)
+    expect(isSessionScoped()).toBe(false)
+  })
+
+  it('marks the sign-in as session scoped and cookies the browser session', () => {
+    expect(startBrowserSession()).toBe(true)
+
+    expect(document.cookie).toContain('ruxailab_browser_session=1')
+    expect(isBrowserSessionAlive()).toBe(true)
+    expect(isSessionScoped()).toBe(true)
+  })
+
+  it('keeps the session scoped for a second tab of the same browser', () => {
+    startBrowserSession()
+
+    // A new tab reads the same cookie jar and the same localStorage, so the
+    // sign-in stays valid instead of being asked for again.
+    expect(isSessionScoped()).toBe(true)
+    expect(isBrowserSessionAlive()).toBe(true)
+  })
+
+  it('treats a dropped cookie as the end of the browser session', () => {
+    startBrowserSession()
+
+    // Closing the browser is what deletes a cookie with no expiry date.
+    document.cookie = 'ruxailab_browser_session=; path=/; max-age=0'
+
+    expect(isBrowserSessionAlive()).toBe(false)
+    expect(isSessionScoped()).toBe(true)
+  })
+
+  it('clears both markers when the session ends', () => {
+    startBrowserSession()
+
+    endBrowserSession()
+
+    expect(isBrowserSessionAlive()).toBe(false)
+    expect(isSessionScoped()).toBe(false)
+  })
+
+  it('reports failure and leaves no marker when cookies are blocked', () => {
+    const cookie = jest
+      .spyOn(document, 'cookie', 'set')
+      .mockImplementation(() => {})
+
+    expect(startBrowserSession()).toBe(false)
+    expect(isSessionScoped()).toBe(false)
+
+    cookie.mockRestore()
+  })
+
+  it('reports failure and drops the cookie when storage is blocked', () => {
+    const setItem = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('storage disabled')
+      })
+
+    expect(startBrowserSession()).toBe(false)
+
+    setItem.mockRestore()
+
+    expect(isBrowserSessionAlive()).toBe(false)
+    expect(isSessionScoped()).toBe(false)
+  })
+
+  it('can track the browser session when cookies and storage work', () => {
+    expect(canTrackBrowserSession()).toBe(true)
+
+    // Probing must not leave anything behind or mark the sign-in itself.
+    expect(document.cookie).not.toContain('probe')
+    expect(isSessionScoped()).toBe(false)
+  })
+
+  it('keeps an existing session marker while probing', () => {
+    startBrowserSession()
+
+    expect(canTrackBrowserSession()).toBe(true)
+    expect(isSessionScoped()).toBe(true)
+    expect(isBrowserSessionAlive()).toBe(true)
+  })
+
+  it('cannot track the browser session when cookies are blocked', () => {
+    const cookie = jest
+      .spyOn(document, 'cookie', 'set')
+      .mockImplementation(() => {})
+
+    expect(canTrackBrowserSession()).toBe(false)
+
+    cookie.mockRestore()
+  })
+
+  it('cannot track the browser session when storage is blocked', () => {
+    const setItem = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('storage disabled')
+      })
+
+    expect(canTrackBrowserSession()).toBe(false)
+
+    setItem.mockRestore()
+  })
+
+  it('reports no session scope when storage cannot be read', () => {
+    const getItem = jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new Error('storage disabled')
+      })
+
+    expect(isSessionScoped()).toBe(false)
+
+    getItem.mockRestore()
+  })
+})


### PR DESCRIPTION
## What

Makes an unchecked "Remember me" behave the way it does on other platforms: the sign-in is shared across the tabs of the same browser, and it ends when the browser is closed.

Closes #2337

## Demo

Both sides sign in with **"Remember me" unchecked**, then open the same URL in a second tab of the same browser. Left is `develop`, right is this PR.

![Remember me: second tab, before and after](https://raw.githubusercontent.com/namanjain24-sudo/RUXAILAB/media/issue-2337/remember-me-before-after.png)

Full clip: [remember-me-before-after.mp4](https://raw.githubusercontent.com/namanjain24-sudo/RUXAILAB/media/issue-2337/remember-me-before-after.mp4)

Recorded with Playwright against the app running on the Firebase emulator suite.

## Before / after

| | Remember me checked | Unchecked (before) | Unchecked (after) |
| --- | --- | --- | --- |
| Second tab, same browser | signed in | **asked to sign in again** | signed in |
| Reopen after closing browser | signed in | signed out | signed out |

The "asked to sign in again" cell is what broke opening a study link in a new tab.

## Why it needs more than swapping a constant

The Firebase Auth web SDK has three persistences and none of them is "shared across tabs, cleared on browser close":

| Persistence | Shared across tabs | Survives browser close |
| --- | --- | --- |
| `browserLocalPersistence` (localStorage) | yes | yes |
| `browserSessionPersistence` (sessionStorage) | **no** | no |
| `inMemoryPersistence` | no | no |

So this rebuilds the convention on the primitive the convention is built on — a cookie with no expiry date, which browsers share across tabs and delete on shutdown.

- Sign-in without "Remember me" now uses `browserLocalPersistence` (every tab can read it) **and** writes a session cookie.
- On app start, `autoSignIn` treats "auth state present, session cookie gone" as "the browser was closed", and signs the user out.
- Sign-in with "Remember me" is unchanged and clears that marker.

No backend, Firestore rules, or schema change.

## Edge cases handled

- **Cookies blocked** — we can no longer tell a second tab apart from a restarted browser, so it falls back to the existing `browserSessionPersistence`. The failure mode stays "signed out too early" rather than "signed in longer than asked".
- **Storage blocked** (e.g. Safari private mode) — every storage and cookie access is guarded, and a failed marker write falls back the same way.
- **Failed sign-in attempt** — markers are only moved after a *successful* sign-in, so mistyping a password on the sign-in page cannot silently convert an existing remembered session into a session-scoped one.
- **Explicit sign-out** — clears both markers. Every sign-out path in the app already routes through `AuthController.signOut`, including account deletion.

One behaviour worth calling out for review: if the browser is set to restore the previous session ("continue where you left off"), it restores session cookies too, so the user stays signed in. That is how any session-cookie site behaves, so I have treated it as correct rather than worked around it.

## Changes

| File | Change |
| --- | --- |
| `src/shared/utils/authSessionPersistence.js` | New — session cookie + marker helpers, all guarded |
| `src/features/auth/controllers/AuthController.js` | `applyPersistence` / `scopeSignIn` / `enforceBrowserSession`; `signOut` clears markers |
| `tests/unit/authSessionPersistence.spec.js` | New — 12 tests for the helpers |
| `tests/unit/AuthController.spec.js` | Updated for the new behaviour, plus cross-tab, browser-close and fallback cases |

## Testing

- `npm test` — 33 suites, 278 tests passing
- `npm run lint` and Prettier clean on the changed files
- The two updated assertions in `AuthController.spec.js` are the intended behaviour change: unchecked "Remember me" now resolves to local persistence plus a session cookie, instead of session persistence

### Verified in a real browser

Driven with Playwright against the app running on the Firebase emulator suite, using real tabs and a real browser restart (localStorage preserved, cookies with no expiry dropped). The same script was run against the code **before** and **after** the change:

| Check | Before | After |
| --- | --- | --- |
| Second tab of the same browser stays signed in | ❌ redirected to `/signin` | ✅ loads `/admin` |
| Session cookie written, with no expiry | ❌ absent | ✅ present, `expires=-1` |
| Closing the browser ends a session-scoped sign-in | ✅ signed out | ✅ signed out |
| "Remember me" writes no session cookie | ✅ none | ✅ none |
| "Remember me" survives a browser restart | ✅ stays signed in | ✅ stays signed in |

The first row is the behaviour from the video in the issue, reproduced before the change and fixed after it. The last two rows confirm the "Remember me" path is untouched.
