### PR TITLE
Feat/transcription sentiment chart

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -114,6 +114,10 @@ service cloud.firestore {
         );
         allow write: if false;
       }
+
+      match /participants/{participantId} {
+        allow read: if signedIn();
+      }
     }
 
     match /answers/{answerId} {

--- a/src/ai/transcriptions/transcriptionAnalyticsUtils.js
+++ b/src/ai/transcriptions/transcriptionAnalyticsUtils.js
@@ -13,6 +13,7 @@ export const toTaskAnalyticsKey = (taskId) => `task${String(taskId)}`
  *   speakingTime: number,
  *   speechRate: number,
  *   keywords: Record<string, number>,
+ *   sentiment: { Positive: number, Neutral: number, Negative: number },
  * }}
  */
 export const emptyMetricsBucket = () => ({
@@ -21,6 +22,7 @@ export const emptyMetricsBucket = () => ({
   speakingTime: 0,
   speechRate: 0,
   keywords: {},
+  sentiment: { Positive: 0, Neutral: 0, Negative: 0 },
 })
 
 /**
@@ -62,6 +64,21 @@ export const mergeKeywordMaps = (maps) => {
 }
 
 /**
+ * @param {Array<Record<string, number>|null|undefined>} buckets
+ * @returns {{ Positive: number, Neutral: number, Negative: number }}
+ */
+export const mergeSentimentCounts = (buckets) => {
+  const counts = { Positive: 0, Neutral: 0, Negative: 0 }
+  for (const b of buckets) {
+    if (!b || typeof b !== 'object') continue
+    for (const key of Object.keys(counts)) {
+      counts[key] += Number(b[key]) || 0
+    }
+  }
+  return counts
+}
+
+/**
  * @param {object} bucket
  * @returns {{
  *   sessionDuration: number,
@@ -84,6 +101,7 @@ export const finalizeSpeechRate = (bucket) => {
     speechRate:
       speakingTime > 0 ? Math.round(wordsSpoken / (speakingTime / 60)) : 0,
     keywords: bucket?.keywords || {},
+    sentiment: bucket?.sentiment || { Positive: 0, Neutral: 0, Negative: 0 },
   }
 }
 
@@ -112,6 +130,7 @@ export const aggregateTranscriptionMetrics = (transcriptions = []) => {
     bucket.wordsSpoken += Number(item.wordsSpoken) || 0
     bucket.speakingTime += Number(item.speakingTime) || 0
     bucket.keywords = mergeKeywordMaps([bucket.keywords, item.keywords])
+    bucket.sentiment = mergeSentimentCounts([bucket.sentiment, item.sentiment])
   }
 
   const tasks = {}
@@ -127,6 +146,7 @@ export const aggregateTranscriptionMetrics = (transcriptions = []) => {
     general.wordsSpoken += finalized.wordsSpoken
     general.speakingTime += finalized.speakingTime
     general.keywords = mergeKeywordMaps([general.keywords, finalized.keywords])
+    general.sentiment = mergeSentimentCounts([general.sentiment, finalized.sentiment])
   }
 
   const generalFinalized = finalizeSpeechRate(general)
@@ -189,5 +209,6 @@ export const normalizeMetricsBucket = (data) => {
       !Array.isArray(data.keywords)
         ? { ...data.keywords }
         : {},
+    sentiment: mergeSentimentCounts([data.sentiment]),
   }
 }

--- a/src/ux/UserTest/components/UnmoderatedTestAnalytics/TranscriptionsOverview.vue
+++ b/src/ux/UserTest/components/UnmoderatedTestAnalytics/TranscriptionsOverview.vue
@@ -115,12 +115,16 @@
       <v-row dense class="mb-4">
         <v-col cols="12" md="4">
           <SelectionPieChart
+            v-if="hasSentimentData"
             question-title="Feedback Tone"
             :options="sentimentOptions"
             :counts="sentimentCounts"
             canvas-id="transcriptions-sentiment-chart"
             :chart-colors="sentimentChartColors"
           />
+          <v-alert v-else type="info" variant="tonal" density="comfortable">
+            No sentiment data available yet.
+          </v-alert>
         </v-col>
 
         <v-col cols="12" md="8">
@@ -413,11 +417,12 @@ const taskTableHeaders = [
 
 const sentimentOptions = ['Positive', 'Neutral', 'Negative']
 
-const sentimentCounts = {
-  Positive: 48,
-  Neutral: 34,
-  Negative: 18,
-}
+const sentimentCounts = computed(
+  () => activeMetrics.value?.sentiment || { Positive: 0, Neutral: 0, Negative: 0 },
+)
+const hasSentimentData = computed(() =>
+  Object.values(sentimentCounts.value).some((v) => v > 0),
+)
 
 const sentimentChartColors = ['#22C55E', '#0EA5E9', '#EF4444']
 


### PR DESCRIPTION
Closes #2258

## Summary
Adds a "Feedback Tone" pie chart to `TranscriptionsOverview.vue` that visualizes
Positive / Neutral / Negative sentiment counts for a transcription.

## Data source
As clarified in #2258 by @JulioManoel, this reads aggregated sentiment counts
from `answers/{answerId}/analytics/transcription.general.sentiment` (Firestore),
rather than calling the sentiment-analysis-api directly. Per-sentence sentiment
classification does not yet exist in `transcription-api`, so `sentimentCounts`
is currently sourced from mocked/placeholder data — the frontend is ready to
consume real values once `transcription-api` persists them into `answers/general`.

## Behavior
- When `sentiment` data is present, renders a donut/pie chart with
  Positive/Neutral/Negative counts and a color-coded legend.
- When `sentiment` is missing (no transcription run yet), shows an empty-state
  alert: "No sentiment data available yet." instead of a broken/empty chart.

## Testing
Verified locally using the Firebase emulator:
- Manually seeded `answers/{id}/analytics/transcription.general` with mock
  `sentiment: { Positive: 5, Neutral: 2, Negative: 1 }` plus session
  duration/words/speaking time/speech rate.
- Confirmed the pie chart renders correctly with matching counts and legend.
- Confirmed the empty-state alert renders correctly when `sentiment` is absent.

##ScreenShots:
Filled state:
<img width="1375" height="855" alt="image" src="https://github.com/user-attachments/assets/772dab50-26e2-43c1-a820-3b09b8b15369" />


Empty state: (when no data)
<img width="1920" height="860" alt="image" src="https://github.com/user-attachments/assets/7df1b4f1-88fc-4e48-b74b-8f4430a1268f" />


## Follow-up (out of scope for this PR)
- Real sentiment counts depend on per-sentence classification being implemented
  in `transcription-api` and persisted to `answers/general` (see maintainer
  comment in #2258).