### PR TITLE
fix(auth): send signed out visitors to sign in before a study

### DIFF
--- a/src/features/auth/views/SignInView.vue
+++ b/src/features/auth/views/SignInView.vue
@@ -113,14 +113,19 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import GoogleSignInButton from '@/features/auth/components/GoogleSignInButton'
 import { createEmailRules } from '@/shared/utils/validators'
+import { resolvePostSignInPath } from '@/shared/utils/authRedirect'
 
 const { t } = useI18n()
 const store = useStore()
 const router = useRouter()
+const route = useRoute()
+
+// A participant who followed a study link is brought back to it once signed in.
+const postSignInPath = () => resolvePostSignInPath(route.query)
 
 const form = ref(null)
 const showPassword = ref(false)
@@ -151,7 +156,7 @@ const onSignIn = async () => {
       password: password.value,
       rememberMe: rememberMe.value,
     })
-    await router.push('/admin')
+    await router.push(postSignInPath())
   } catch (error) {
     if (error.message === 'EMAIL_NOT_VERIFIED') {
       await router.push('/verify-email')
@@ -183,7 +188,7 @@ const onGoogleSignInStart = () => {
 
 const onGoogleSignInSuccess = async () => {
   try {
-    if (store.getters.user) router.push('/admin')
+    if (store.getters.user) router.push(postSignInPath())
   } catch (error) {
     if (error.message === 'EMAIL_NOT_VERIFIED') {
       await router.push('/verify-email')

--- a/src/shared/utils/authRedirect.js
+++ b/src/shared/utils/authRedirect.js
@@ -1,0 +1,75 @@
+/**
+ * Helpers for sending a visitor to sign in and bringing them back afterwards.
+ *
+ * A study link is usually the first RUXAILAB page a participant ever opens, so
+ * losing it at the sign-in screen costs them the invitation they were sent.
+ * The path they asked for travels as a `redirect` query parameter and is
+ * replayed once they are signed in.
+ */
+
+export const SIGN_IN_PATH = '/signin'
+export const REDIRECT_QUERY_KEY = 'redirect'
+export const DEFAULT_SIGNED_IN_PATH = '/admin'
+
+/**
+ * Whether a path can be safely replayed after sign-in.
+ *
+ * Only same-origin paths qualify: anything the browser could read as another
+ * host would turn the sign-in screen into an open redirect.
+ * @param {string} path - Candidate path
+ * @returns {boolean}
+ */
+export const isSafeInternalPath = (path) => {
+  if (typeof path !== 'string' || path.length === 0) return false
+  if (!path.startsWith('/')) return false
+
+  // "//host" and "/\host" are read as protocol-relative URLs by browsers.
+  if (path.startsWith('//') || path.startsWith('/\\')) return false
+  if (path.includes('\\')) return false
+
+  return true
+}
+
+/**
+ * Sign-in path that remembers where the visitor was heading.
+ * @param {string} [redirectTo] - Path to return to after signing in
+ * @returns {string}
+ */
+export const buildSignInPath = (redirectTo = '') => {
+  if (!isSafeInternalPath(redirectTo)) return SIGN_IN_PATH
+
+  // Coming back to the sign-in screen would only loop.
+  if (redirectTo.split('?')[0] === SIGN_IN_PATH) return SIGN_IN_PATH
+
+  return `${SIGN_IN_PATH}?${REDIRECT_QUERY_KEY}=${encodeURIComponent(redirectTo)}`
+}
+
+/**
+ * Whether a destination is the sign-in screen.
+ *
+ * Being asked to sign in is not an access denial, and the two are reported to
+ * the participant differently.
+ * @param {string} path - Destination path
+ * @returns {boolean}
+ */
+export const isSignInPath = (path) =>
+  typeof path === 'string' && path.split('?')[0] === SIGN_IN_PATH
+
+/**
+ * Where to send a freshly signed-in user.
+ * @param {Object} [query] - Route query holding the remembered path
+ * @param {string} [fallback] - Used when nothing safe was remembered
+ * @returns {string}
+ */
+export const resolvePostSignInPath = (
+  query = {},
+  fallback = DEFAULT_SIGNED_IN_PATH,
+) => {
+  const requested = query?.[REDIRECT_QUERY_KEY]
+  const path = Array.isArray(requested) ? requested[0] : requested
+
+  if (!isSafeInternalPath(path)) return fallback
+  if (isSignInPath(path)) return fallback
+
+  return path
+}

--- a/src/shared/utils/studyNavigation.js
+++ b/src/shared/utils/studyNavigation.js
@@ -12,6 +12,7 @@ import {
   hasStudyCapability,
   resolveStudyAccess,
 } from '@/shared/utils/studyAccessPolicy'
+import { buildSignInPath } from '@/shared/utils/authRedirect'
 
 const C = STUDY_CAPABILITY
 
@@ -35,6 +36,7 @@ export function getTestViewAccessRedirect({
   user,
   token,
   invitation = null,
+  redirectTo = '',
 }) {
   if (!study) return '/admin'
 
@@ -46,6 +48,16 @@ export function getTestViewAccessRedirect({
 
   const isAnonymousInvitation =
     invitation?.requiredLogin === false && invitation?.studyId == study?.id
+
+  /*
+   * Signing in is what identifies a participant, and a study being public only
+   * says who may answer it, not that answers can be anonymous. An invitation
+   * that waives login is the one way in without an account; everybody else
+   * signs in first and is brought back to the study afterwards.
+   */
+  if (!user && !isAnonymousInvitation) {
+    return buildSignInPath(redirectTo)
+  }
 
   if (isModeratedUserStudy && !token && !study?.isPublic) {
     return getStudyFallbackPath(study, user, routeBase)

--- a/src/views/public/TestView.vue
+++ b/src/views/public/TestView.vue
@@ -71,6 +71,7 @@ import {
 } from '@/shared/constants/methodDefinitions'
 
 import { getTestViewAccessRedirect } from '@/shared/utils/studyNavigation'
+import { isSignInPath } from '@/shared/utils/authRedirect'
 import { showError } from '@/shared/utils/toast'
 
 const props = defineProps({
@@ -222,10 +223,20 @@ const handleLoadedStudy = async (loadedStudy) => {
     user: user.value,
     token: props.token,
     invitation: invitation.value,
+    redirectTo: route.fullPath,
   })
 
   if (!destination) {
     return true
+  }
+
+  /*
+   * Being asked to sign in is not an access denial: the participant simply has
+   * not identified themselves yet, and the study is waiting for them.
+   */
+  if (!isSignInPath(destination)) {
+    accessError.value = ACCESS_ERROR_MESSAGE
+    showError('AccessNotAllowed.noAccess')
   }
 
   await redirectIfNeeded(destination)
@@ -315,12 +326,7 @@ onBeforeMount(async () => {
          * to enter the study without STUDY_ANSWER capability.
          */
         if (isAnonymousInvitation.value) {
-          const hasAccessThroughInvitation =
-            await handleLoadedStudy(loadedStudy)
-
-          if (!hasAccessThroughInvitation) {
-            await denyAccess()
-          }
+          await handleLoadedStudy(loadedStudy)
 
           return
         }
@@ -332,11 +338,7 @@ onBeforeMount(async () => {
          * Let the normal access policy determine whether
          * the current user can enter the study.
          */
-        const hasAccess = await handleLoadedStudy(loadedStudy)
-
-        if (!hasAccess) {
-          await denyAccess()
-        }
+        await handleLoadedStudy(loadedStudy)
 
         return
       }
@@ -347,11 +349,7 @@ onBeforeMount(async () => {
      *
      * Fall back to the normal study access flow.
      */
-    const hasAccess = await handleLoadedStudy(loadedStudy)
-
-    if (!hasAccess) {
-      await denyAccess()
-    }
+    await handleLoadedStudy(loadedStudy)
   } finally {
     loading.value = false
   }

--- a/tests/unit/authRedirect.spec.js
+++ b/tests/unit/authRedirect.spec.js
@@ -1,0 +1,105 @@
+import {
+  buildSignInPath,
+  isSafeInternalPath,
+  isSignInPath,
+  resolvePostSignInPath,
+} from '@/shared/utils/authRedirect'
+
+describe('auth redirect', () => {
+  describe('isSafeInternalPath', () => {
+    it('accepts a same-origin path', () => {
+      expect(isSafeInternalPath('/testview/study-1')).toBe(true)
+      expect(isSafeInternalPath('/testview/study-1?inviteToken=abc')).toBe(true)
+    })
+
+    it('rejects anything that could leave the site', () => {
+      // Every one of these is read as another host by some browser.
+      expect(isSafeInternalPath('https://evil.example.com')).toBe(false)
+      expect(isSafeInternalPath('//evil.example.com')).toBe(false)
+      expect(isSafeInternalPath('/\\evil.example.com')).toBe(false)
+      expect(isSafeInternalPath('/testview\\@evil.example.com')).toBe(false)
+    })
+
+    it('rejects values that are not a path at all', () => {
+      expect(isSafeInternalPath('testview/study-1')).toBe(false)
+      expect(isSafeInternalPath('')).toBe(false)
+      expect(isSafeInternalPath(undefined)).toBe(false)
+      expect(isSafeInternalPath(null)).toBe(false)
+      expect(isSafeInternalPath(42)).toBe(false)
+    })
+  })
+
+  describe('buildSignInPath', () => {
+    it('remembers where the visitor was heading', () => {
+      expect(buildSignInPath('/testview/study-1')).toBe(
+        '/signin?redirect=%2Ftestview%2Fstudy-1',
+      )
+    })
+
+    it('keeps the query of the remembered path', () => {
+      expect(buildSignInPath('/testview/study-1?inviteToken=abc')).toBe(
+        '/signin?redirect=%2Ftestview%2Fstudy-1%3FinviteToken%3Dabc',
+      )
+    })
+
+    it('remembers nothing when the path could leave the site', () => {
+      expect(buildSignInPath('https://evil.example.com')).toBe('/signin')
+      expect(buildSignInPath('//evil.example.com')).toBe('/signin')
+      expect(buildSignInPath('')).toBe('/signin')
+    })
+
+    it('does not send the sign-in screen back to itself', () => {
+      expect(buildSignInPath('/signin')).toBe('/signin')
+      expect(buildSignInPath('/signin?redirect=%2Fadmin')).toBe('/signin')
+    })
+  })
+
+  describe('isSignInPath', () => {
+    it('recognises the sign-in screen with or without a query', () => {
+      expect(isSignInPath('/signin')).toBe(true)
+      expect(isSignInPath('/signin?redirect=%2Ftestview%2Fstudy-1')).toBe(true)
+    })
+
+    it('does not mistake other pages for it', () => {
+      expect(isSignInPath('/signup')).toBe(false)
+      expect(isSignInPath('/admin')).toBe(false)
+      expect(isSignInPath(null)).toBe(false)
+    })
+  })
+
+  describe('resolvePostSignInPath', () => {
+    it('replays the remembered path', () => {
+      expect(resolvePostSignInPath({ redirect: '/testview/study-1' })).toBe(
+        '/testview/study-1',
+      )
+    })
+
+    it('falls back when nothing was remembered', () => {
+      expect(resolvePostSignInPath({})).toBe('/admin')
+      expect(resolvePostSignInPath()).toBe('/admin')
+    })
+
+    it('falls back rather than following a path off the site', () => {
+      expect(
+        resolvePostSignInPath({ redirect: 'https://evil.example.com' }),
+      ).toBe('/admin')
+      expect(resolvePostSignInPath({ redirect: '//evil.example.com' })).toBe(
+        '/admin',
+      )
+    })
+
+    it('falls back rather than looping on the sign-in screen', () => {
+      expect(resolvePostSignInPath({ redirect: '/signin' })).toBe('/admin')
+    })
+
+    it('uses the first value when the query repeats the parameter', () => {
+      expect(
+        resolvePostSignInPath({ redirect: ['/testview/study-1', '/admin'] }),
+      ).toBe('/testview/study-1')
+    })
+
+    it('honours a caller supplied fallback', () => {
+      expect(resolvePostSignInPath({}, '/dashboard')).toBe('/dashboard')
+    })
+  })
+})

--- a/tests/unit/studyNavigation.spec.js
+++ b/tests/unit/studyNavigation.spec.js
@@ -421,4 +421,101 @@ describe('study navigation', () => {
       }),
     ).toBe('/userTest/unmoderated/manager/study-1')
   })
+  describe('signed out participants', () => {
+    const signInFor = (path) => `/signin?redirect=${encodeURIComponent(path)}`
+
+    it('sends a signed out visitor to sign in and back to a public study', () => {
+      const study = { ...studyWith('HEURISTIC'), isPublic: true }
+
+      // A public study says who may answer it, not that answers may be
+      // anonymous, so the participant still identifies themselves first.
+      expect(
+        getTestViewAccessRedirect({
+          study,
+          user: null,
+          token: null,
+          redirectTo: '/testview/study-1',
+        }),
+      ).toBe(signInFor('/testview/study-1'))
+    })
+
+    it('sends a signed out visitor to sign in and back to a private study', () => {
+      expect(
+        getTestViewAccessRedirect({
+          study: studyWith('HEURISTIC'),
+          user: null,
+          token: null,
+          redirectTo: '/testview/study-1',
+        }),
+      ).toBe(signInFor('/testview/study-1'))
+    })
+
+    it('sends a signed out visitor to sign in from a moderated study link', () => {
+      const study = {
+        ...studyWith('USER'),
+        subType: USER_STUDY_SUBTYPES.MODERATED,
+      }
+
+      expect(
+        getTestViewAccessRedirect({
+          study,
+          user: null,
+          token: 'participant',
+          redirectTo: '/testview/study-1/participant',
+        }),
+      ).toBe(signInFor('/testview/study-1/participant'))
+    })
+
+    it('lets an invitation that waives login through without signing in', () => {
+      const study = { ...studyWith('HEURISTIC'), isPublic: true }
+
+      expect(
+        getTestViewAccessRedirect({
+          study,
+          user: null,
+          token: null,
+          invitation: { requiredLogin: false, studyId: study.id },
+          redirectTo: '/testview/study-1',
+        }),
+      ).toBeNull()
+    })
+
+    it('still asks for sign in when the invitation requires login', () => {
+      const study = { ...studyWith('HEURISTIC'), isPublic: true }
+
+      expect(
+        getTestViewAccessRedirect({
+          study,
+          user: null,
+          token: null,
+          invitation: { requiredLogin: true, studyId: study.id },
+          redirectTo: '/testview/study-1',
+        }),
+      ).toBe(signInFor('/testview/study-1'))
+    })
+
+    it('still asks for sign in when the invitation belongs to another study', () => {
+      const study = { ...studyWith('HEURISTIC'), isPublic: true }
+
+      expect(
+        getTestViewAccessRedirect({
+          study,
+          user: null,
+          token: null,
+          invitation: { requiredLogin: false, studyId: 'another-study' },
+          redirectTo: '/testview/study-1',
+        }),
+      ).toBe(signInFor('/testview/study-1'))
+    })
+
+    it('falls back to a plain sign in when there is no path to return to', () => {
+      expect(
+        getTestViewAccessRedirect({
+          study: studyWith('HEURISTIC'),
+          user: null,
+          token: null,
+        }),
+      ).toBe('/signin')
+    })
+  })
 })


### PR DESCRIPTION
## What

A signed out visitor who opens a study link is now asked to sign in and is returned to that study afterwards — except when the invitation they followed says login is not required.

Closes #2336

## Demo

A signed out browser opens the same public Heuristic study link. Left is `develop`, right is this PR.

![Signed out visitor opening a study, before and after](https://raw.githubusercontent.com/namanjain24-sudo/RUXAILAB/media/issue-2336/redirect-before-after.png)

Full clip: [redirect-before-after.mp4](https://raw.githubusercontent.com/namanjain24-sudo/RUXAILAB/media/issue-2336/redirect-before-after.mp4)

Recorded with Playwright against the app running on the Firebase emulator suite.

## Not blindly redirecting people

Following up on @KarinePistili's context in the issue, and @tim48-robot's note to carry it into the PR — the rule implemented here is:

| Who is opening the study | Behaviour |
| --- | --- |
| Invitation with `requiredLogin === false`, matching this study | **Enters and answers, no account needed** — unchanged |
| Invitation that requires login | Sign in, then back to the study |
| No invitation, study is public | Sign in, then back to the study |
| No invitation, study is private | Sign in, then back to the study |
| Already signed in | Unchanged — existing capability checks decide |

The anonymous-invite path is the one way into a study without an account, and it keeps working exactly as before. Everything else is asked to identify itself first, which is option 1 from the issue (sign in, then return to the test) rather than dropping the participant on the homepage.

## Why it was letting people in

`getTestViewAccessRedirect` decided access with:

```js
if (!study?.isPublic && !isAnonymousInvitation && !hasStudyCapability(...))
```

For a **public** study the first term is already false, so the whole check was skipped and `null` (meaning "allowed") was returned — without ever asking whether anybody was signed in. That is how a signed out visitor reached a Heuristic test and could start answering it.

This was also inconsistent with the capability model next door, where `resolveStudyAccess` computes `isPublicParticipant: Boolean(userId && study?.isPublic)` — a public study already required a signed-in participant everywhere else.

On a **private** study the visitor did get bounced, but to `/admin` carrying a red "You do not have access" error, and the study link was lost. For someone who was simply not logged in yet, that reads as a rejection rather than an invitation to sign in.

## Changes

| File | Change |
| --- | --- |
| `src/shared/utils/authRedirect.js` | New — builds `/signin?redirect=…`, and resolves it back after sign-in |
| `src/shared/utils/studyNavigation.js` | `getTestViewAccessRedirect` requires a signed-in user unless the invitation waives login |
| `src/views/public/TestView.vue` | Passes the current path as the return target; a sign-in redirect no longer raises the "no access" error |
| `src/features/auth/views/SignInView.vue` | Honours `?redirect=` after email and Google sign-in |
| `tests/unit/authRedirect.spec.js` | New — 15 tests |
| `tests/unit/studyNavigation.spec.js` | 7 tests for the signed out paths |

### One related fix that this needed

`denyAccess()` ran `redirectIfNeeded('/admin')` *after* `handleLoadedStudy` had already navigated to the destination it computed, so the computed fallback was immediately overwritten by `/admin`. The sign-in redirect could not survive that, so denial is now reported by the same function that chooses the destination, and `denyAccess` is left for the two cases it is actually about — a study or a session that could not be loaded.

## Open redirect

`redirect` is replayed only when it is a same-origin path. `//host`, `/\host`, anything containing a backslash, anything not starting with `/`, and `/signin` itself all fall back to `/admin`. There is a browser check for this below, and unit tests covering each rejected shape.

## Testing

- `npm test` — 33 suites, 281 tests passing (259 before this branch)
- `npm run lint` and Prettier clean on the changed files
- Removing the new guard makes 6 of the new tests fail, so they are pinning the behaviour rather than passing vacuously

### Verified in a real browser

Playwright against the app on the Firebase emulator suite, with a public Heuristic study and a signed out browser. The same script was run before and after the change:

| Check | Before | After |
| --- | --- | --- |
| Signed out visitor is sent to sign in | ❌ stayed on `/testview/…` | ✅ `/signin?redirect=…` |
| The study link is remembered | ❌ no `redirect` parameter | ✅ `redirect=/testview/…` |
| Signing in returns to the study | n/a — no sign-in screen was reached | ✅ back on `/testview/…` |
| A signed in participant opens the study directly | ✅ | ✅ |
| An off-site `redirect` is ignored | ✅ | ✅ lands on `/admin` |

The issue mentions this needs checking on other test types too. `/testview/:id` is the shared entry point for Heuristic, unmoderated User and Card Sorting studies, so all three go through this check.

**Moderated User sessions are the exception.** They enter through their own session-token branch in `TestView`, which returns before this check runs, so the change above does not apply there. A signed out visitor is still blocked on that path, but by the existing behaviour: they end up on `/signin` without the study link being remembered, and with the "no access" error. I have left that branch alone rather than restructure a flow whose session-loading rules I could not exercise end to end locally — and it may well be separate on purpose. Happy to extend the same treatment to it in this PR if you would like, or to open a follow-up.
