### PR TITLE
fix(ux-creation): allow returning to study type options from template…

### DIFF
--- a/src/features/ux_creation/ChooseStudyType.vue
+++ b/src/features/ux_creation/ChooseStudyType.vue
@@ -65,6 +65,12 @@
 
       <v-row v-if="selectedOption === 'template'" justify="center" class="mb-8">
         <v-col cols="12" lg="10" xl="8">
+          <BackButton
+            :label="$t('studyCreation.backToStudyType')"
+            adjust="start"
+            class="mb-4"
+            @back="clearStudyTypeSelection"
+          />
           <CommunityTemplatesSection
             :selection-mode="true"
             :include-my-templates="true"
@@ -81,6 +87,7 @@
 import SectionHeader from '@/features/ux_creation/SectionHeader.vue'
 import SelectableCard from '@/shared/components/cards/SelectableCard.vue'
 import StepperHeader from '@/features/ux_creation/StepperHeader.vue'
+import BackButton from '@/features/ux_creation/components/BackButton.vue'
 import CommunityTemplatesSection from '@/features/navigation/components/navbarSections/CommunityTemplatesSection.vue'
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
@@ -161,6 +168,15 @@ const selectOption = (optionId) => {
   if (optionId === 'blank') {
     router.push({ name: 'study-create-step4' })
   }
+}
+
+// Selecting 'template' swaps the option cards out for the template list, so
+// without this the user cannot get back to 'blank' -- worse when the list is
+// empty, which is the case on any install with no community templates yet.
+const clearStudyTypeSelection = () => {
+  selectedOption.value = ''
+  store.commit('SET_STUDY_TYPE', null)
+  store.commit('SET_SELECTED_TEMPLATE', null)
 }
 
 const selectTemplate = (template) => {


### PR DESCRIPTION
… list

Selecting "Use a template" in study creation step 3 replaced the Blank/Template option cards with the template list, and nothing in that branch could bring them back. CommunityTemplatesSection emits only template-selected, and onStepperStepClick early-returns on step 3, so a user who picked "template" could not switch back to "blank".

This was most visible on a fresh install, where the community template list is empty: the screen offered no selectable item and no exit, and only a page reload or stepping back to Methods/Category recovered -- both of which discard the chosen category and method.

Add a BackButton to the template branch that clears the selection and restores the option cards, reusing the existing
studyCreation.backToStudyType label so no new locale keys are needed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Closes #2350