### PR TITLE
fix(ux-creation): allow returning to study type options from template list

### DIFF
--- a/src/features/ux_creation/ChooseStudyType.vue
+++ b/src/features/ux_creation/ChooseStudyType.vue
@@ -65,6 +65,12 @@
 
       <v-row v-if="selectedOption === 'template'" justify="center" class="mb-8">
         <v-col cols="12" lg="10" xl="8">
+          <BackButton
+            :label="$t('studyCreation.backToStudyType')"
+            adjust="start"
+            class="mb-4"
+            @back="clearStudyTypeSelection"
+          />
           <CommunityTemplatesSection
             :selection-mode="true"
             :include-my-templates="true"
@@ -81,6 +87,7 @@
 import SectionHeader from '@/features/ux_creation/SectionHeader.vue'
 import SelectableCard from '@/shared/components/cards/SelectableCard.vue'
 import StepperHeader from '@/features/ux_creation/StepperHeader.vue'
+import BackButton from '@/features/ux_creation/components/BackButton.vue'
 import CommunityTemplatesSection from '@/features/navigation/components/navbarSections/CommunityTemplatesSection.vue'
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
@@ -161,6 +168,15 @@ const selectOption = (optionId) => {
   if (optionId === 'blank') {
     router.push({ name: 'study-create-step4' })
   }
+}
+
+// Selecting 'template' swaps the option cards out for the template list, so
+// without this the user cannot get back to 'blank' -- worse when the list is
+// empty, which is the case on any install with no community templates yet.
+const clearStudyTypeSelection = () => {
+  selectedOption.value = ''
+  store.commit('SET_STUDY_TYPE', null)
+  store.commit('SET_SELECTED_TEMPLATE', null)
 }
 
 const selectTemplate = (template) => {


### PR DESCRIPTION
Closes #2350

## Problem
In study creation step 3, selecting "Use a template" replaces the Blank/Template
option cards with the template list. Nothing in that branch can bring them back:
`ChooseStudyType.vue` hides the cards via `v-if="selectedOption !== 'template'"`,
`CommunityTemplatesSection` emits only `template-selected`, and
`onStepperStepClick` early-returns on step 3.

Most visible on a fresh install, where the community template list is empty — the
screen offers no selectable item and no exit. Only a page reload or stepping back
to Methods/Category recovers, and both discard the chosen category and method.

## Solution
Add a `BackButton` to the template branch that clears the selection and restores
the option cards.

- Reuses the existing `BackButton` component, already used by `StudyDetailsForm`
  in this same feature
- Reuses the existing `studyCreation.backToStudyType` locale key, present in both
  `en` and `es` — no new translations needed
- Mirrors the resets `selectOption` already performs (`SET_STUDY_TYPE`,
  `SET_SELECTED_TEMPLATE`)

<img width="1897" height="851" alt="image" src="https://github.com/user-attachments/assets/7a7acbd8-e056-4eae-b5d3-1745839fb99f" />


## Testing
- ESLint and Prettier clean
- Full unit suite passes (32 suites, 259 tests) via the pre-commit hook
- Verified against Firebase emulators: step 3 → "Use a template" → back button
  returns to the cards → "Blank" is selectable again

## Notes
The stepper's step-3 early return is left as-is — a no-op on the current step is
normal stepper behavior, and it no longer traps anyone now that a visible exit
exists. Happy to change that instead if preferred.
