### PR TITLE
fix: keep action buttons visible on long titles/descriptions

### DIFF
--- a/src/ux/Heuristic/components/HeuristicsTable.vue
+++ b/src/ux/Heuristic/components/HeuristicsTable.vue
@@ -50,7 +50,7 @@
           :class="{ expanded: itemSelect === index }"
         >
           <!-- Heuristic Header -->
-          <v-card-title class="d-flex align-center pa-4 heuristic-header">
+          <v-card-title class="d-flex pa-4 heuristic-header">
             <v-btn
               :icon="
                 itemSelect === index ? 'mdi-chevron-up' : 'mdi-chevron-down'
@@ -1119,6 +1119,58 @@ const updateDescription = () => {
 </script>
 
 <style scoped>
+/* Desktop/default layout: clamp title (1 line), description (2 lines), keep actions visible */
+.heuristic-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-width: 0;
+}
+
+.heuristic-info {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.heuristic-title {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  margin: 0;
+  min-width: 0;
+}
+
+.heuristic-description {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-word;
+  margin: 0;
+  min-width: 0;
+}
+
+.heuristic-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  min-width: max-content;
+  justify-content: flex-end;
+}
+
+.heuristic-actions .action-btn {
+  flex-shrink: 0;
+}
+
 /* Responsive styles for mobile devices */
 @media (max-width: 768px) {
   /* Make header section stack vertically */


### PR DESCRIPTION
Partially closes #2335

## Summary
Addresses the two UX issues raised in #2335 for the Heuristics editor:
1. Action buttons (Move Up, Move Down, Add Question, Edit, Delete) getting
   squeezed out or hidden when a heuristic's title or description is long.
2. The auto-save indicator being a large, persistent card that felt
   intrusive while editing.

## Changes

**Heuristic tile layout** (`src/ux/Heuristic/components/HeuristicsTable.vue`)
- Title now clamps to 1 line with ellipsis truncation.
- Description now clamps to 2 lines with ellipsis truncation.
- Action buttons (`.heuristic-actions`) no longer shrink regardless of
  text length (`flex-shrink: 0`), so all five icons stay visible and
  usable at any width.
- Removed reliance on Vuetify's `align-center` utility class for the
  header row; alignment is now explicit in the component's scoped CSS.

**Auto-save indicator** (`src/shared/components/AutoSaveStatusBanner.vue`)
- Restyled from a large fixed card to a small snackbar-style pill,
  consistent with the rest of the app's notification style (solid
  background color per status — success/error).
- Behavior is unchanged: only appears while saving or just after a save,
  auto-dismisses shortly after success (1800ms), and is gone on refresh —
  it doesn't reappear on scroll.

## Behavior
- Long titles/descriptions no longer affect the action buttons' visibility
  or size.
- The auto-save indicator is now a lightweight, less intrusive confirmation
  instead of a large card blocking part of the screen.

## Testing
Verified locally using the Firebase emulator:
- Created heuristics with very long titles and descriptions and confirmed
  text truncates correctly while all action buttons remain visible and
  clickable, on both desktop and mobile widths.
- Triggered auto-save (editing a heuristic) and confirmed the new compact
  indicator appears only during/after a save, matches the app's existing
  success/error toast styling, and disappears after a page refresh.

## Screenshots
Before:
<img width="890" height="448" alt="image" src="https://github.com/user-attachments/assets/d99f1a66-6bc7-4984-9b29-19137dc92247" />


After:
<img width="1920" height="866" alt="image" src="https://github.com/user-attachments/assets/0c4984c6-ad57-46a2-8142-e7ee840cc681" />
<img width="1920" height="866" alt="image" src="https://github.com/user-attachments/assets/ee1cec02-5a19-4583-83e7-35c2425b420a" />



## Follow-up (out of scope for this PR)
While testing, I noticed clicking "Save now" inside the auto-save banner
triggers **two** separate success notifications at once — the banner's
own success state and a separate toast ("Changes saved successfully").
Flagging this for discussion since it's a UX call (e.g. remove the
redundant toast, or reconsider whether "Save now" is needed given
everything already auto-saves) rather than something to silently change
in this PR. Happy to open a follow-up once there's a preferred direction.